### PR TITLE
fix: #8 detect tool updates when switching from from_file to inline source_code

### DIFF
--- a/src/commands/apply-template.ts
+++ b/src/commands/apply-template.ts
@@ -75,7 +75,7 @@ export async function applyTemplateMode(
 
   // Generate tool source hashes and register tools
   const toolSourceHashes = fileTracker.generateToolSourceHashes(templateTools, parser.toolConfigs);
-  const toolNameToId = await parser.registerRequiredTools(config, client, verbose, toolSourceHashes);
+  const { toolNameToId, updatedTools } = await parser.registerRequiredTools(config, client, verbose, toolSourceHashes);
 
   // Apply template to each matching agent
   for (const existingAgent of matchingAgents) {
@@ -110,7 +110,8 @@ export async function applyTemplateMode(
         toolNameToId,
         createdFolders,
         verbose,
-        sharedBlockIds
+        sharedBlockIds,
+        updatedTools
       );
 
       // MERGE semantics: clear toRemove arrays (don't remove existing resources)

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -87,7 +87,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
     const globalToolSourceHashes = fileTracker.generateToolSourceHashes(Array.from(allToolNames), parser.toolConfigs);
 
     if (verbose) console.log('Registering tools...');
-    const toolNameToId = await parser.registerRequiredTools(config, client, verbose, globalToolSourceHashes);
+    const { toolNameToId, updatedTools } = await parser.registerRequiredTools(config, client, verbose, globalToolSourceHashes);
 
     // Process folders
     const createdFolders = await processFolders(config, client, parser, options, verbose);
@@ -156,6 +156,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
             diffEngine,
             agentManager,
             toolNameToId,
+            updatedTools,
             createdFolders,
             sharedBlockIds,
             spinnerEnabled,

--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -99,13 +99,14 @@ export async function updateExistingAgent(
     diffEngine: DiffEngine;
     agentManager: AgentManager;
     toolNameToId: Map<string, string>;
+    updatedTools: Set<string>;
     createdFolders: Map<string, string>;
     sharedBlockIds: Map<string, string>;
     spinnerEnabled: boolean;
     verbose: boolean;
   }
 ): Promise<void> {
-  const { diffEngine, agentManager, toolNameToId, createdFolders, sharedBlockIds, spinnerEnabled, verbose } = context;
+  const { diffEngine, agentManager, toolNameToId, updatedTools, createdFolders, sharedBlockIds, spinnerEnabled, verbose } = context;
 
   console.log(`Updating agent ${agent.name}:`);
 
@@ -118,7 +119,8 @@ export async function updateExistingAgent(
       toolNameToId,
       createdFolders,
       verbose,
-      sharedBlockIds
+      sharedBlockIds,
+      updatedTools
     );
 
     spinner.stop();

--- a/src/lib/diff-engine.ts
+++ b/src/lib/diff-engine.ts
@@ -87,7 +87,8 @@ export class DiffEngine {
     toolRegistry: Map<string, string>,
     folderRegistry: Map<string, string>,
     verbose: boolean = false,
-    sharedBlockIds?: Map<string, string>
+    sharedBlockIds?: Map<string, string>,
+    updatedTools?: Set<string>
   ): Promise<AgentUpdateOperations> {
     
     const operations: AgentUpdateOperations = {
@@ -151,7 +152,8 @@ export class DiffEngine {
       currentTools,
       desiredConfig.tools || [],
       toolRegistry,
-      desiredConfig.toolSourceHashes || {}
+      desiredConfig.toolSourceHashes || {},
+      updatedTools
     );
     operations.operationCount += operations.tools.toAdd.length + operations.tools.toRemove.length + operations.tools.toUpdate.length;
 

--- a/tests/lib/diff-engine.test.ts
+++ b/tests/lib/diff-engine.test.ts
@@ -30,12 +30,13 @@ describe('DiffEngine', () => {
       expect(result.unchanged).toHaveLength(1);
     });
 
-    it('marks tool for update when source hash exists and ID changed', async () => {
+    it('marks tool for update when in updatedTools set', async () => {
       const result = await analyzeToolChanges(
-        [{ name: 'tool', id: 'old-id' }],
+        [{ name: 'tool', id: 'tool-id' }],
         ['tool'],
-        new Map([['tool', 'new-id']]),
-        { 'tool': 'hash' }
+        new Map([['tool', 'tool-id']]),
+        {},
+        new Set(['tool'])
       );
       expect(result.toUpdate[0].reason).toBe('source_code_changed');
     });


### PR DESCRIPTION
Adds `source_code` support to fleet-parser's `resolveContent` method and tracks which tools were updated during registration so the diff display correctly shows tool updates.

Closes #8