### PR TITLE
build: #27 add e2e test infrastructure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,86 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      letta:
+        image: letta/letta:latest
+        ports:
+          - 8283:8283
+        options: >-
+          --health-cmd "curl -f http://localhost:8283/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 60s
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build project
+      run: pnpm build
+
+    - name: Wait for Letta server
+      run: |
+        echo "Waiting for Letta server to be ready..."
+        for i in {1..30}; do
+          if curl -s http://localhost:8283/health >/dev/null 2>&1; then
+            echo "Letta server is ready!"
+            break
+          fi
+          echo "Attempt $i: Waiting for Letta server..."
+          sleep 5
+        done
+
+    - name: Run E2E tests
+      env:
+        LETTA_BASE_URL: http://localhost:8283
+      run: |
+        chmod +x tests/e2e/run-e2e-tests.sh
+        ./tests/e2e/run-e2e-tests.sh
+
+    - name: Upload test artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-failure-logs
+        path: |
+          tests/e2e/*.log
+        retention-days: 7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  letta:
+    image: letta/letta:latest
+    container_name: letta-e2e
+    ports:
+      - "8283:8283"
+    environment:
+      - LETTA_SERVER_PORT=8283
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8283/v1/agents/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+    volumes:
+      - letta-data:/root/.letta
+
+volumes:
+  letta-data:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  roots: ['<rootDir>/src', '<rootDir>/tests/unit'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/tests/e2e/'],
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },

--- a/tests/e2e/01-basic-agent.yaml
+++ b/tests/e2e/01-basic-agent.yaml
@@ -1,0 +1,13 @@
+# E2E Test: Basic agent creation
+# Tests: Simple agent with inline system prompt
+
+agents:
+  - name: e2e-basic-agent
+    description: Basic test agent for e2e testing
+    system_prompt:
+      value: You are a helpful test assistant.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free

--- a/tests/e2e/02-memory-blocks.yaml
+++ b/tests/e2e/02-memory-blocks.yaml
@@ -1,0 +1,30 @@
+# E2E Test: Memory blocks
+# Tests: Agent with inline memory blocks
+
+agents:
+  - name: e2e-memory-agent
+    description: Agent with memory blocks
+    system_prompt:
+      value: You are an assistant with persistent memory.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: user_preferences
+        description: Stores user preferences and settings
+        limit: 2000
+        value: "User prefers concise answers."
+      - name: conversation_context
+        description: Stores ongoing conversation context
+        limit: 4000
+        value: "No prior context."
+      - name: knowledge_base
+        description: Domain-specific knowledge
+        limit: 8000
+        value: |
+          # Knowledge Base
+          - Topic A: Important information about A
+          - Topic B: Critical details about B
+          - Topic C: Essential facts about C

--- a/tests/e2e/03-shared-blocks.yaml
+++ b/tests/e2e/03-shared-blocks.yaml
@@ -1,0 +1,46 @@
+# E2E Test: Shared blocks
+# Tests: Multiple agents sharing memory blocks
+
+shared_blocks:
+  - name: e2e_shared_guidelines
+    description: Shared operational guidelines
+    limit: 5000
+    value: |
+      # Shared Guidelines
+      1. Always be helpful and accurate
+      2. Provide concise responses
+      3. Ask clarifying questions when needed
+  - name: e2e_shared_knowledge
+    description: Shared knowledge base
+    limit: 8000
+    value: |
+      # Shared Knowledge
+      Company: Test Corp
+      Industry: Technology
+      Mission: Building great software
+
+agents:
+  - name: e2e-shared-agent-1
+    description: First agent using shared blocks
+    system_prompt:
+      value: You are assistant 1 with shared knowledge.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    shared_blocks:
+      - e2e_shared_guidelines
+      - e2e_shared_knowledge
+
+  - name: e2e-shared-agent-2
+    description: Second agent using shared blocks
+    system_prompt:
+      value: You are assistant 2 with shared knowledge.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    shared_blocks:
+      - e2e_shared_guidelines

--- a/tests/e2e/04-tools.yaml
+++ b/tests/e2e/04-tools.yaml
@@ -1,0 +1,16 @@
+# E2E Test: Custom tools
+# Tests: Agent with custom Python tools
+
+agents:
+  - name: e2e-tools-agent
+    description: Agent with custom tools
+    system_prompt:
+      value: You are an assistant with specialized tools.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    tools:
+      - e2e_calculator
+      - e2e_string_utils

--- a/tests/e2e/05-mcp-servers.yaml
+++ b/tests/e2e/05-mcp-servers.yaml
@@ -1,0 +1,34 @@
+# E2E Test: MCP servers
+# Tests: All MCP server types (sse, stdio, streamable_http)
+
+mcp_servers:
+  # SSE server
+  - name: e2e-sse-server
+    type: sse
+    server_url: http://localhost:3001/sse
+
+  # Stdio server
+  - name: e2e-stdio-server
+    type: stdio
+    command: python3
+    args:
+      - "-m"
+      - "test_mcp_server"
+    env:
+      DEBUG: "true"
+
+  # Streamable HTTP server
+  - name: e2e-http-server
+    type: streamable_http
+    server_url: http://localhost:3002/mcp
+
+agents:
+  - name: e2e-mcp-agent
+    description: Agent with MCP server access
+    system_prompt:
+      value: You are an assistant with MCP tools.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free

--- a/tests/e2e/06-folders.yaml
+++ b/tests/e2e/06-folders.yaml
@@ -1,0 +1,18 @@
+# E2E Test: Folders and file attachments
+# Tests: Agent with document folders
+
+agents:
+  - name: e2e-folders-agent
+    description: Agent with document folders
+    system_prompt:
+      value: You are a document assistant with access to files.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    folders:
+      - name: e2e-documents
+        files:
+          - files/test-doc-1.txt
+          - files/test-doc-2.txt

--- a/tests/e2e/07-multi-agent.yaml
+++ b/tests/e2e/07-multi-agent.yaml
@@ -1,0 +1,43 @@
+# E2E Test: Multiple agents
+# Tests: Fleet with multiple agents, different configs
+
+agents:
+  - name: e2e-multi-agent-1
+    description: First agent in multi-agent fleet
+    system_prompt:
+      value: You are the first agent in a fleet.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: agent1_memory
+        description: Agent 1 specific memory
+        limit: 2000
+        value: "Agent 1 initialized."
+
+  - name: e2e-multi-agent-2
+    description: Second agent in multi-agent fleet
+    system_prompt:
+      value: You are the second agent in a fleet.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 16000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: agent2_memory
+        description: Agent 2 specific memory
+        limit: 4000
+        value: "Agent 2 initialized."
+
+  - name: e2e-multi-agent-3
+    description: Third agent in multi-agent fleet
+    system_prompt:
+      value: You are the third agent in a fleet.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 24000
+    embedding: letta/letta-free

--- a/tests/e2e/08-full-featured.yaml
+++ b/tests/e2e/08-full-featured.yaml
@@ -1,0 +1,50 @@
+# E2E Test: Full-featured agent
+# Tests: Agent with all features combined
+
+shared_blocks:
+  - name: e2e_full_shared
+    description: Shared block for full-featured test
+    limit: 5000
+    value: |
+      # Shared Configuration
+      Mode: Full-featured test
+      Version: 1.0
+
+mcp_servers:
+  - name: e2e-full-mcp
+    type: sse
+    server_url: http://localhost:3001/sse
+
+agents:
+  - name: e2e-full-featured-agent
+    description: Agent with all features enabled
+    system_prompt:
+      value: |
+        You are a full-featured assistant with:
+        - Custom tools
+        - Memory blocks
+        - Shared blocks
+        - Document folders
+        - MCP server access
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 32000
+    embedding: letta/letta-free
+    shared_blocks:
+      - e2e_full_shared
+    memory_blocks:
+      - name: full_agent_memory
+        description: Agent-specific memory
+        limit: 4000
+        value: "Full-featured agent initialized."
+      - name: full_agent_context
+        description: Conversation context
+        limit: 8000
+        value: "No prior context."
+    tools:
+      - e2e_calculator
+    folders:
+      - name: e2e-full-docs
+        files:
+          - files/test-doc-1.txt

--- a/tests/e2e/09-update-detection.yaml
+++ b/tests/e2e/09-update-detection.yaml
@@ -1,0 +1,19 @@
+# E2E Test: Update detection
+# Tests: Idempotency and change detection
+# Run this twice - second run should detect no changes
+
+agents:
+  - name: e2e-update-test-agent
+    description: Agent for testing update detection
+    system_prompt:
+      value: You are a test agent for update detection.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: update_test_memory
+        description: Memory block for update testing
+        limit: 2000
+        value: "Initial value - should not change on re-apply."

--- a/tests/e2e/10-llm-configs.yaml
+++ b/tests/e2e/10-llm-configs.yaml
@@ -1,0 +1,33 @@
+# E2E Test: Different LLM configurations
+# Tests: Various model and context window settings
+
+agents:
+  - name: e2e-llm-small-context
+    description: Agent with small context window
+    system_prompt:
+      value: You are a lightweight agent.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 4000
+    embedding: letta/letta-free
+
+  - name: e2e-llm-medium-context
+    description: Agent with medium context window
+    system_prompt:
+      value: You are a standard agent.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 16000
+    embedding: letta/letta-free
+
+  - name: e2e-llm-large-context
+    description: Agent with large context window
+    system_prompt:
+      value: You are a high-capacity agent.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 64000
+    embedding: letta/letta-free

--- a/tests/e2e/11-template-mode.yaml
+++ b/tests/e2e/11-template-mode.yaml
@@ -1,0 +1,21 @@
+# E2E Test: Template mode
+# Tests: Apply config to existing agents via --match pattern
+# Usage: lettactl apply -f 11-template-mode.yaml --match "e2e-template-*"
+
+agents:
+  - name: e2e-template-target
+    description: Template target agent
+    system_prompt:
+      value: |
+        You are an agent that will receive template updates.
+        This prompt will be applied to matching agents.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 16000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: template_memory
+        description: Memory added via template
+        limit: 2000
+        value: "Added via template mode."

--- a/tests/e2e/12-edge-cases.yaml
+++ b/tests/e2e/12-edge-cases.yaml
@@ -1,0 +1,41 @@
+# E2E Test: Edge cases
+# Tests: Special characters, long values, empty blocks
+
+agents:
+  - name: e2e-edge-case-agent
+    description: Agent testing edge cases and special scenarios
+    system_prompt:
+      value: |
+        You are a test agent for edge cases.
+        Special chars: !@#$%^&*()_+-=[]{}|;':",.<>?/`~
+        Unicode: こんにちは 你好 مرحبا 🎉
+        Quotes: "double" 'single' `backtick`
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: long_content_block
+        description: Block with long content
+        limit: 10000
+        value: |
+          This is a very long content block designed to test handling of large text.
+          Line 1: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Line 2: Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Line 3: Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+          Line 4: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.
+          Line 5: Excepteur sint occaecat cupidatat non proident, sunt in culpa qui.
+          Line 6: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Line 7: Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          Line 8: Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+          Line 9: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.
+          Line 10: Excepteur sint occaecat cupidatat non proident, sunt in culpa qui.
+      - name: minimal_block
+        description: Minimal block
+        limit: 100
+        value: ""
+      - name: special_chars_block
+        description: Block with special characters
+        limit: 1000
+        value: "Tab:\there Newline:\nhere Carriage:\rhere"

--- a/tests/e2e/13-validation-errors.yaml
+++ b/tests/e2e/13-validation-errors.yaml
@@ -1,0 +1,9 @@
+# E2E Test: Validation (this should FAIL validation)
+# Tests: lettactl validate -f should catch errors
+# Expected: Validation should fail due to missing required fields
+
+agents:
+  - name: e2e-invalid-agent
+    # Missing: description, llm_config
+    system_prompt:
+      value: This agent is missing required fields.

--- a/tests/e2e/14-from-file.yaml
+++ b/tests/e2e/14-from-file.yaml
@@ -1,0 +1,18 @@
+# E2E Test: From-file directives
+# Tests: Loading content from files (prompts, memory blocks)
+
+agents:
+  - name: e2e-from-file-agent
+    description: Agent with content loaded from files
+    system_prompt:
+      from_file: prompts/from-file-prompt.md
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+    memory_blocks:
+      - name: file_loaded_memory
+        description: Memory block loaded from file
+        limit: 5000
+        from_file: memory-blocks/from-file-block.md

--- a/tests/e2e/15-delete-cleanup.yaml
+++ b/tests/e2e/15-delete-cleanup.yaml
@@ -1,0 +1,24 @@
+# E2E Test: Delete and cleanup
+# Tests: Creating agents that will be deleted
+# Used to test: lettactl delete agent <name> --force
+
+agents:
+  - name: e2e-delete-me-1
+    description: Agent to be deleted in cleanup test
+    system_prompt:
+      value: I will be deleted.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free
+
+  - name: e2e-delete-me-2
+    description: Another agent to be deleted
+    system_prompt:
+      value: I will also be deleted.
+      disable_base_prompt: true
+    llm_config:
+      model: letta/letta-free
+      context_window: 8000
+    embedding: letta/letta-free

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# E2E Test Runner for lettactl
+# Usage: ./tests/e2e/run-e2e-tests.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+E2E_DIR="$SCRIPT_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Counters
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+# Check if LETTA_BASE_URL is set
+if [ -z "$LETTA_BASE_URL" ]; then
+    export LETTA_BASE_URL="http://localhost:8283"
+    echo -e "${YELLOW}Using default LETTA_BASE_URL: $LETTA_BASE_URL${NC}"
+fi
+
+# Build the project first
+echo "Building lettactl..."
+cd "$PROJECT_ROOT"
+pnpm build
+
+# Function to run a test
+run_test() {
+    local test_name="$1"
+    local yaml_file="$2"
+    local expect_fail="${3:-false}"
+
+    echo -n "Testing $test_name... "
+
+    if [ "$expect_fail" = "true" ]; then
+        if node "$PROJECT_ROOT/dist/index.js" apply -f "$yaml_file" 2>/dev/null; then
+            echo -e "${RED}FAILED${NC} (expected failure but succeeded)"
+            FAILED=$((FAILED + 1))
+            return 1
+        else
+            echo -e "${GREEN}PASSED${NC} (failed as expected)"
+            PASSED=$((PASSED + 1))
+            return 0
+        fi
+    else
+        if node "$PROJECT_ROOT/dist/index.js" apply -f "$yaml_file" 2>&1; then
+            echo -e "${GREEN}PASSED${NC}"
+            PASSED=$((PASSED + 1))
+            return 0
+        else
+            echo -e "${RED}FAILED${NC}"
+            FAILED=$((FAILED + 1))
+            return 1
+        fi
+    fi
+}
+
+# Function to run validation test
+run_validate_test() {
+    local test_name="$1"
+    local yaml_file="$2"
+    local expect_fail="${3:-false}"
+
+    echo -n "Validating $test_name... "
+
+    if [ "$expect_fail" = "true" ]; then
+        if node "$PROJECT_ROOT/dist/index.js" validate -f "$yaml_file" 2>/dev/null; then
+            echo -e "${RED}FAILED${NC} (expected validation failure)"
+            FAILED=$((FAILED + 1))
+            return 1
+        else
+            echo -e "${GREEN}PASSED${NC} (validation failed as expected)"
+            PASSED=$((PASSED + 1))
+            return 0
+        fi
+    else
+        if node "$PROJECT_ROOT/dist/index.js" validate -f "$yaml_file" 2>&1; then
+            echo -e "${GREEN}PASSED${NC}"
+            PASSED=$((PASSED + 1))
+            return 0
+        else
+            echo -e "${RED}FAILED${NC}"
+            FAILED=$((FAILED + 1))
+            return 1
+        fi
+    fi
+}
+
+# Function to test get commands
+run_get_test() {
+    local resource="$1"
+    echo -n "Testing get $resource... "
+
+    if node "$PROJECT_ROOT/dist/index.js" get "$resource" 2>&1 >/dev/null; then
+        echo -e "${GREEN}PASSED${NC}"
+        PASSED=$((PASSED + 1))
+        return 0
+    else
+        echo -e "${RED}FAILED${NC}"
+        FAILED=$((FAILED + 1))
+        return 1
+    fi
+}
+
+# Function to cleanup test agents
+cleanup_e2e_agents() {
+    echo "Cleaning up e2e test agents..."
+    node "$PROJECT_ROOT/dist/index.js" delete-all agents --pattern "e2e-.*" --force 2>/dev/null || true
+}
+
+echo ""
+echo "=========================================="
+echo "  lettactl E2E Test Suite"
+echo "=========================================="
+echo ""
+
+# Cleanup any previous test data
+cleanup_e2e_agents
+
+echo ""
+echo "--- Apply Tests ---"
+echo ""
+
+# Run apply tests - minimal set for CI speed
+cd "$E2E_DIR"
+run_test "01-basic-agent" "01-basic-agent.yaml" || true
+run_test "03-shared-blocks" "03-shared-blocks.yaml" || true
+run_test "04-tools" "04-tools.yaml" || true
+run_test "07-multi-agent" "07-multi-agent.yaml" || true
+run_test "14-from-file" "14-from-file.yaml" || true
+
+echo ""
+echo "--- Idempotency Test ---"
+echo ""
+
+# Run same config twice to test idempotency
+echo -n "Testing idempotency (re-apply 01-basic-agent)... "
+if node "$PROJECT_ROOT/dist/index.js" apply -f "01-basic-agent.yaml" 2>&1 | grep -q "unchanged\|up to date\|No changes"; then
+    echo -e "${GREEN}PASSED${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${YELLOW}WARNING${NC} (may have detected changes)"
+fi
+
+echo ""
+echo "--- Validation Tests ---"
+echo ""
+
+run_validate_test "valid-config" "01-basic-agent.yaml" || true
+run_validate_test "invalid-config" "13-validation-errors.yaml" true || true
+
+echo ""
+echo "--- Get Command Tests ---"
+echo ""
+
+cd "$PROJECT_ROOT"
+run_get_test "agents" || true
+run_get_test "tools" || true
+
+echo ""
+echo "--- Delete Tests ---"
+echo ""
+
+echo -n "Testing delete agent... "
+if node "$PROJECT_ROOT/dist/index.js" delete agent e2e-basic-agent --force 2>&1; then
+    echo -e "${GREEN}PASSED${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAILED${NC}"
+    FAILED=$((FAILED + 1))
+fi
+
+echo ""
+echo "--- Cleanup ---"
+echo ""
+
+cleanup_e2e_agents
+
+echo ""
+echo "=========================================="
+echo "  E2E Test Results"
+echo "=========================================="
+echo -e "  ${GREEN}Passed:${NC}  $PASSED"
+echo -e "  ${RED}Failed:${NC}  $FAILED"
+echo -e "  ${YELLOW}Skipped:${NC} $SKIPPED"
+echo "=========================================="
+echo ""
+
+if [ $FAILED -gt 0 ]; then
+    exit 1
+fi
+
+exit 0

--- a/tests/e2e/setup_ollama.sh
+++ b/tests/e2e/setup_ollama.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Setup Ollama provider in Letta for e2e testing
+
+set -e
+
+LETTA_URL="${LETTA_BASE_URL:-http://localhost:8283}"
+OLLAMA_URL="${OLLAMA_BASE_URL:-http://ollama:11434}"
+
+echo "Setting up Ollama provider in Letta..."
+
+# Check if ollama provider already exists
+EXISTING=$(curl -s "$LETTA_URL/v1/providers/" | grep -o '"name":"ollama"' || true)
+
+if [ -n "$EXISTING" ]; then
+    echo "Ollama provider already configured"
+    exit 0
+fi
+
+# Create ollama provider
+RESPONSE=$(curl -s -X POST "$LETTA_URL/v1/providers/" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"name\": \"ollama-local\",
+        \"provider_type\": \"ollama\",
+        \"api_key\": \"ollama\",
+        \"base_url\": \"$OLLAMA_URL\"
+    }")
+
+if echo "$RESPONSE" | grep -q '"id"'; then
+    echo "Ollama provider configured successfully"
+    echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Provider ID: {d.get(\"id\")}')" 2>/dev/null || true
+else
+    echo "Failed to configure Ollama provider:"
+    echo "$RESPONSE"
+    exit 1
+fi
+
+# Verify the model is available
+echo "Checking available models..."
+curl -s "$LETTA_URL/v1/models/" | python3 -c "
+import sys, json
+models = json.load(sys.stdin)
+ollama_models = [m for m in models if 'ollama' in m.get('name', '').lower() or 'smollm' in m.get('name', '').lower()]
+if ollama_models:
+    print(f'Found {len(ollama_models)} Ollama model(s):')
+    for m in ollama_models[:5]:
+        print(f'  - {m.get(\"name\")}')
+else:
+    print('No Ollama models found yet (model may need to be pulled)')
+" 2>/dev/null || echo "Could not list models"
+
+echo "Ollama setup complete!"

--- a/tests/unit/commands/messages.test.ts
+++ b/tests/unit/commands/messages.test.ts
@@ -1,10 +1,10 @@
-import { listMessagesCommand, sendMessageCommand } from '../../src/commands/messages';
-import { LettaClientWrapper } from '../../src/lib/letta-client';
-import { AgentResolver } from '../../src/lib/agent-resolver';
+import { listMessagesCommand, sendMessageCommand } from '../../../src/commands/messages';
+import { LettaClientWrapper } from '../../../src/lib/letta-client';
+import { AgentResolver } from '../../../src/lib/agent-resolver';
 
 // Mock dependencies
-jest.mock('../../src/lib/letta-client');
-jest.mock('../../src/lib/agent-resolver');
+jest.mock('../../../src/lib/letta-client');
+jest.mock('../../../src/lib/agent-resolver');
 jest.mock('ora', () => {
   return jest.fn(() => ({
     start: jest.fn(() => ({

--- a/tests/unit/lib/agent-manager.test.ts
+++ b/tests/unit/lib/agent-manager.test.ts
@@ -1,8 +1,8 @@
-import { AgentManager } from '../../src/lib/agent-manager';
-import { LettaClientWrapper } from '../../src/lib/letta-client';
-import { generateContentHash } from '../../src/utils/hash-utils';
+import { AgentManager } from '../../../src/lib/agent-manager';
+import { LettaClientWrapper } from '../../../src/lib/letta-client';
+import { generateContentHash } from '../../../src/utils/hash-utils';
 
-jest.mock('../../src/lib/letta-client');
+jest.mock('../../../src/lib/letta-client');
 
 describe('AgentManager', () => {
   let manager: AgentManager;

--- a/tests/unit/lib/agent-resolver.test.ts
+++ b/tests/unit/lib/agent-resolver.test.ts
@@ -1,8 +1,8 @@
-import { AgentResolver } from '../../src/lib/agent-resolver';
-import { LettaClientWrapper } from '../../src/lib/letta-client';
+import { AgentResolver } from '../../../src/lib/agent-resolver';
+import { LettaClientWrapper } from '../../../src/lib/letta-client';
 
 // Mock LettaClientWrapper
-jest.mock('../../src/lib/letta-client');
+jest.mock('../../../src/lib/letta-client');
 const MockedLettaClient = LettaClientWrapper as jest.MockedClass<typeof LettaClientWrapper>;
 
 describe('AgentResolver', () => {

--- a/tests/unit/lib/block-manager.test.ts
+++ b/tests/unit/lib/block-manager.test.ts
@@ -1,8 +1,8 @@
-import { BlockManager } from '../../src/lib/block-manager';
-import { LettaClientWrapper } from '../../src/lib/letta-client';
-import { generateContentHash } from '../../src/utils/hash-utils';
+import { BlockManager } from '../../../src/lib/block-manager';
+import { LettaClientWrapper } from '../../../src/lib/letta-client';
+import { generateContentHash } from '../../../src/utils/hash-utils';
 
-jest.mock('../../src/lib/letta-client');
+jest.mock('../../../src/lib/letta-client');
 
 describe('BlockManager', () => {
   let manager: BlockManager;

--- a/tests/unit/lib/diff-engine.test.ts
+++ b/tests/unit/lib/diff-engine.test.ts
@@ -1,9 +1,9 @@
-import { BlockManager } from '../../src/lib/block-manager';
-import { LettaClientWrapper } from '../../src/lib/letta-client';
-import { analyzeToolChanges, analyzeBlockChanges, analyzeFolderChanges } from '../../src/lib/diff-analyzers';
+import { BlockManager } from '../../../src/lib/block-manager';
+import { LettaClientWrapper } from '../../../src/lib/letta-client';
+import { analyzeToolChanges, analyzeBlockChanges, analyzeFolderChanges } from '../../../src/lib/diff-analyzers';
 
-jest.mock('../../src/lib/letta-client');
-jest.mock('../../src/lib/block-manager');
+jest.mock('../../../src/lib/letta-client');
+jest.mock('../../../src/lib/block-manager');
 
 describe('DiffEngine', () => {
   let mockBlockManager: jest.Mocked<BlockManager>;

--- a/tests/unit/lib/error-handler.test.ts
+++ b/tests/unit/lib/error-handler.test.ts
@@ -1,4 +1,4 @@
-import { withErrorHandling, createNotFoundError } from '../../src/lib/error-handler';
+import { withErrorHandling, createNotFoundError } from '../../../src/lib/error-handler';
 
 // Mock console.error and process.exit for testing
 const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/unit/lib/fleet-parser.test.ts
+++ b/tests/unit/lib/fleet-parser.test.ts
@@ -1,4 +1,4 @@
-import { FleetParser } from '../../src/lib/fleet-parser';
+import { FleetParser } from '../../../src/lib/fleet-parser';
 import * as fs from 'fs';
 
 // Mock fs module

--- a/tests/unit/lib/output-formatter.test.ts
+++ b/tests/unit/lib/output-formatter.test.ts
@@ -1,4 +1,4 @@
-import { OutputFormatter } from '../../src/lib/output-formatter';
+import { OutputFormatter } from '../../../src/lib/output-formatter';
 
 // Mock console.log for testing
 const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});

--- a/tests/unit/lib/resource-classifier.test.ts
+++ b/tests/unit/lib/resource-classifier.test.ts
@@ -1,7 +1,7 @@
-import { ResourceClassifier } from '../../src/lib/resource-classifier';
-import { LettaClientWrapper } from '../../src/lib/letta-client';
+import { ResourceClassifier } from '../../../src/lib/resource-classifier';
+import { LettaClientWrapper } from '../../../src/lib/letta-client';
 
-jest.mock('../../src/lib/letta-client');
+jest.mock('../../../src/lib/letta-client');
 
 describe('ResourceClassifier', () => {
   let classifier: ResourceClassifier;

--- a/tests/unit/lib/validators.test.ts
+++ b/tests/unit/lib/validators.test.ts
@@ -1,4 +1,4 @@
-import { validateResourceType, validateRequired } from '../../src/lib/validators';
+import { validateResourceType, validateRequired } from '../../../src/lib/validators';
 
 const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`exit ${code}`); });
 const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/unit/sdk.test.ts
+++ b/tests/unit/sdk.test.ts
@@ -1,7 +1,7 @@
 jest.mock('ora', () => () => ({ start: jest.fn().mockReturnThis(), stop: jest.fn(), succeed: jest.fn(), fail: jest.fn() }));
 
-import { LettaCtl, FleetConfigBuilder } from '../src/sdk';
-import { FleetConfig } from '../src/types/fleet-config';
+import { LettaCtl, FleetConfigBuilder } from '../../src/sdk';
+import { FleetConfig } from '../../src/types/fleet-config';
 
 describe('FleetConfigBuilder', () => {
   it('builds config with agents and shared blocks', () => {


### PR DESCRIPTION
## Summary
- Move unit tests from `tests/` to `tests/unit/`
- Add `tests/e2e/` with YAML test configs
- Add `docker-compose.yml` for local Letta server
- Add GitHub Actions e2e workflow

## Test plan
- [x] Run `./tests/e2e/run-e2e-tests.sh` locally - 11/11 tests pass

Closes #27