### PR TITLE
feat: #32 add service role key for private buckets

### DIFF
--- a/src/lib/storage-error-handler.ts
+++ b/src/lib/storage-error-handler.ts
@@ -105,18 +105,19 @@ export class StorageErrorHandler {
     // Handle StorageUnknownError - check status to differentiate bucket vs auth issues
     if (error.__isStorageError && error.name === 'StorageUnknownError') {
       const status = error.originalError?.status;
-      
+
       if (status === 400) {
         throw new Error(
           `Failed to ${context.operation} ${context.bucket}/${context.filePath} (supabase): ` +
-          `Bucket '${context.bucket}' doesn't exist. Check: 1) bucket name is spelled correctly, ` +
-          `2) bucket exists in your Supabase project, 3) you're connected to the right project.`
+          `Bucket '${context.bucket}' not accessible. This could mean: 1) bucket doesn't exist, ` +
+          `2) bucket is private and requires SUPABASE_SERVICE_ROLE_KEY instead of SUPABASE_ANON_KEY. ` +
+          `For private buckets, set SUPABASE_SERVICE_ROLE_KEY in your environment.`
         );
       } else if (!error.originalError || Object.keys(error.originalError).length === 0) {
         throw new Error(
           `Failed to ${context.operation} ${context.bucket}/${context.filePath} (supabase): ` +
-          'Authentication error. Please check your SUPABASE_ANON_KEY is correct and not expired. ' +
-          'Get a new one from Supabase Dashboard > Settings > API.'
+          'Authentication error. Check your Supabase credentials. ' +
+          'For private buckets, use SUPABASE_SERVICE_ROLE_KEY instead of SUPABASE_ANON_KEY.'
         );
       }
     }
@@ -135,8 +136,9 @@ export class StorageErrorHandler {
       if (error.message.includes('Bucket not found') || error.message.includes('The resource you requested could not be found')) {
         throw new Error(
           `Failed to ${context.operation} ${context.bucket}/${context.filePath} (supabase): ` +
-          `Bucket '${context.bucket}' doesn't exist. Check: 1) bucket name is spelled correctly, ` +
-          `2) bucket exists in your Supabase project, 3) you're connected to the right project.`
+          `Bucket '${context.bucket}' not accessible. Check: 1) bucket name is correct, ` +
+          `2) bucket exists in your Supabase project. If bucket is private, ` +
+          `use SUPABASE_SERVICE_ROLE_KEY instead of SUPABASE_ANON_KEY.`
         );
       }
     }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,6 +13,7 @@ export interface LettaCtlOptions {
   lettaApiKey?: string;
   supabaseUrl?: string;
   supabaseAnonKey?: string;
+  supabaseServiceRoleKey?: string;
 }
 
 export class LettaCtl {
@@ -23,8 +24,11 @@ export class LettaCtl {
     if (options.lettaApiKey) process.env.LETTA_API_KEY = options.lettaApiKey;
     if (options.supabaseUrl) process.env.SUPABASE_URL = options.supabaseUrl;
     if (options.supabaseAnonKey) process.env.SUPABASE_ANON_KEY = options.supabaseAnonKey;
+    if (options.supabaseServiceRoleKey) process.env.SUPABASE_SERVICE_ROLE_KEY = options.supabaseServiceRoleKey;
 
-    if (options.supabaseUrl && options.supabaseAnonKey) {
+    const hasSupabaseCredentials = options.supabaseUrl &&
+      (options.supabaseAnonKey || options.supabaseServiceRoleKey);
+    if (hasSupabaseCredentials) {
       this.supabaseBackend = new SupabaseStorageBackend();
     }
   }


### PR DESCRIPTION
## Summary
- Add SUPABASE_SERVICE_ROLE_KEY support for accessing private buckets
- Prefer service role key over anon key when both are set
- Update SDK options to accept supabaseServiceRoleKey
- Improve error messages to guide users to use service role key for private buckets

Closes #32