### PR TITLE
refactor: #30 centralize Supabase config check

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -5,7 +5,7 @@ import { AgentManager } from '../lib/agent-manager';
 import { DiffEngine } from '../lib/diff-engine';
 import { FileContentTracker } from '../lib/file-content-tracker';
 import { getSpinnerEnabled } from '../lib/spinner';
-import { SupabaseStorageBackend } from '../lib/storage-backend';
+import { SupabaseStorageBackend, hasSupabaseConfig } from '../lib/storage-backend';
 import { applyTemplateMode } from './apply-template';
 import { processSharedBlocks, processFolders, updateExistingAgent, createNewAgent } from '../lib/apply-helpers';
 
@@ -27,7 +27,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
     let supabaseBackend: SupabaseStorageBackend | undefined;
     
     try {
-      if (process.env.SUPABASE_URL && (process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY)) {
+      if (hasSupabaseConfig()) {
         supabaseBackend = new SupabaseStorageBackend();
         console.log('Supabase backend configured for cloud storage access');
       }

--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -9,7 +9,7 @@ import { FileContentTracker } from './file-content-tracker';
 import { OutputFormatter } from './output-formatter';
 import { createSpinner } from './spinner';
 import { FleetParser } from './fleet-parser';
-import { StorageBackendManager, SupabaseStorageBackend } from './storage-backend';
+import { StorageBackendManager, SupabaseStorageBackend, hasSupabaseConfig } from './storage-backend';
 import { FolderFileConfig } from '../types/fleet-config';
 
 export async function processSharedBlocks(
@@ -39,9 +39,7 @@ let supabaseBackendInstance: SupabaseStorageBackend | undefined = undefined;
 
 function getStorageManager(): StorageBackendManager {
   if (!storageManager) {
-    supabaseBackendInstance = process.env.SUPABASE_URL && (process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY)
-      ? new SupabaseStorageBackend()
-      : undefined;
+    supabaseBackendInstance = hasSupabaseConfig() ? new SupabaseStorageBackend() : undefined;
     storageManager = new StorageBackendManager({ supabaseBackend: supabaseBackendInstance });
   }
   return storageManager;

--- a/src/lib/diff-applier.ts
+++ b/src/lib/diff-applier.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { LettaClientWrapper } from './letta-client';
 import { AgentUpdateOperations } from './diff-engine';
-import { StorageBackendManager, SupabaseStorageBackend } from './storage-backend';
+import { StorageBackendManager, SupabaseStorageBackend, hasSupabaseConfig } from './storage-backend';
 
 /**
  * DiffApplier applies update operations to agents
@@ -140,9 +140,7 @@ export class DiffApplier {
       const filePath = pathParts.join('/');
 
       // Initialize storage backend
-      const supabaseBackend = process.env.SUPABASE_URL && (process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY)
-        ? new SupabaseStorageBackend()
-        : undefined;
+      const supabaseBackend = hasSupabaseConfig() ? new SupabaseStorageBackend() : undefined;
 
       if (!supabaseBackend) {
         throw new Error('Supabase credentials not configured for bucket file download');

--- a/src/lib/storage-backend.ts
+++ b/src/lib/storage-backend.ts
@@ -16,6 +16,13 @@ export interface BucketConfig {
 }
 
 /**
+ * Check if Supabase storage is configured
+ */
+export function hasSupabaseConfig(): boolean {
+  return !!(process.env.SUPABASE_URL && (process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY));
+}
+
+/**
  * Storage backend manager that routes requests to appropriate backends
  */
 export class StorageBackendManager {


### PR DESCRIPTION
## Summary
- Add `hasSupabaseConfig()` helper to storage-backend.ts
- Replace duplicated `process.env.SUPABASE_URL && (process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY)` checks in:
  - apply.ts
  - apply-helpers.ts
  - diff-applier.ts

Closes #30