### PR TITLE
feat: #64 detect builtin tools and show helpful warnings

### DIFF
--- a/src/commands/apply-template.ts
+++ b/src/commands/apply-template.ts
@@ -92,7 +92,7 @@ export async function applyTemplateMode(
 
   // Generate tool source hashes and register tools
   const toolSourceHashes = fileTracker.generateToolSourceHashes(templateTools, parser.toolConfigs);
-  const { toolNameToId, updatedTools } = await parser.registerRequiredTools(config, client, verbose, toolSourceHashes);
+  const { toolNameToId, updatedTools, builtinTools } = await parser.registerRequiredTools(config, client, verbose, toolSourceHashes);
 
   // Apply template to each matching agent
   for (const existingAgent of matchingAgents) {
@@ -170,7 +170,7 @@ export async function applyTemplateMode(
       }
 
       agentSpinner.stop();
-      OutputFormatter.showAgentUpdateDiff(ops);
+      OutputFormatter.showAgentUpdateDiff(ops, builtinTools);
 
       const updateSpinner = createSpinner(`Applying updates to ${existingAgent.name}...`, spinnerEnabled).start();
       await diffEngine.applyUpdateOperations(existingAgent.id, ops, verbose);

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -88,7 +88,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
     const globalToolSourceHashes = fileTracker.generateToolSourceHashes(Array.from(allToolNames), parser.toolConfigs);
 
     if (verbose) console.log('Registering tools...');
-    const { toolNameToId, updatedTools } = await parser.registerRequiredTools(config, client, verbose, globalToolSourceHashes);
+    const { toolNameToId, updatedTools, builtinTools } = await parser.registerRequiredTools(config, client, verbose, globalToolSourceHashes);
 
     // Register MCP servers
     if (config.mcp_servers && config.mcp_servers.length > 0) {
@@ -183,6 +183,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
             agentManager,
             toolNameToId,
             updatedTools,
+            builtinTools,
             createdFolders,
             sharedBlockIds,
             spinnerEnabled,
@@ -196,6 +197,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
             blockManager,
             agentManager,
             toolNameToId,
+            builtinTools,
             createdFolders,
             sharedBlockIds,
             spinnerEnabled,

--- a/src/lib/builtin-tools.ts
+++ b/src/lib/builtin-tools.ts
@@ -1,0 +1,94 @@
+/**
+ * Registry of Letta built-in tools and their server-side requirements
+ *
+ * Built-in tools are maintained by Letta and execute in a privileged server context.
+ * They have fixed implementations that cannot be modified - you can only attach them to agents.
+ *
+ * @see https://docs.letta.com/guides/agents/tool-execution-builtin
+ */
+
+export interface BuiltinToolInfo {
+  name: string;
+  description: string;
+  requiredEnvVar?: string;       // Required for the tool to be available
+  optionalEnvVar?: string;       // Optional enhancement
+  docsUrl: string;
+}
+
+/**
+ * Registry of all known Letta built-in tools
+ */
+export const BUILTIN_TOOLS: Record<string, BuiltinToolInfo> = {
+  web_search: {
+    name: 'web_search',
+    description: 'Search the web using Exa AI-powered search engine',
+    requiredEnvVar: 'EXA_API_KEY',
+    docsUrl: 'https://docs.letta.com/guides/agents/web-search'
+  },
+  run_code: {
+    name: 'run_code',
+    description: 'Execute code in a secure E2B sandbox',
+    requiredEnvVar: 'E2B_API_KEY',
+    docsUrl: 'https://docs.letta.com/guides/agents/code-interpreter'
+  },
+  fetch_webpage: {
+    name: 'fetch_webpage',
+    description: 'Fetch and convert webpages to readable text/markdown',
+    optionalEnvVar: 'EXA_API_KEY',
+    docsUrl: 'https://docs.letta.com/guides/agents/prebuilt-tools'
+  }
+};
+
+/**
+ * Core memory tools that are always available (no configuration needed)
+ */
+export const CORE_MEMORY_TOOLS = [
+  'archival_memory_insert',
+  'archival_memory_search',
+  'conversation_search',
+  'memory_insert',
+  'memory_replace',
+  'memory_rethink'
+];
+
+/**
+ * Check if a tool name is a known built-in tool
+ */
+export function isBuiltinTool(toolName: string): boolean {
+  return toolName in BUILTIN_TOOLS || CORE_MEMORY_TOOLS.includes(toolName);
+}
+
+/**
+ * Get info about a built-in tool if it exists
+ */
+export function getBuiltinToolInfo(toolName: string): BuiltinToolInfo | null {
+  return BUILTIN_TOOLS[toolName] || null;
+}
+
+/**
+ * Get the required environment variable for a built-in tool
+ */
+export function getRequiredEnvVar(toolName: string): string | undefined {
+  return BUILTIN_TOOLS[toolName]?.requiredEnvVar;
+}
+
+/**
+ * Format a helpful message when a built-in tool is not available on the server
+ */
+export function formatBuiltinToolWarning(toolName: string): string {
+  const info = BUILTIN_TOOLS[toolName];
+  if (!info) return `Tool '${toolName}' not found on server.`;
+
+  const lines = [
+    `Built-in tool '${toolName}' not found on server.`
+  ];
+
+  if (info.requiredEnvVar) {
+    lines.push(`This tool requires ${info.requiredEnvVar} to be set on your Letta server.`);
+    lines.push(`Restart your Letta server with: -e ${info.requiredEnvVar}=your_key`);
+  }
+
+  lines.push(`See: ${info.docsUrl}`);
+
+  return lines.join('\n');
+}

--- a/src/lib/diff-applier.ts
+++ b/src/lib/diff-applier.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { LettaClientWrapper } from './letta-client';
 import { AgentUpdateOperations } from './diff-engine';
 import { StorageBackendManager, SupabaseStorageBackend, hasSupabaseConfig } from './storage-backend';
+import { isBuiltinTool } from './builtin-tools';
 
 /**
  * DiffApplier applies update operations to agents
@@ -56,8 +57,10 @@ export class DiffApplier {
 
     // Apply tool changes
     if (operations.tools) {
+      const getBuiltinTag = (name: string) => isBuiltinTool(name) ? ' [builtin]' : '';
+
       for (const tool of operations.tools.toAdd) {
-        if (verbose) console.log(`  Attaching tool: ${tool.name}`);
+        if (verbose) console.log(`  Attaching tool: ${tool.name}${getBuiltinTag(tool.name)}`);
         await this.client.attachToolToAgent(agentId, tool.id);
       }
 
@@ -69,7 +72,7 @@ export class DiffApplier {
       }
 
       for (const tool of operations.tools.toRemove) {
-        if (verbose) console.log(`  Detaching tool: ${tool.name}`);
+        if (verbose) console.log(`  Detaching tool: ${tool.name}${getBuiltinTag(tool.name)}`);
         await this.client.detachToolFromAgent(agentId, tool.id);
       }
     }


### PR DESCRIPTION
## Summary
- Add builtin tools registry (web_search, run_code, fetch_webpage) with env var requirements
- Show warning when builtin tool not available on server (missing EXA_API_KEY, E2B_API_KEY)
- Display [builtin] tag in logs when attaching/detaching builtin tools
- Don't break agent setup when builtin is missing, just skip it with helpful message

Closes #64