### PR TITLE
feat: add runs commands for async job tracking

### DIFF
--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -5,8 +5,10 @@ import { OutputFormatter } from '../lib/output-formatter';
 import { createSpinner, getSpinnerEnabled } from '../lib/spinner';
 import { sendMessageToAgent } from '../lib/message-sender';
 
-// Helper function to safely extract content from different message types
-function getMessageContent(message: any): string | null {
+/**
+ * Safely extracts content from different message types
+ */
+export function getMessageContent(message: any): string | null {
   // Try different properties that might contain the message content
   if (message.text) return message.text;
   if (message.content) {

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -1,0 +1,210 @@
+import { LettaClientWrapper } from '../lib/letta-client';
+import { AgentResolver } from '../lib/agent-resolver';
+import { normalizeResponse, sleep } from '../lib/response-normalizer';
+import { formatStatus } from '../lib/output-formatter';
+import { getMessageContent } from './messages';
+import { Run } from '../types/run';
+
+export async function listRunsCommand(
+  options: { active?: boolean; agent?: string; limit?: number },
+  command: any
+) {
+  const verbose = command.parent?.opts().verbose || false;
+  const client = new LettaClientWrapper();
+
+  let agentId: string | undefined;
+  if (options.agent) {
+    const resolver = new AgentResolver(client);
+    const { agent } = await resolver.findAgentByName(options.agent);
+    agentId = agent.id;
+  }
+
+  const runsResponse = await client.listRuns({
+    agentId,
+    active: options.active,
+    limit: options.limit || 20
+  });
+
+  const runs = normalizeResponse(runsResponse) as Run[];
+
+  if (runs.length === 0) {
+    console.log('No runs found.');
+    return;
+  }
+
+  console.log('Runs');
+  console.log('='.repeat(80));
+  console.log('');
+
+  for (const run of runs) {
+    const status = formatStatus(run.status);
+    const created = new Date(run.created_at).toLocaleString();
+
+    console.log(`${run.id}`);
+    console.log(`  Status:  ${status}`);
+    console.log(`  Agent:   ${run.agent_id}`);
+    console.log(`  Created: ${created}`);
+
+    if (run.completed_at) {
+      const completed = new Date(run.completed_at).toLocaleString();
+      console.log(`  Completed: ${completed}`);
+    }
+
+    if (run.stop_reason) {
+      console.log(`  Stop reason: ${run.stop_reason}`);
+    }
+
+    if (verbose && run.background !== undefined) {
+      console.log(`  Background: ${run.background}`);
+    }
+
+    console.log('');
+  }
+
+  console.log(`Total: ${runs.length} run(s)`);
+}
+
+export async function getRunCommand(
+  runId: string,
+  options: { wait?: boolean; stream?: boolean; messages?: boolean },
+  command: any
+) {
+  const verbose = command.parent?.opts().verbose || false;
+  const client = new LettaClientWrapper();
+
+  if (options.wait) {
+    await waitForRun(client, runId, verbose);
+    return;
+  }
+
+  if (options.stream) {
+    await streamRun(client, runId);
+    return;
+  }
+
+  if (options.messages) {
+    await showRunMessages(client, runId);
+    return;
+  }
+
+  // Default: show run details
+  const run = await client.getRun(runId) as Run;
+
+  console.log(`Run: ${run.id}`);
+  console.log('='.repeat(50));
+  console.log('');
+  console.log(`Status:     ${formatStatus(run.status)}`);
+  console.log(`Agent:      ${run.agent_id}`);
+  console.log(`Created:    ${new Date(run.created_at).toLocaleString()}`);
+
+  if (run.completed_at) {
+    console.log(`Completed:  ${new Date(run.completed_at).toLocaleString()}`);
+  }
+
+  if (run.stop_reason) {
+    console.log(`Stop reason: ${run.stop_reason}`);
+  }
+
+  if (verbose) {
+    console.log(`Background: ${run.background ?? false}`);
+  }
+}
+
+export async function deleteRunCommand(
+  runId: string,
+  _options: {},
+  _command: any
+) {
+  const client = new LettaClientWrapper();
+
+  try {
+    await client.deleteRun(runId);
+    console.log(`Run ${runId} deleted.`);
+  } catch (error: any) {
+    console.error(`Failed to delete run: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+async function waitForRun(client: LettaClientWrapper, runId: string, verbose: boolean) {
+  const pollInterval = 1000; // 1 second
+  const timeout = 5 * 60 * 1000; // 5 minutes
+  const startTime = Date.now();
+
+  console.log(`Waiting for run ${runId}...`);
+
+  while (true) {
+    const run = await client.getRun(runId) as Run;
+
+    if (verbose) {
+      console.log(`  Status: ${run.status}`);
+    }
+
+    if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
+      console.log('');
+      console.log(`Run ${run.status}.`);
+
+      if (run.stop_reason) {
+        console.log(`Stop reason: ${run.stop_reason}`);
+      }
+
+      // Show messages if completed
+      if (run.status === 'completed') {
+        await showRunMessages(client, runId);
+      }
+
+      return;
+    }
+
+    if (Date.now() - startTime > timeout) {
+      console.log('');
+      console.log('Timeout waiting for run to complete.');
+      process.exit(1);
+    }
+
+    await sleep(pollInterval);
+  }
+}
+
+async function streamRun(client: LettaClientWrapper, runId: string) {
+  // Check run status first
+  const run = await client.getRun(runId) as Run;
+
+  if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
+    console.log(`Run ${run.status}.`);
+    await showRunMessages(client, runId);
+    return;
+  }
+
+  // Fall back to wait mode for consistent behavior
+  await waitForRun(client, runId, false);
+}
+
+async function showRunMessages(client: LettaClientWrapper, runId: string) {
+  const messagesResponse = await client.getRunMessages(runId);
+  const messages = normalizeResponse(messagesResponse);
+
+  if (messages.length === 0) {
+    console.log('No messages.');
+    return;
+  }
+
+  console.log('');
+  console.log('Messages:');
+  console.log('-'.repeat(40));
+
+  for (const msg of messages) {
+    const role = msg.role || msg.message_type || 'unknown';
+    const content = getMessageContent(msg) || JSON.stringify(msg);
+
+    if (role === 'assistant_message' || role === 'assistant') {
+      console.log(`[Assistant] ${content}`);
+    } else if (role === 'user_message' || role === 'user') {
+      console.log(`[User] ${content}`);
+    } else if (role === 'tool_call_message' || role === 'tool_call') {
+      console.log(`[Tool Call] ${msg.tool_call?.name || 'unknown'}`);
+    } else if (role === 'tool_return_message' || role === 'tool_return') {
+      console.log(`[Tool Return] ${content}`);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { validateCommand } from './commands/validate';
 import { healthCommand } from './commands/health';
 import { filesCommand } from './commands/files';
 import { contextCommand } from './commands/context';
+import { listRunsCommand, getRunCommand, deleteRunCommand } from './commands/runs';
 
 // Global verbose flag for error handling
 let verboseMode = false;
@@ -258,6 +259,30 @@ program
   .description('Show context window token usage breakdown')
   .argument('<agent>', 'agent name')
   .action(contextCommand);
+
+// Runs - manage async job runs
+program
+  .command('runs')
+  .description('List async job runs')
+  .option('--active', 'show only active runs')
+  .option('-a, --agent <name>', 'filter by agent name')
+  .option('-l, --limit <number>', 'limit number of results', parseInt)
+  .action(listRunsCommand);
+
+program
+  .command('run')
+  .description('Get run details')
+  .argument('<run-id>', 'run ID')
+  .option('--wait', 'wait for run to complete')
+  .option('--stream', 'stream run output')
+  .option('--messages', 'show run messages')
+  .action(getRunCommand);
+
+program
+  .command('run-delete')
+  .description('Delete/cancel a run')
+  .argument('<run-id>', 'run ID')
+  .action(deleteRunCommand);
 
 // Global error handler to prevent stack traces from leaking
 process.on('unhandledRejection', (error: any) => {

--- a/src/lib/letta-client.ts
+++ b/src/lib/letta-client.ts
@@ -185,6 +185,51 @@ export class LettaClientWrapper {
     return await this.client.agents.messages.compact(agentId);
   }
 
+  // === Run Management ===
+
+  async listRuns(options?: { agentId?: string; active?: boolean; limit?: number }) {
+    return await this.client.runs.list({
+      agent_id: options?.agentId,
+      active: options?.active,
+      limit: options?.limit
+    });
+  }
+
+  async getRun(runId: string) {
+    return await this.client.runs.retrieve(runId);
+  }
+
+  async deleteRun(runId: string) {
+    // SDK doesn't expose delete, call API directly
+    const baseUrl = process.env.LETTA_BASE_URL;
+    const response = await fetch(`${baseUrl}/v1/runs/${runId}`, {
+      method: 'DELETE',
+      headers: this.getAuthHeaders()
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to delete run: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async getRunMessages(runId: string) {
+    return await this.client.runs.messages.list(runId);
+  }
+
+  async streamRun(runId: string) {
+    return await this.client.runs.messages.stream(runId);
+  }
+
+  private getAuthHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    };
+    if (process.env.LETTA_API_KEY) {
+      headers['Authorization'] = `Bearer ${process.env.LETTA_API_KEY}`;
+    }
+    return headers;
+  }
+
   // === Granular Agent Update Operations ===
   // These methods enable partial updates that preserve conversation history
 

--- a/src/lib/output-formatter.ts
+++ b/src/lib/output-formatter.ts
@@ -2,6 +2,26 @@ import Table from 'cli-table3';
 import { AgentUpdateOperations } from './diff-engine';
 import { isBuiltinTool } from './builtin-tools';
 
+/**
+ * Formats run/job status as bracketed labels
+ */
+export function formatStatus(status: string): string {
+  switch (status) {
+    case 'created':
+      return '[CREATED]';
+    case 'running':
+      return '[RUNNING]';
+    case 'completed':
+      return '[OK]';
+    case 'failed':
+      return '[FAILED]';
+    case 'cancelled':
+      return '[CANCELLED]';
+    default:
+      return `[${status.toUpperCase()}]`;
+  }
+}
+
 export class OutputFormatter {
   /**
    * Formats output based on the specified format

--- a/src/lib/response-normalizer.ts
+++ b/src/lib/response-normalizer.ts
@@ -25,3 +25,10 @@ export function normalizeResponse(response: any): any[] {
   // Fallback: return empty array for unexpected formats
   return [];
 }
+
+/**
+ * Sleep utility for polling and delays
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -1,0 +1,9 @@
+export interface Run {
+  id: string;
+  status: 'created' | 'running' | 'completed' | 'failed' | 'cancelled' | string;
+  agent_id: string;
+  created_at: string;
+  completed_at?: string;
+  stop_reason?: string;
+  background?: boolean;
+}


### PR DESCRIPTION
## Summary
- Add `runs` command to list async job runs with filtering options
- Add `run <id>` command to get run details with --wait, --stream, --messages
- Add `run-delete <id>` command to delete/cancel runs
- Refactor shared utilities (formatStatus, sleep, getMessageContent)
- Add Run type to types/

Closes #75