### PR TITLE
feat: #84 add quiet mode for CI pipelines

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,4 +15,4 @@ if [ -z "$LETTA_BASE_URL" ]; then
   exit 1
 fi
 
-./tests/e2e/script.sh
+pnpm test:e2e -- -q

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "test": "jest",
+    "test:e2e": "./tests/e2e/script.sh",
     "prepare": "husky",
     "prepublishOnly": "npm test && npm run build",
     "preversion": "npm test",

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -5,6 +5,7 @@ import { validateResourceType } from '../lib/validators';
 import { withErrorHandling } from '../lib/error-handler';
 import { createSpinner, getSpinnerEnabled } from '../lib/spinner';
 import { normalizeToArray, computeAgentCounts } from '../lib/resource-usage';
+import { log } from '../lib/logger';
 
 const SUPPORTED_RESOURCES = ['agents', 'blocks', 'tools', 'folders', 'mcp-servers'];
 
@@ -30,14 +31,14 @@ async function getCommandImpl(resource: string, _name?: string, options?: GetOpt
     throw new Error('Cannot use --shared or --orphaned with --agent');
   }
   if ((options?.shared || options?.orphaned) && resource === 'agents') {
-    console.log('Note: --shared and --orphaned flags are ignored for "get agents"');
+    log('Note: --shared and --orphaned flags are ignored for "get agents"');
   }
 
   // If --agent flag is provided, resolve agent name to ID
   let agentId: string | undefined;
   if (options?.agent) {
     if (resource === 'agents') {
-      console.log('Note: --agent flag is ignored for "get agents"');
+      log('Note: --agent flag is ignored for "get agents"');
     } else {
       const spinner = createSpinner(`Resolving agent ${options.agent}...`, spinnerEnabled).start();
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import { filesCommand } from './commands/files';
 import { contextCommand } from './commands/context';
 import { listRunsCommand, getRunCommand, deleteRunCommand } from './commands/runs';
 
+import { setQuietMode } from './lib/logger';
+
 // Global verbose flag for error handling
 let verboseMode = false;
 
@@ -30,6 +32,9 @@ let verboseMode = false;
 function validateEnvironment(thisCommand: any, actionCommand: any) {
   // Capture verbose flag for global error handler
   verboseMode = thisCommand.opts().verbose || false;
+
+  // Set quiet mode globally
+  setQuietMode(thisCommand.opts().quiet || false);
 
   if (!process.env.LETTA_BASE_URL) {
     console.error('Error: LETTA_BASE_URL environment variable is required');
@@ -60,6 +65,7 @@ program
   .description('kubectl-style CLI for managing Letta AI agent fleets')
   .version(version)
   .option('-v, --verbose', 'enable verbose output')
+  .option('-q, --quiet', 'suppress progress output (for CI)')
   .option('--no-spinner', 'disable loading spinners')
   .hook('preAction', validateEnvironment);
 

--- a/src/lib/agent-manager.ts
+++ b/src/lib/agent-manager.ts
@@ -2,6 +2,7 @@ import { LettaClientWrapper } from './letta-client';
 import { normalizeResponse } from './response-normalizer';
 import { generateContentHash, generateTimestampVersion } from '../utils/hash-utils';
 import type { AgentConfigHashes, AgentVersion } from '../types/agent';
+import { log } from './logger';
 
 // Re-export types for backwards compatibility
 export type { AgentConfigHashes, AgentVersion } from '../types/agent';
@@ -176,7 +177,7 @@ export class AgentManager {
 
     if (!existingAgent) {
       // No agent with this base name exists
-      if (verbose) console.log(`  No existing agent found for: ${baseName}`);
+      if (verbose) log(`  No existing agent found for: ${baseName}`);
       return { 
         agentName: baseName, 
         shouldCreate: true 
@@ -185,7 +186,7 @@ export class AgentManager {
 
     // For existing agents, we need to compare properly by generating current config hash
     // from the server state. For now, we'll always prefer partial updates over recreation.
-    if (verbose) console.log(`  Found existing agent: ${existingAgent.name}, checking for changes...`);
+    if (verbose) log(`  Found existing agent: ${existingAgent.name}, checking for changes...`);
     
     // Always return existing agent to trigger partial update logic in apply command
     // The actual comparison will happen in the DiffEngine

--- a/src/lib/block-manager.ts
+++ b/src/lib/block-manager.ts
@@ -1,6 +1,7 @@
 import { LettaClientWrapper } from './letta-client';
 import { normalizeResponse } from './response-normalizer';
 import { generateContentHash } from '../utils/hash-utils';
+import { log } from './logger';
 
 export interface BlockInfo {
   id: string;
@@ -69,12 +70,12 @@ export class BlockManager {
 
     if (existing) {
       if (existing.contentHash === contentHash) {
-        console.log(`Using existing shared block: ${existing.label}`);
+        log(`Using existing shared block: ${existing.label}`);
         return existing.id;
       }
 
       // Content changed - update in-place
-      console.log(`Updating shared block: ${existing.label}`);
+      log(`Updating shared block: ${existing.label}`);
       await this.client.updateBlock(existing.id, {
         value: blockConfig.value,
         description: blockConfig.description,
@@ -91,7 +92,7 @@ export class BlockManager {
     }
 
     // Create new block
-    console.log(`Creating new shared block: ${blockConfig.name}`);
+    log(`Creating new shared block: ${blockConfig.name}`);
     const newBlock = await this.client.createBlock({
       label: blockConfig.name,
       description: blockConfig.description,
@@ -123,12 +124,12 @@ export class BlockManager {
 
     if (existing) {
       if (existing.contentHash === contentHash) {
-        console.log(`Using existing block: ${existing.label}`);
+        log(`Using existing block: ${existing.label}`);
         return existing.id;
       }
 
       // Content changed - update in-place
-      console.log(`Updating block: ${existing.label}`);
+      log(`Updating block: ${existing.label}`);
       await this.client.updateBlock(existing.id, {
         value: blockConfig.value,
         description: blockConfig.description,
@@ -145,7 +146,7 @@ export class BlockManager {
     }
 
     // Create new block
-    console.log(`Creating new block: ${blockConfig.name}`);
+    log(`Creating new block: ${blockConfig.name}`);
     const newBlock = await this.client.createBlock({
       label: blockConfig.name,
       description: blockConfig.description,

--- a/src/lib/diff-engine.ts
+++ b/src/lib/diff-engine.ts
@@ -5,6 +5,7 @@ import { normalizeResponse } from './response-normalizer';
 import { DiffApplier } from './diff-applier';
 import { analyzeToolChanges, analyzeBlockChanges, analyzeFolderChanges } from './diff-analyzers';
 import type { AgentUpdateOperations } from '../types/diff';
+import { log } from './logger';
 
 // Re-export types for backwards compatibility
 export type { ToolDiff, BlockDiff, FolderDiff, FieldChange, AgentUpdateOperations } from '../types/diff';
@@ -57,7 +58,7 @@ export class DiffEngine {
       operationCount: 0
     };
 
-    if (verbose) console.log(`  Analyzing configuration changes for agent: ${existingAgent.name}`);
+    if (verbose) log(`  Analyzing configuration changes for agent: ${existingAgent.name}`);
 
     // Get current agent state from server
     const currentAgent = await this.client.getAgent(existingAgent.id);
@@ -80,7 +81,7 @@ export class DiffEngine {
     const normalizedDesired = (desiredConfig.systemPrompt || '').trim();
     
     if (normalizedCurrent !== normalizedDesired) {
-      if (verbose) console.log(`    System prompt differs - current length: ${normalizedCurrent.length}, desired length: ${normalizedDesired.length}`);
+      if (verbose) log(`    System prompt differs - current length: ${normalizedCurrent.length}, desired length: ${normalizedDesired.length}`);
       fieldUpdates.system = desiredConfig.systemPrompt;
       operations.operationCount++;
     }

--- a/src/lib/file-content-tracker.ts
+++ b/src/lib/file-content-tracker.ts
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 import { StorageBackendManager, BucketConfig } from './storage-backend';
 import { FolderConfig, FolderFileConfig } from '../types/fleet-config';
 import { isBuiltinTool } from './builtin-tools';
+import { warn } from './logger';
 
 export interface FileContentMap {
   [filePath: string]: string; // filePath -> content hash
@@ -30,7 +31,7 @@ export class FileContentTracker {
       const content = fs.readFileSync(fullPath, 'utf8');
       return crypto.createHash('sha256').update(content).digest('hex').substring(0, 16);
     } catch (error) {
-      console.warn(`Warning: Could not read file ${filePath} for hashing:`, (error as Error).message);
+      warn(`Warning: Could not read file ${filePath} for hashing:`, (error as Error).message);
       return crypto.createHash('sha256').update(`file-not-found:${filePath}`).digest('hex').substring(0, 16);
     }
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,47 @@
+/**
+ * Centralized logger that respects quiet mode
+ * In quiet mode, only errors are shown
+ */
+
+let quietMode = false;
+
+export function setQuietMode(quiet: boolean): void {
+  quietMode = quiet;
+}
+
+export function isQuietMode(): boolean {
+  return quietMode;
+}
+
+/**
+ * Log info messages (suppressed in quiet mode)
+ */
+export function log(...args: any[]): void {
+  if (!quietMode) {
+    console.log(...args);
+  }
+}
+
+/**
+ * Log errors (always shown)
+ */
+export function error(...args: any[]): void {
+  console.error(...args);
+}
+
+/**
+ * Log warnings (suppressed in quiet mode)
+ */
+export function warn(...args: any[]): void {
+  if (!quietMode) {
+    console.warn(...args);
+  }
+}
+
+/**
+ * Log output that should always be shown (e.g., command results, tables)
+ * This is for final output the user requested, not progress info
+ */
+export function output(...args: any[]): void {
+  console.log(...args);
+}

--- a/src/lib/output-formatter.ts
+++ b/src/lib/output-formatter.ts
@@ -1,6 +1,7 @@
 import Table from 'cli-table3';
 import { AgentUpdateOperations } from './diff-engine';
 import { isBuiltinTool } from './builtin-tools';
+import { log, output } from './logger';
 
 /**
  * Formats run/job status as bracketed labels
@@ -258,7 +259,7 @@ export class OutputFormatter {
    */
   static handleJsonOutput(data: any, format?: string): boolean {
     if (format === 'json') {
-      console.log(JSON.stringify(data, null, 2));
+      output(JSON.stringify(data, null, 2));
       return true;
     }
     return false;
@@ -274,22 +275,22 @@ export class OutputFormatter {
     // System prompt and basic field changes
     if (operations.updateFields) {
       if (operations.updateFields.system !== undefined) {
-        console.log(`  ~ System prompt: updated`);
+        log(`  ~ System prompt: updated`);
       }
       if (operations.updateFields.model !== undefined) {
         const { from, to } = operations.updateFields.model;
-        console.log(`  ~ Model: ${from} → ${to}`);
+        log(`  ~ Model: ${from} → ${to}`);
       }
       if (operations.updateFields.embedding !== undefined) {
         const { from, to } = operations.updateFields.embedding;
-        console.log(`  ~ Embedding: ${from} → ${to}`);
+        log(`  ~ Embedding: ${from} → ${to}`);
       }
       if (operations.updateFields.contextWindow !== undefined) {
         const { from, to } = operations.updateFields.contextWindow;
-        console.log(`  ~ Context window: ${from} → ${to}`);
+        log(`  ~ Context window: ${from} → ${to}`);
       }
     } else {
-      console.log(`  = Basic fields: unchanged`);
+      log(`  = Basic fields: unchanged`);
     }
 
     // Tools changes
@@ -301,16 +302,16 @@ export class OutputFormatter {
         (builtinTools?.has(name) || isBuiltinTool(name)) ? ' [builtin]' : '';
 
       if (toAdd.length > 0 || toRemove.length > 0 || toUpdate.length > 0) {
-        console.log(`  ~ Tools: ${unchanged.length} unchanged, ${toAdd.length + toRemove.length + toUpdate.length} modified`);
+        log(`  ~ Tools: ${unchanged.length} unchanged, ${toAdd.length + toRemove.length + toUpdate.length} modified`);
 
-        toAdd.forEach(tool => console.log(`    + Added tool: ${tool.name}${getBuiltinTag(tool.name)}`));
-        toRemove.forEach(tool => console.log(`    - Removed tool: ${tool.name}${getBuiltinTag(tool.name)}`));
-        toUpdate.forEach(tool => console.log(`    ~ Updated tool: ${tool.name} (${tool.reason})`));
+        toAdd.forEach(tool => log(`    + Added tool: ${tool.name}${getBuiltinTag(tool.name)}`));
+        toRemove.forEach(tool => log(`    - Removed tool: ${tool.name}${getBuiltinTag(tool.name)}`));
+        toUpdate.forEach(tool => log(`    ~ Updated tool: ${tool.name} (${tool.reason})`));
       } else {
-        console.log(`  = Tools: unchanged`);
+        log(`  = Tools: unchanged`);
       }
     } else {
-      console.log(`  = Tools: unchanged`);
+      log(`  = Tools: unchanged`);
     }
 
     // Memory blocks changes  
@@ -318,16 +319,16 @@ export class OutputFormatter {
       const { toAdd, toRemove, toUpdate, unchanged } = operations.blocks;
       
       if (toAdd.length > 0 || toRemove.length > 0 || toUpdate.length > 0) {
-        console.log(`  ~ Memory blocks: ${unchanged.length} unchanged, ${toAdd.length + toRemove.length + toUpdate.length} modified`);
+        log(`  ~ Memory blocks: ${unchanged.length} unchanged, ${toAdd.length + toRemove.length + toUpdate.length} modified`);
         
-        toAdd.forEach(block => console.log(`    + Added block: ${block.name}`));
-        toRemove.forEach(block => console.log(`    - Removed block: ${block.name}`));
-        toUpdate.forEach(block => console.log(`    ~ Updated block: ${block.name}`));
+        toAdd.forEach(block => log(`    + Added block: ${block.name}`));
+        toRemove.forEach(block => log(`    - Removed block: ${block.name}`));
+        toUpdate.forEach(block => log(`    ~ Updated block: ${block.name}`));
       } else {
-        console.log(`  = Memory blocks: unchanged`);
+        log(`  = Memory blocks: unchanged`);
       }
     } else {
-      console.log(`  = Memory blocks: unchanged`);
+      log(`  = Memory blocks: unchanged`);
     }
 
     // Folders changes
@@ -335,23 +336,23 @@ export class OutputFormatter {
       const { toAttach, toDetach, toUpdate, unchanged } = operations.folders;
       
       if (toAttach.length > 0 || toDetach.length > 0 || toUpdate.length > 0) {
-        console.log(`  ~ Folders: ${unchanged.length} unchanged, ${toAttach.length + toDetach.length + toUpdate.length} modified`);
+        log(`  ~ Folders: ${unchanged.length} unchanged, ${toAttach.length + toDetach.length + toUpdate.length} modified`);
         
-        toAttach.forEach(folder => console.log(`    + Added folder: ${folder.name}`));
-        toDetach.forEach(folder => console.log(`    - Removed folder: ${folder.name}`));
+        toAttach.forEach(folder => log(`    + Added folder: ${folder.name}`));
+        toDetach.forEach(folder => log(`    - Removed folder: ${folder.name}`));
         toUpdate.forEach(folder => {
-          console.log(`    ~ Updated folder: ${folder.name}`);
-          folder.filesToAdd.forEach(file => console.log(`      + Added file: ${file}`));
-          folder.filesToRemove.forEach(file => console.log(`      - Removed file: ${file}`));
-          folder.filesToUpdate.forEach(file => console.log(`      ~ Updated file: ${file}`));
+          log(`    ~ Updated folder: ${folder.name}`);
+          folder.filesToAdd.forEach(file => log(`      + Added file: ${file}`));
+          folder.filesToRemove.forEach(file => log(`      - Removed file: ${file}`));
+          folder.filesToUpdate.forEach(file => log(`      ~ Updated file: ${file}`));
         });
       } else {
-        console.log(`  = Folders: unchanged`);
+        log(`  = Folders: unchanged`);
       }
     } else {
-      console.log(`  = Folders: unchanged`);
+      log(`  = Folders: unchanged`);
     }
 
-    console.log(`  Total operations: ${operations.operationCount}, preserves conversation: ${operations.preservesConversation}`);
+    log(`  Total operations: ${operations.operationCount}, preserves conversation: ${operations.preservesConversation}`);
   }
 }

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -1,4 +1,5 @@
 import ora from 'ora';
+import { isQuietMode } from './logger';
 
 export interface SpinnerInterface {
   text: string;
@@ -30,7 +31,31 @@ class NoSpinner implements SpinnerInterface {
   }
 }
 
+class QuietSpinner implements SpinnerInterface {
+  text: string = '';
+
+  start(): SpinnerInterface {
+    return this;
+  }
+
+  succeed(_text?: string): SpinnerInterface {
+    return this;
+  }
+
+  fail(_text?: string): SpinnerInterface {
+    return this;
+  }
+
+  stop(): SpinnerInterface {
+    return this;
+  }
+}
+
 export function createSpinner(text: string, enabled: boolean = true): SpinnerInterface {
+  // Quiet mode always returns silent spinner
+  if (isQuietMode()) {
+    return new QuietSpinner();
+  }
   if (!enabled) {
     console.log(text);
     return new NoSpinner();
@@ -44,4 +69,10 @@ export function getSpinnerEnabled(command: any): boolean {
   const parentOpts = command?.parent?.opts?.() || {};
   const commandOpts = command?.opts?.() || {};
   return !(parentOpts.noSpinner || commandOpts.noSpinner);
+}
+
+export function getQuietMode(command: any): boolean {
+  const parentOpts = command?.parent?.opts?.() || {};
+  const commandOpts = command?.opts?.() || {};
+  return parentOpts.quiet || commandOpts.quiet || false;
 }

--- a/tests/e2e/script.sh
+++ b/tests/e2e/script.sh
@@ -16,11 +16,25 @@ NC='\033[0m'
 PASSED=0
 FAILED=0
 
+# Parse flags
+QUIET_FLAG=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -q|--quiet)
+            QUIET_FLAG="-q"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
 # Paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 FIXTURES="$SCRIPT_DIR/fixtures"
-CLI="node $ROOT_DIR/dist/index.js"
+CLI="node $ROOT_DIR/dist/index.js $QUIET_FLAG"
 LOG_DIR="$ROOT_DIR/logs"
 OUT="$LOG_DIR/e2e-out.txt"
 


### PR DESCRIPTION
## Summary
- Add `-q`/`--quiet` global flag to suppress progress output for CI pipelines
- Create centralized logger with `log()`, `warn()`, `error()`, `output()` functions
- Add `test:e2e` script and quiet flag to e2e test script

Closes #84