### PR TITLE
fix: #89 fail apply when self-hosted without embedding

### DIFF
--- a/tests/e2e/fixtures/fleet-invalid.yml
+++ b/tests/e2e/fixtures/fleet-invalid.yml
@@ -1,0 +1,12 @@
+# Invalid configurations for negative testing
+# Each agent tests a specific validation error
+
+agents:
+  # Missing embedding (required for self-hosted)
+  - name: e2e-invalid-no-embedding
+    description: Agent missing embedding field
+    system_prompt:
+      value: This agent has no embedding configured.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000

--- a/tests/e2e/script.sh
+++ b/tests/e2e/script.sh
@@ -148,6 +148,25 @@ else
 fi
 
 # ============================================================================
+# Test: Invalid Configs (should fail)
+# ============================================================================
+
+section "Invalid Config Validation"
+
+# Self-hosted without embedding should fail
+if $CLI apply -f "$FIXTURES/fleet-invalid.yml" --dry-run > $OUT 2>&1; then
+    fail "fleet-invalid.yml should have failed (missing embedding)"
+    cat $OUT
+else
+    if output_contains "Self-hosted Letta requires explicit embedding"; then
+        pass "Missing embedding rejected on self-hosted"
+    else
+        fail "Wrong error for missing embedding"
+        cat $OUT
+    fi
+fi
+
+# ============================================================================
 # Test: Dry Run (should show creates)
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Add validation to fail apply when self-hosting without embedding configured
- Previously it silently passed and caused huge context window usage
- Added fleet-invalid.yml test fixture for negative test cases
- Added e2e test that expects failure for missing embedding

Closes #89

## Test plan
- [x] Apply without embedding on self-hosted fails with helpful error
- [x] All 55 e2e tests pass (including new negative test)