### PR TITLE
fix: #94 auto-add file search tools with folders

### DIFF
--- a/src/lib/builtin-tools.ts
+++ b/src/lib/builtin-tools.ts
@@ -52,6 +52,12 @@ export const CORE_MEMORY_TOOLS = [
 ];
 
 /**
+ * File search tools auto-added when folders are attached
+ * Note: open_files excluded - it loads files into context which bloats the window
+ */
+export const FILE_SEARCH_TOOLS = ['grep_files', 'semantic_search_files'];
+
+/**
  * Check if a tool name is a known built-in tool
  */
 export function isBuiltinTool(toolName: string): boolean {

--- a/tests/e2e/fixtures/fleet-updated.yml
+++ b/tests/e2e/fixtures/fleet-updated.yml
@@ -381,3 +381,22 @@ agents:
     tools:
       - archival_memory_insert
       - archival_memory_search
+
+  # ============================================================================
+  # FILE SEARCH TOOLS AUTO-MANAGEMENT
+  # ============================================================================
+
+  # 21: Folders REMOVED - tests auto-removal of file search tools
+  # When folders are removed, grep_files and semantic_search_files should auto-remove
+  # The explicit archival tools should be PRESERVED
+  - name: e2e-21-folder-tools-auto
+    description: Tests file search tools auto-remove
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent testing file search tool auto-management - folders removed.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    tools:
+      - archival_memory_insert
+      - archival_memory_search

--- a/tests/e2e/fixtures/fleet.yml
+++ b/tests/e2e/fixtures/fleet.yml
@@ -370,3 +370,26 @@ agents:
     tools:
       - archival_memory_insert
       - archival_memory_search
+
+  # ============================================================================
+  # FILE SEARCH TOOLS AUTO-MANAGEMENT
+  # ============================================================================
+
+  # 21: Folder with explicit tools - tests auto-add of file search tools
+  # When folders are attached, grep_files and semantic_search_files should auto-add
+  # The explicit archival tools should remain unchanged
+  - name: e2e-21-folder-tools-auto
+    description: Tests file search tools auto-add
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent testing file search tool auto-management.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    folders:
+      - name: e2e-folder-auto-test
+        files:
+          - folder-files/doc1.txt
+    tools:
+      - archival_memory_insert
+      - archival_memory_search


### PR DESCRIPTION
## Summary
- Auto-add `grep_files` and `semantic_search_files` when folders are attached
- Auto-remove file search tools when folders are removed
- Preserve explicitly-defined tools during removal
- `open_files` intentionally excluded (bloats context window)

## Test plan
- [x] Manual test: agent with folders gets file search tools auto-added
- [x] Manual test: removing folders auto-removes file search tools
- [x] Manual test: explicit tools preserved when folders removed
- [ ] E2E test case added to fleet.yml/fleet-updated.yml

Closes #94