### PR TITLE
fix: #98 prevent bucket file duplicates on apply

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -174,7 +174,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
 
       try {
         // Generate hashes for change detection
-        const folderContentHashes = fileTracker.generateFolderFileHashes(agent.folders || []);
+        const folderContentHashes = await fileTracker.generateFolderFileHashes(agent.folders || []);
         const toolSourceHashes = fileTracker.generateToolSourceHashes(agent.tools || [], parser.toolConfigs);
         const memoryBlockFileHashes = await fileTracker.generateMemoryBlockFileHashes(agent.memory_blocks || []);
 

--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -181,20 +181,8 @@ export async function processFolders(
         } else {
           if (verbose) log(`Using existing folder: ${folderConfig.name}`);
           createdFolders.set(folderConfig.name, folder.id);
-
-          // Still upload from_bucket files for existing folders
-          for (const fileConfig of folderConfig.files) {
-            try {
-              if (isFromBucketConfig(fileConfig)) {
-                await uploadBucketFilesToFolder(fileConfig.from_bucket, folder.id, client, verbose);
-              }
-            } catch (error: any) {
-              const fileDesc = isFromBucketConfig(fileConfig)
-                ? `${fileConfig.from_bucket.bucket}/${fileConfig.from_bucket.path}`
-                : fileConfig;
-              console.error(`  Failed to upload ${fileDesc}:`, error.message);
-            }
-          }
+          // File uploads for existing folders are handled by the diff engine
+          // during agent update - this avoids creating duplicate files
         }
       }
     }

--- a/src/lib/dry-run.ts
+++ b/src/lib/dry-run.ts
@@ -106,7 +106,7 @@ async function computeAgentDiff(
   const { client, agentManager, diffEngine, fileTracker, parser, toolNameToId, folderNameToId, sharedBlockIds } = ctx;
 
   // Build agent config
-  const folderContentHashes = fileTracker.generateFolderFileHashes(agent.folders || []);
+  const folderContentHashes = await fileTracker.generateFolderFileHashes(agent.folders || []);
   const toolSourceHashes = fileTracker.generateToolSourceHashes(agent.tools || [], parser.toolConfigs);
   const memoryBlockFileHashes = await fileTracker.generateMemoryBlockFileHashes(agent.memory_blocks || []);
 

--- a/src/lib/letta-client.ts
+++ b/src/lib/letta-client.ts
@@ -104,7 +104,11 @@ export class LettaClientWrapper {
   }
 
   async listFolderFiles(folderId: string) {
-    return await this.client.folders.files.list(folderId);
+    const allFiles: any[] = [];
+    for await (const file of this.client.folders.files.list(folderId)) {
+      allFiles.push(file);
+    }
+    return allFiles;
   }
 
   async updateAgent(agentId: string, agentData: any) {

--- a/src/lib/storage-backend.ts
+++ b/src/lib/storage-backend.ts
@@ -96,7 +96,24 @@ export class StorageBackendManager {
 
     throw new Error(`Provider '${config.provider}' not yet supported. Supported: supabase. Coming soon: s3, gcs`);
   }
-  
+
+  /**
+   * List files in a bucket with optional prefix filter
+   */
+  async listBucketFiles(bucket: string, prefix: string = ''): Promise<string[]> {
+    if (!this.supabaseBackend) {
+      throw new Error('Supabase backend not configured');
+    }
+    return this.supabaseBackend.listFiles(bucket, prefix);
+  }
+
+  /**
+   * Download text content from bucket
+   */
+  async downloadFromBucket(config: BucketConfig): Promise<string> {
+    return this.readFromBucket(config);
+  }
+
   private validateBucketConfig(config: any): void {
     if (!config || typeof config !== 'object') {
       throw new Error(

--- a/tests/e2e/fixtures/fleet-updated.yml
+++ b/tests/e2e/fixtures/fleet-updated.yml
@@ -400,3 +400,24 @@ agents:
     tools:
       - archival_memory_insert
       - archival_memory_search
+
+  # ============================================================================
+  # BUCKET FILES - Duplicate Prevention (#98)
+  # ============================================================================
+
+  # 22: Same bucket glob files - re-apply should show NO changes (not re-upload)
+  - name: e2e-22-bucket-glob
+    description: Tests bucket glob file duplicate prevention
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with bucket glob files.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    folders:
+      - name: e2e-bucket-test
+        files:
+          - from_bucket:
+              provider: supabase
+              bucket: test-bucket
+              path: "*.txt"

--- a/tests/e2e/fixtures/fleet.yml
+++ b/tests/e2e/fixtures/fleet.yml
@@ -393,3 +393,26 @@ agents:
     tools:
       - archival_memory_insert
       - archival_memory_search
+
+  # ============================================================================
+  # BUCKET FILES - Duplicate Prevention (#98)
+  # ============================================================================
+
+  # 22: Bucket glob files - tests that re-apply doesn't create duplicates
+  # On first apply: files uploaded with clean names
+  # On second apply: should detect existing files and NOT re-upload
+  - name: e2e-22-bucket-glob
+    description: Tests bucket glob file duplicate prevention
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with bucket glob files.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    folders:
+      - name: e2e-bucket-test
+        files:
+          - from_bucket:
+              provider: supabase
+              bucket: test-bucket
+              path: "*.txt"


### PR DESCRIPTION
## Summary
- Fix bucket glob files being re-uploaded on every apply, causing Letta to create `_(N)` duplicates
- Root cause: `processFolders()` was uploading bucket files before diff analysis ran
- Now file changes for existing folders are handled by the diff engine

Closes #98