### PR TITLE
feat: #106 improve memory block limit error message

### DIFF
--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -35,7 +35,19 @@ const PROVIDER_ENV_VARS: Record<string, string> = {
 /**
  * Formats Letta API errors with helpful context
  */
-export function formatLettaError(message: string): string {
+export function formatLettaError(message: string, context?: { blockName?: string }): string {
+  // Check for memory block character limit exceeded
+  const limitMatch = message.match(/Exceeds (\d+) character limit \(requested (\d+)\)/i);
+  if (limitMatch) {
+    const limit = parseInt(limitMatch[1], 10);
+    const actual = parseInt(limitMatch[2], 10);
+    const blockInfo = context?.blockName ? `Memory block '${context.blockName}'` : 'Memory block';
+    return `${blockInfo} exceeds character limit\n` +
+      `  Limit: ${limit.toLocaleString()} characters\n` +
+      `  Actual: ${actual.toLocaleString()} characters\n` +
+      `  Hint: Increase the 'limit' field in your YAML or reduce content size`;
+  }
+
   // Check for provider not supported error
   const providerMatch = message.match(/Provider (\w+) is not supported/i);
   if (providerMatch) {

--- a/tests/unit/lib/error-handler.test.ts
+++ b/tests/unit/lib/error-handler.test.ts
@@ -1,4 +1,4 @@
-import { withErrorHandling, createNotFoundError } from '../../../src/lib/error-handler';
+import { withErrorHandling, createNotFoundError, formatLettaError } from '../../../src/lib/error-handler';
 
 // Mock console.error and process.exit for testing
 const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -47,9 +47,43 @@ describe('error-handler', () => {
   describe('createNotFoundError', () => {
     it('should create error with correct message', () => {
       const error = createNotFoundError('Agent', 'test-agent');
-      
+
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toBe('Agent "test-agent" not found');
+    });
+  });
+
+  describe('formatLettaError', () => {
+    it('should format memory block character limit error', () => {
+      const rawError = `422 {"detail":"[{'type': 'value_error', 'msg': 'Value error, Edit failed: Exceeds 4000 character limit (requested 6538)'}]"}`;
+      const result = formatLettaError(rawError);
+
+      expect(result).toContain('Memory block exceeds character limit');
+      expect(result).toContain('Limit: 4,000 characters');
+      expect(result).toContain('Actual: 6,538 characters');
+      expect(result).toContain('Hint:');
+    });
+
+    it('should include block name when provided in context', () => {
+      const rawError = 'Exceeds 4000 character limit (requested 6538)';
+      const result = formatLettaError(rawError, { blockName: 'creative_guidelines' });
+
+      expect(result).toContain("Memory block 'creative_guidelines' exceeds character limit");
+    });
+
+    it('should format provider not supported error', () => {
+      const rawError = 'Provider anthropic is not supported';
+      const result = formatLettaError(rawError);
+
+      expect(result).toContain("Provider 'anthropic' is not configured");
+      expect(result).toContain('ANTHROPIC_API_KEY');
+    });
+
+    it('should return original message for unknown errors', () => {
+      const rawError = 'Some unknown error';
+      const result = formatLettaError(rawError);
+
+      expect(result).toBe('Some unknown error');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Improves error message when memory block exceeds character limit
- Parses raw 422 JSON error into clean, human-readable format
- Shows limit, actual size, and helpful hint

**Before:**
```
Apply failed: 422 {"trace_id":"","detail":"[{'type': 'value_error', 'msg': 'Value error, Edit failed: Exceeds 4000 character limit (requested 6538)'...
```

**After:**
```
Memory block exceeds character limit
  Limit: 4,000 characters
  Actual: 6,538 characters
  Hint: Increase the 'limit' field in your YAML or reduce content size
```

## Test plan
- [x] Unit tests added for formatLettaError
- [x] All existing tests pass

Closes #106