### PR TITLE
feat: #117 dry-run diff preview with actual values

### DIFF
--- a/src/lib/diff-analyzers.ts
+++ b/src/lib/diff-analyzers.ts
@@ -96,7 +96,7 @@ export async function analyzeBlockChanges(
   const toAdd: Array<{ name: string; id: string }> = [];
   const toRemove: Array<{ name: string; id: string }> = [];
   const toUpdate: Array<{ name: string; currentId: string; newId: string }> = [];
-  const toUpdateValue: Array<{ name: string; id: string; newValue: string }> = [];
+  const toUpdateValue: Array<{ name: string; id: string; oldValue: string; newValue: string }> = [];
   const unchanged: Array<{ name: string; id: string }> = [];
 
   // Find blocks to add
@@ -142,7 +142,7 @@ export async function analyzeBlockChanges(
         const currentValue = block.value || '';
 
         if (desiredValue !== currentValue) {
-          toUpdateValue.push({ name: block.label, id: block.id, newValue: desiredValue });
+          toUpdateValue.push({ name: block.label, id: block.id, oldValue: currentValue, newValue: desiredValue });
           continue;
         }
       }

--- a/src/lib/diff-applier.ts
+++ b/src/lib/diff-applier.ts
@@ -40,7 +40,7 @@ export class DiffApplier {
       const fields = operations.updateFields;
 
       if (fields.system !== undefined) {
-        apiFields.system = fields.system;
+        apiFields.system = fields.system.to;
       }
       if (fields.description !== undefined) {
         apiFields.description = fields.description.to;

--- a/src/lib/diff-engine.ts
+++ b/src/lib/diff-engine.ts
@@ -82,7 +82,7 @@ export class DiffEngine {
     
     if (normalizedCurrent !== normalizedDesired) {
       if (verbose) log(`    System prompt differs - current length: ${normalizedCurrent.length}, desired length: ${normalizedDesired.length}`);
-      fieldUpdates.system = desiredConfig.systemPrompt;
+      fieldUpdates.system = { from: normalizedCurrent, to: normalizedDesired };
       operations.operationCount++;
     }
 

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -9,7 +9,7 @@ export interface BlockDiff {
   toAdd: Array<{ name: string; id: string }>;
   toRemove: Array<{ name: string; id: string }>;
   toUpdate: Array<{ name: string; currentId: string; newId: string }>;
-  toUpdateValue: Array<{ name: string; id: string; newValue: string }>; // For mutable: false blocks
+  toUpdateValue: Array<{ name: string; id: string; oldValue: string; newValue: string }>; // For mutable: false blocks
   unchanged: Array<{ name: string; id: string }>;
 }
 
@@ -34,7 +34,7 @@ export interface FieldChange<T> {
 export interface AgentUpdateOperations {
   // Basic agent field updates (preserve conversation)
   updateFields?: {
-    system?: string;
+    system?: FieldChange<string>;
     description?: FieldChange<string>;
     model?: FieldChange<string>;
     embedding?: FieldChange<string>;


### PR DESCRIPTION
## Summary
- Show actual before/after values in dry-run output instead of just "modified"
- System prompt, description, and block values now display truncated diffs
- Model, embedding, context_window already showed from->to, kept as-is

Example output:
```
[~] e2e-01-minimal (UPDATE - 4 changes)
    description:
      - Minimal required fields only
      + Minimal config - UPDATED
```

Closes #117