### PR TITLE
feat: #119 explicit error handling for missing blocks/tools

### DIFF
--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -13,7 +13,7 @@ import { StorageBackendManager, SupabaseStorageBackend, hasSupabaseConfig } from
 import { FolderFileConfig } from '../types/fleet-config';
 import { isBuiltinTool } from './builtin-tools';
 import { AgentResolver } from './agent-resolver';
-import { log, warn } from './logger';
+import { log } from './logger';
 
 export async function processSharedBlocks(
   config: any,
@@ -159,8 +159,7 @@ export async function processFolders(
                 const resolvedPath = path.resolve(parser.basePath, filePath);
 
                 if (!fs.existsSync(resolvedPath)) {
-                  warn(`File not found, skipping: ${filePath}`);
-                  continue;
+                  throw new Error(`File not found: ${filePath}`);
                 }
 
                 if (verbose) log(`  Uploading ${filePath}...`);
@@ -288,7 +287,7 @@ export async function createNewAgent(
         blockIds.push(sharedBlockId);
         if (verbose) log(`  Using shared block: ${sharedBlockName}`);
       } else {
-        warn(`  Shared block not found: ${sharedBlockName}`);
+        throw new Error(`Shared block '${sharedBlockName}' not found. Define it in shared_blocks.`);
       }
     }
   }
@@ -313,7 +312,7 @@ export async function createNewAgent(
         if (toolId) {
           toolIds.push(toolId);
         } else {
-          warn(`  Tool not found: ${toolName}`);
+          throw new Error(`Tool '${toolName}' not found. Check tool name or ensure tools/${toolName}.py exists.`);
         }
       }
     }

--- a/tests/e2e/fixtures/fleet-partial-failure.yml
+++ b/tests/e2e/fixtures/fleet-partial-failure.yml
@@ -23,6 +23,30 @@ agents:
       model: invalid-provider/nonexistent-model
       context_window: 32000
 
+  # Missing shared block - will fail with explicit error
+  - name: e2e-partial-bad-block
+    description: Agent with missing shared block
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: This agent references a nonexistent shared block.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    shared_blocks:
+      - nonexistent-shared-block
+
+  # Missing tool - will fail with explicit error
+  - name: e2e-partial-bad-tool
+    description: Agent with missing tool
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: This agent references a nonexistent tool.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    tools:
+      - nonexistent_custom_tool
+
   # Valid agent - should succeed (tests continuation after failure)
   - name: e2e-partial-valid-2
     description: Second valid agent after the failure

--- a/tests/e2e/script.sh
+++ b/tests/e2e/script.sh
@@ -192,11 +192,27 @@ else
         cat $OUT
     fi
 
-    # Verify summary output
-    if output_contains "Succeeded:" && output_contains "Failed:"; then
-        pass "Summary shows succeeded/failed counts"
+    # Verify summary output shows 2 succeeded, 3 failed
+    if output_contains "Succeeded: 2" && output_contains "Failed: 3"; then
+        pass "Summary shows correct counts (2 succeeded, 3 failed)"
     else
-        fail "Missing summary output"
+        fail "Incorrect summary counts"
+        cat $OUT
+    fi
+
+    # Verify explicit error for missing shared block
+    if output_contains "Shared block" && output_contains "not found"; then
+        pass "Missing shared block error surfaced"
+    else
+        fail "Missing shared block error not shown"
+        cat $OUT
+    fi
+
+    # Verify explicit error for missing tool
+    if output_contains "Tool" && output_contains "not found"; then
+        pass "Missing tool error surfaced"
+    else
+        fail "Missing tool error not shown"
         cat $OUT
     fi
 fi

--- a/tests/e2e/tests/31-partial-failure.sh
+++ b/tests/e2e/tests/31-partial-failure.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Test: Partial failure handling (kubectl-style continue on error)
+# Tests: invalid model, missing shared block, missing tool
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,11 +25,27 @@ else
         cat $OUT
     fi
 
-    # Verify summary output
-    if output_contains "Succeeded:" && output_contains "Failed:"; then
-        pass "Summary shows succeeded/failed counts"
+    # Verify summary output shows 2 succeeded, 3 failed
+    if output_contains "Succeeded: 2" && output_contains "Failed: 3"; then
+        pass "Summary shows correct counts (2 succeeded, 3 failed)"
     else
-        fail "Missing summary output"
+        fail "Incorrect summary counts"
+        cat $OUT
+    fi
+
+    # Verify explicit error for missing shared block
+    if output_contains "Shared block" && output_contains "not found"; then
+        pass "Missing shared block error surfaced"
+    else
+        fail "Missing shared block error not shown"
+        cat $OUT
+    fi
+
+    # Verify explicit error for missing tool
+    if output_contains "Tool" && output_contains "not found"; then
+        pass "Missing tool error surfaced"
+    else
+        fail "Missing tool error not shown"
         cat $OUT
     fi
 fi


### PR DESCRIPTION
## Summary
- Throw explicit errors for missing shared blocks and tools instead of silent warnings
- Errors are caught by per-agent try/catch, so partial failure handling still works
- Added test cases for missing shared block and missing tool errors

Before: Agent created with missing resources, marked as "succeeded"
After: Agent fails with clear error message, other agents continue

Closes #119