### PR TITLE
feat: #121 bulk delete and use custom logger across app

### DIFF
--- a/src/commands/apply-template.ts
+++ b/src/commands/apply-template.ts
@@ -8,6 +8,7 @@ import { createSpinner, getSpinnerEnabled } from '../lib/ux/spinner';
 import { minimatch } from 'minimatch';
 import { readLastApplied, applyThreeWayMerge, hashCurrentTools, hashCurrentBlocks, METADATA_KEY } from '../lib/last-applied-config';
 import { normalizeResponse } from '../lib/response-normalizer';
+import { log, output } from '../lib/logger';
 
 /**
  * Template mode: apply a template config to all existing agents matching a glob pattern.
@@ -44,10 +45,10 @@ export async function applyTemplateMode(
   }
 
   findSpinner.succeed(`Found ${matchingAgents.length} agents matching "${pattern}"`);
-  matchingAgents.forEach((a: any) => console.log(`  - ${a.name}`));
+  matchingAgents.forEach((a: any) => output(`  - ${a.name}`));
 
   if (options.dryRun) {
-    console.log('\nDry-run mode: no changes will be made');
+    output('\nDry-run mode: no changes will be made');
     return;
   }
 
@@ -80,7 +81,7 @@ export async function applyTemplateMode(
     for (const sharedBlock of config.shared_blocks) {
       const blockId = await blockManager.getOrCreateSharedBlock(sharedBlock);
       sharedBlockIds.set(sharedBlock.name, blockId);
-      if (verbose) console.log(`  ${sharedBlock.name} -> ${blockId}`);
+      if (verbose) output(`  ${sharedBlock.name} -> ${blockId}`);
     }
     blockSpinner.succeed(`Processed ${config.shared_blocks.length} shared blocks`);
   }
@@ -182,10 +183,10 @@ export async function applyTemplateMode(
 
       updateSpinner.succeed(`${existingAgent.name}: updated successfully`);
 
-    } catch (error: any) {
-      agentSpinner.fail(`${existingAgent.name}: ${error.message}`);
+    } catch (err: any) {
+      agentSpinner.fail(`${existingAgent.name}: ${err.message}`);
     }
   }
 
-  console.log('\nTemplate apply completed');
+  output('\nTemplate apply completed');
 }

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,6 +1,7 @@
 /**
  * Shell completion scripts for lettactl
  */
+import { output, error } from '../lib/logger';
 
 const COMMANDS = [
   'apply',
@@ -217,27 +218,27 @@ complete -c lettactl -n '__fish_seen_subcommand_from get describe messages runs 
 export function completionCommand(shell: string) {
   switch (shell) {
     case 'bash':
-      console.log(bashCompletion.trim());
+      output(bashCompletion.trim());
       break;
     case 'zsh':
-      console.log(zshCompletion.trim());
+      output(zshCompletion.trim());
       break;
     case 'fish':
-      console.log(fishCompletion.trim());
+      output(fishCompletion.trim());
       break;
     default:
-      console.error(`Unknown shell: ${shell}`);
-      console.error('Supported shells: bash, zsh, fish');
-      console.error('');
-      console.error('Usage:');
-      console.error('  # Bash');
-      console.error('  lettactl completion bash >> ~/.bashrc');
-      console.error('');
-      console.error('  # Zsh');
-      console.error('  lettactl completion zsh >> ~/.zshrc');
-      console.error('');
-      console.error('  # Fish');
-      console.error('  lettactl completion fish > ~/.config/fish/completions/lettactl.fish');
+      error(`Unknown shell: ${shell}`);
+      error('Supported shells: bash, zsh, fish');
+      error('');
+      error('Usage:');
+      error('  # Bash');
+      error('  lettactl completion bash >> ~/.bashrc');
+      error('');
+      error('  # Zsh');
+      error('  lettactl completion zsh >> ~/.zshrc');
+      error('');
+      error('  # Fish');
+      error('  lettactl completion fish > ~/.config/fish/completions/lettactl.fish');
       process.exit(1);
   }
 }

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,6 +1,7 @@
 import { AgentResolver } from '../lib/agent-resolver';
 import { LettaClientWrapper } from '../lib/letta-client';
 import { OutputFormatter } from '../lib/ux/output-formatter';
+import { output, error } from '../lib/logger';
 
 interface ContextWindow {
   context_window_size_max: number;
@@ -24,7 +25,7 @@ export async function contextCommand(agentName: string, options: { output?: stri
   // Resolve agent name to ID
   const { agent } = await resolver.findAgentByName(agentName);
   if (!agent) {
-    console.error(`Agent "${agentName}" not found`);
+    error(`Agent "${agentName}" not found`);
     process.exit(1);
   }
 
@@ -33,7 +34,7 @@ export async function contextCommand(agentName: string, options: { output?: stri
   const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/context`);
 
   if (!response.ok) {
-    console.error(`Failed to fetch context: ${response.status}`);
+    error(`Failed to fetch context: ${response.status}`);
     process.exit(1);
   }
 
@@ -43,43 +44,43 @@ export async function contextCommand(agentName: string, options: { output?: stri
     return;
   }
 
-  console.log(`Context Window: ${agentName}`);
-  console.log('='.repeat(40));
+  output(`Context Window: ${agentName}`);
+  output('='.repeat(40));
 
   // Usage bar
   const pct = Math.round((ctx.context_window_size_current / ctx.context_window_size_max) * 100);
   const barWidth = 30;
   const filled = Math.round((pct / 100) * barWidth);
   const bar = '[' + '#'.repeat(filled) + '-'.repeat(barWidth - filled) + ']';
-  console.log(`\nUsage: ${bar} ${pct}%`);
-  console.log(`       ${ctx.context_window_size_current.toLocaleString()} / ${ctx.context_window_size_max.toLocaleString()} tokens\n`);
+  output(`\nUsage: ${bar} ${pct}%`);
+  output(`       ${ctx.context_window_size_current.toLocaleString()} / ${ctx.context_window_size_max.toLocaleString()} tokens\n`);
 
   // Token breakdown
-  console.log('Token Breakdown:');
-  console.log(`  System prompt:     ${ctx.num_tokens_system.toLocaleString().padStart(8)}`);
-  console.log(`  Core memory:       ${ctx.num_tokens_core_memory.toLocaleString().padStart(8)}`);
-  console.log(`  Tool definitions:  ${ctx.num_tokens_functions_definitions.toLocaleString().padStart(8)}`);
-  console.log(`  Messages:          ${ctx.num_tokens_messages.toLocaleString().padStart(8)}`);
-  console.log(`  Memory summary:    ${ctx.num_tokens_external_memory_summary.toLocaleString().padStart(8)}`);
+  output('Token Breakdown:');
+  output(`  System prompt:     ${ctx.num_tokens_system.toLocaleString().padStart(8)}`);
+  output(`  Core memory:       ${ctx.num_tokens_core_memory.toLocaleString().padStart(8)}`);
+  output(`  Tool definitions:  ${ctx.num_tokens_functions_definitions.toLocaleString().padStart(8)}`);
+  output(`  Messages:          ${ctx.num_tokens_messages.toLocaleString().padStart(8)}`);
+  output(`  Memory summary:    ${ctx.num_tokens_external_memory_summary.toLocaleString().padStart(8)}`);
   if (ctx.num_tokens_summary_memory > 0) {
-    console.log(`  Summary memory:    ${ctx.num_tokens_summary_memory.toLocaleString().padStart(8)}`);
+    output(`  Summary memory:    ${ctx.num_tokens_summary_memory.toLocaleString().padStart(8)}`);
   }
 
   // Memory counts
-  console.log('\nMemory:');
-  console.log(`  Messages in context:  ${ctx.num_messages}`);
-  console.log(`  Recall memory:        ${ctx.num_recall_memory}`);
-  console.log(`  Archival memory:      ${ctx.num_archival_memory}`);
+  output('\nMemory:');
+  output(`  Messages in context:  ${ctx.num_messages}`);
+  output(`  Recall memory:        ${ctx.num_recall_memory}`);
+  output(`  Archival memory:      ${ctx.num_archival_memory}`);
 
   if (verbose) {
     // Show warnings if context is high
-    console.log('\nStatus:');
+    output('\nStatus:');
     if (pct >= 90) {
-      console.log('  [WARN] Context nearly full - consider compacting messages');
+      output('  [WARN] Context nearly full - consider compacting messages');
     } else if (pct >= 75) {
-      console.log('  [INFO] Context usage high');
+      output('  [INFO] Context usage high');
     } else {
-      console.log('  [OK] Context usage healthy');
+      output('  [OK] Context usage healthy');
     }
   }
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,5 +1,6 @@
 import { LettaClientWrapper } from '../lib/letta-client';
 import { createSpinner, getSpinnerEnabled } from '../lib/ux/spinner';
+import { log, output, error } from '../lib/logger';
 
 export default async function createCommand(
   resource: string,
@@ -28,7 +29,7 @@ export default async function createCommand(
     const client = new LettaClientWrapper();
 
     if (verbose) {
-      console.log(`Creating agent: ${name}`);
+      log(`Creating agent: ${name}`);
     }
 
     // Build create payload
@@ -64,7 +65,7 @@ export default async function createCommand(
     if (!createPayload.system) createPayload.system = "You are a helpful AI assistant.";
 
     if (verbose) {
-      console.log('Create payload:', JSON.stringify(createPayload, null, 2));
+      log('Create payload:', JSON.stringify(createPayload, null, 2));
     }
 
     // Create the agent
@@ -74,21 +75,21 @@ export default async function createCommand(
       const createdAgent = await client.createAgent(createPayload);
       
       spinner.succeed(`Agent ${name} created successfully`);
-      console.log(`Agent ID: ${createdAgent.id}`);
-      
+      output(`Agent ID: ${createdAgent.id}`);
+
       if (verbose) {
-        console.log(`Model: ${createdAgent.model || createPayload.model}`);
-        console.log(`Embedding: ${createdAgent.embedding || createPayload.embedding}`);
-        if (createPayload.description) console.log(`Description: ${createPayload.description}`);
-        if (createPayload.tags) console.log(`Tags: ${createPayload.tags.join(', ')}`);
+        log(`Model: ${createdAgent.model || createPayload.model}`);
+        log(`Embedding: ${createdAgent.embedding || createPayload.embedding}`);
+        if (createPayload.description) log(`Description: ${createPayload.description}`);
+        if (createPayload.tags) log(`Tags: ${createPayload.tags.join(', ')}`);
       }
-    } catch (error: any) {
+    } catch (err: any) {
       spinner.fail(`Failed to create agent ${name}`);
-      throw error;
+      throw err;
     }
 
-  } catch (error: any) {
-    console.error(`Failed to create agent ${name}:`, error.message);
-    throw error;
+  } catch (err: any) {
+    error(`Failed to create agent ${name}:`, err.message);
+    throw err;
   }
 }

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -5,6 +5,7 @@ import { validateResourceType, validateRequired } from '../lib/validators';
 import { withErrorHandling } from '../lib/error-handler';
 import { normalizeResponse } from '../lib/response-normalizer';
 import { createSpinner, getSpinnerEnabled } from '../lib/ux/spinner';
+import { output, error, warn } from '../lib/logger';
 
 async function deleteCommandImpl(resource: string, name: string, options?: { force?: boolean }, command?: any) {
   validateResourceType(resource, ['agent', 'agents', 'mcp-servers']);
@@ -22,13 +23,13 @@ async function deleteCommandImpl(resource: string, name: string, options?: { for
   const { agent, allAgents } = await resolver.findAgentByName(name);
     
   if (!options?.force) {
-    console.log(`This will permanently delete agent: ${name} (${agent.id})`);
-    console.log('This will also delete:');
-    console.log('  - Agent-specific memory blocks');
-    console.log('  - Agent-specific folders (if not shared)');
-    console.log('  - Associated conversation history');
-    console.log('Shared blocks and folders will be preserved.');
-    console.log('Use --force to confirm deletion');
+    output(`This will permanently delete agent: ${name} (${agent.id})`);
+    output('This will also delete:');
+    output('  - Agent-specific memory blocks');
+    output('  - Agent-specific folders (if not shared)');
+    output('  - Associated conversation history');
+    output('Shared blocks and folders will be preserved.');
+    output('Use --force to confirm deletion');
     process.exit(1);
   }
     
@@ -40,72 +41,253 @@ async function deleteCommandImpl(resource: string, name: string, options?: { for
     await deleteAgentWithCleanup(client, resolver, agent, allAgents, true);
     
     spinner.succeed(`Agent ${name} and associated resources deleted successfully`);
-  } catch (error) {
+  } catch (err) {
     spinner.fail(`Failed to delete agent ${name}`);
-    throw error;
+    throw err;
   }
 }
 
-async function deleteAllCommandImpl(resource: string, options?: { 
-  force?: boolean; 
+async function deleteAllCommandImpl(resource: string, options?: {
+  force?: boolean;
   pattern?: string;
-}) {
-  validateResourceType(resource, ['agent', 'agents']);
+}, command?: any) {
+  validateResourceType(resource, ['agent', 'agents', 'folders', 'folder', 'blocks', 'block', 'tools', 'tool', 'mcp-servers']);
 
   const client = new LettaClientWrapper();
+  const spinnerEnabled = getSpinnerEnabled(command);
+
+  // Route to appropriate handler
+  if (resource === 'folders' || resource === 'folder') {
+    return await deleteAllFolders(client, options, spinnerEnabled);
+  }
+  if (resource === 'blocks' || resource === 'block') {
+    return await deleteAllBlocks(client, options, spinnerEnabled);
+  }
+  if (resource === 'tools' || resource === 'tool') {
+    return await deleteAllTools(client, options, spinnerEnabled);
+  }
+  if (resource === 'mcp-servers') {
+    return await deleteAllMcpServers(client, options, spinnerEnabled);
+  }
+
+  // Default: agents
   const resolver = new AgentResolver(client);
-  
+
   // Get all agents
   const allAgents = await resolver.getAllAgents();
-  
+
   // Filter agents by pattern if provided
   let agentsToDelete = allAgents;
   if (options?.pattern) {
     const pattern = new RegExp(options.pattern, 'i');
-    agentsToDelete = allAgents.filter(agent => 
+    agentsToDelete = allAgents.filter(agent =>
       pattern.test(agent.name) || pattern.test(agent.id)
     );
   }
-  
+
   if (agentsToDelete.length === 0) {
-    console.log(options?.pattern 
+    output(options?.pattern
       ? `No agents found matching pattern: ${options.pattern}`
       : 'No agents found to delete'
     );
     return;
   }
-  
-  console.log(`Found ${agentsToDelete.length} agent(s) to delete:`);
+
+  output(`Found ${agentsToDelete.length} agent(s) to delete:`);
   agentsToDelete.forEach((agent, i) => {
-    console.log(`  ${i + 1}. ${agent.name} (${agent.id})`);
+    output(`  ${i + 1}. ${agent.name} (${agent.id})`);
   });
-  
+
   if (!options?.force) {
-    console.log('');
-    console.log('This will permanently delete all listed agents and their associated resources:');
-    console.log('  - Agent-specific memory blocks');
-    console.log('  - Agent-specific folders (if not shared)');
-    console.log('  - Associated conversation history');
-    console.log('Shared blocks and folders will be preserved.');
-    console.log('Use --force to confirm deletion.');
+    output('');
+    output('This will permanently delete all listed agents and their associated resources:');
+    output('  - Agent-specific memory blocks');
+    output('  - Agent-specific folders (if not shared)');
+    output('  - Associated conversation history');
+    output('Shared blocks and folders will be preserved.');
+    output('Use --force to confirm deletion.');
     process.exit(1);
   }
-  
-  console.log('');
-  console.log('Starting bulk deletion...');
-  
+
+  output('');
+  output('Starting bulk deletion...');
+
   // Delete each agent
   for (const agent of agentsToDelete) {
     try {
-      console.log(`\nDeleting agent: ${agent.name}...`);
+      output(`\nDeleting agent: ${agent.name}...`);
       await deleteAgentWithCleanup(client, resolver, agent, allAgents, false);
-      console.log(`Agent ${agent.name} deleted successfully`);
-    } catch (error: any) {
-      console.error(`Failed to delete agent ${agent.name}: ${error.message}`);
+      output(`Agent ${agent.name} deleted successfully`);
+    } catch (err: any) {
+      error(`Failed to delete agent ${agent.name}: ${err.message}`);
     }
   }
-  
-  console.log(`\nBulk deletion completed. Deleted ${agentsToDelete.length} agent(s).`);
+
+  output(`\nBulk deletion completed. Deleted ${agentsToDelete.length} agent(s).`);
+}
+
+async function deleteAllFolders(client: LettaClientWrapper, options?: { force?: boolean; pattern?: string }, spinnerEnabled: boolean = true) {
+  const listSpinner = createSpinner('Loading folders...', spinnerEnabled).start();
+  const folders = await client.listFolders();
+  const folderList = normalizeResponse(folders);
+  listSpinner.stop();
+
+  let foldersToDelete = folderList;
+  if (options?.pattern) {
+    const pattern = new RegExp(options.pattern, 'i');
+    foldersToDelete = folderList.filter((f: any) => pattern.test(f.name) || pattern.test(f.id));
+  }
+
+  if (foldersToDelete.length === 0) {
+    output(options?.pattern ? `No folders found matching pattern: ${options.pattern}` : 'No folders found to delete');
+    return;
+  }
+
+  output(`Found ${foldersToDelete.length} folder(s) to delete:`);
+  foldersToDelete.forEach((f: any, i: number) => output(`  ${i + 1}. ${f.name} (${f.id})`));
+
+  if (!options?.force) {
+    output('\nThis will permanently delete all listed folders and their files.');
+    output('Use --force to confirm deletion.');
+    process.exit(1);
+  }
+
+  const spinner = createSpinner(`Deleting ${foldersToDelete.length} folders...`, spinnerEnabled).start();
+  let deleted = 0;
+  for (const folder of foldersToDelete) {
+    try {
+      await client.deleteFolder(folder.id);
+      deleted++;
+    } catch (err: any) {
+      error(`Failed to delete folder ${folder.name}: ${err.message}`);
+    }
+  }
+  spinner.succeed(`Deleted ${deleted}/${foldersToDelete.length} folder(s)`);
+}
+
+async function deleteAllBlocks(client: LettaClientWrapper, options?: { force?: boolean; pattern?: string }, spinnerEnabled: boolean = true) {
+  const listSpinner = createSpinner('Loading blocks...', spinnerEnabled).start();
+  const blocks = await client.listBlocks();
+  const blockList = normalizeResponse(blocks);
+  listSpinner.stop();
+
+  let blocksToDelete = blockList;
+  if (options?.pattern) {
+    const pattern = new RegExp(options.pattern, 'i');
+    blocksToDelete = blockList.filter((b: any) => pattern.test(b.label || b.name || '') || pattern.test(b.id));
+  }
+
+  if (blocksToDelete.length === 0) {
+    output(options?.pattern ? `No blocks found matching pattern: ${options.pattern}` : 'No blocks found to delete');
+    return;
+  }
+
+  output(`Found ${blocksToDelete.length} block(s) to delete:`);
+  blocksToDelete.forEach((b: any, i: number) => output(`  ${i + 1}. ${b.label || b.name || b.id} (${b.id})`));
+
+  if (!options?.force) {
+    output('\nThis will permanently delete all listed memory blocks.');
+    output('WARNING: Blocks attached to agents will cause errors.');
+    output('Use --force to confirm deletion.');
+    process.exit(1);
+  }
+
+  const spinner = createSpinner(`Deleting ${blocksToDelete.length} blocks...`, spinnerEnabled).start();
+  let deleted = 0;
+  for (const block of blocksToDelete) {
+    try {
+      await client.deleteBlock(block.id);
+      deleted++;
+    } catch (err: any) {
+      error(`Failed to delete block ${block.label || block.id}: ${err.message}`);
+    }
+  }
+  spinner.succeed(`Deleted ${deleted}/${blocksToDelete.length} block(s)`);
+}
+
+async function deleteAllTools(client: LettaClientWrapper, options?: { force?: boolean; pattern?: string }, spinnerEnabled: boolean = true) {
+  const listSpinner = createSpinner('Loading tools...', spinnerEnabled).start();
+  const tools = await client.listTools();
+  const toolList = normalizeResponse(tools);
+  listSpinner.stop();
+
+  let toolsToDelete = toolList;
+  if (options?.pattern) {
+    const pattern = new RegExp(options.pattern, 'i');
+    toolsToDelete = toolList.filter((t: any) => pattern.test(t.name) || pattern.test(t.id));
+  }
+
+  if (toolsToDelete.length === 0) {
+    output(options?.pattern ? `No tools found matching pattern: ${options.pattern}` : 'No tools found to delete');
+    return;
+  }
+
+  output(`Found ${toolsToDelete.length} tool(s) to delete:`);
+  toolsToDelete.forEach((t: any, i: number) => output(`  ${i + 1}. ${t.name} (${t.id})`));
+
+  if (!options?.force) {
+    output('\nThis will permanently delete all listed tools.');
+    output('WARNING: Tools attached to agents will cause errors.');
+    output('Use --force to confirm deletion.');
+    process.exit(1);
+  }
+
+  const spinner = createSpinner(`Deleting ${toolsToDelete.length} tools...`, spinnerEnabled).start();
+  let deleted = 0;
+  for (const tool of toolsToDelete) {
+    try {
+      await client.deleteTool(tool.id);
+      deleted++;
+    } catch (err: any) {
+      error(`Failed to delete tool ${tool.name}: ${err.message}`);
+    }
+  }
+  spinner.succeed(`Deleted ${deleted}/${toolsToDelete.length} tool(s)`);
+}
+
+async function deleteAllMcpServers(client: LettaClientWrapper, options?: { force?: boolean; pattern?: string }, spinnerEnabled: boolean = true) {
+  const listSpinner = createSpinner('Loading MCP servers...', spinnerEnabled).start();
+  const servers = await client.listMcpServers();
+  const serverList = Array.isArray(servers) ? servers : [];
+  listSpinner.stop();
+
+  let serversToDelete = serverList;
+  if (options?.pattern) {
+    const pattern = new RegExp(options.pattern, 'i');
+    serversToDelete = serverList.filter((s: any) =>
+      pattern.test(s.server_name || s.name || '') || pattern.test(s.id)
+    );
+  }
+
+  if (serversToDelete.length === 0) {
+    output(options?.pattern ? `No MCP servers found matching pattern: ${options.pattern}` : 'No MCP servers found to delete');
+    return;
+  }
+
+  output(`Found ${serversToDelete.length} MCP server(s) to delete:`);
+  serversToDelete.forEach((s: any, i: number) => {
+    const name = (s as any).server_name || (s as any).name || s.id;
+    output(`  ${i + 1}. ${name} (${s.id})`);
+  });
+
+  if (!options?.force) {
+    output('\nThis will permanently delete all listed MCP servers.');
+    output('Use --force to confirm deletion.');
+    process.exit(1);
+  }
+
+  const spinner = createSpinner(`Deleting ${serversToDelete.length} MCP servers...`, spinnerEnabled).start();
+  let deleted = 0;
+  for (const server of serversToDelete) {
+    const serverName = (server as any).server_name || (server as any).name || server.id;
+    try {
+      await client.deleteMcpServer(server.id!);
+      deleted++;
+    } catch (err: any) {
+      error(`Failed to delete MCP server ${serverName}: ${err.message}`);
+    }
+  }
+  spinner.succeed(`Deleted ${deleted}/${serversToDelete.length} MCP server(s)`);
 }
 
 async function deleteAgentWithCleanup(
@@ -123,12 +305,12 @@ async function deleteAgentWithCleanup(
   // Delete agent-attached memory blocks first (custom blocks attached to this specific agent)
   const agentAttachedBlocks = (agentDetails as any).blocks || [];
   if (agentAttachedBlocks.length > 0) {
-    if (verbose) console.log(`Checking attached memory blocks...`);
+    if (verbose) output(`Checking attached memory blocks...`);
     for (const block of agentAttachedBlocks) {
       // Check if this is a shared block
       const isShared = classifier.isSharedBlock(block);
       if (isShared) {
-        if (verbose) console.log(`  Keeping shared block: ${block.label || block.id}`);
+        if (verbose) output(`  Keeping shared block: ${block.label || block.id}`);
         continue;
       }
       
@@ -136,15 +318,15 @@ async function deleteAgentWithCleanup(
       const blockInUse = await classifier.isBlockUsedByOtherAgents(block.id, agent.id, allAgents);
       
       if (!blockInUse) {
-        if (verbose) console.log(`  Deleting agent-specific block: ${block.label || block.id}`);
+        if (verbose) output(`  Deleting agent-specific block: ${block.label || block.id}`);
         try {
           await client.deleteBlock(block.id);
-          if (verbose) console.log(`  Block deleted`);
-        } catch (error: any) {
-          console.warn(`  Could not delete block: ${error.message}`);
+          if (verbose) output(`  Block deleted`);
+        } catch (err: any) {
+          warn(`  Could not delete block: ${err.message}`);
         }
       } else {
-        if (verbose) console.log(`  Keeping block used by other agents: ${block.label || block.id}`);
+        if (verbose) output(`  Keeping block used by other agents: ${block.label || block.id}`);
       }
     }
   }
@@ -152,24 +334,24 @@ async function deleteAgentWithCleanup(
   // Delete attached folders if they're not shared
   const folders = (agentDetails as any).folders;
   if (folders) {
-    if (verbose) console.log(`Checking attached folders...`);
+    if (verbose) output(`Checking attached folders...`);
     for (const folder of folders) {
       // Check if folder is shared or used by other agents
       const isShared = classifier.isSharedFolder(folder);
       const usedByOthers = await classifier.isFolderUsedByOtherAgents(folder.id, agent.id, allAgents);
       
       if (isShared) {
-        if (verbose) console.log(`  Keeping shared folder: ${folder.name || folder.id}`);
+        if (verbose) output(`  Keeping shared folder: ${folder.name || folder.id}`);
       } else if (!usedByOthers) {
-        if (verbose) console.log(`  Deleting agent-specific folder: ${folder.name || folder.id}`);
+        if (verbose) output(`  Deleting agent-specific folder: ${folder.name || folder.id}`);
         try {
           await client.deleteFolder(folder.id);
-          if (verbose) console.log(`  Folder deleted`);
-        } catch (error: any) {
-          console.warn(`  Could not delete folder: ${error.message}`);
+          if (verbose) output(`  Folder deleted`);
+        } catch (err: any) {
+          warn(`  Could not delete folder: ${err.message}`);
         }
       } else {
-        if (verbose) console.log(`  Keeping folder used by other agents: ${folder.name || folder.id}`);
+        if (verbose) output(`  Keeping folder used by other agents: ${folder.name || folder.id}`);
       }
     }
   }
@@ -178,7 +360,7 @@ async function deleteAgentWithCleanup(
   await client.deleteAgent(agent.id);
   
   // Clean up any remaining orphaned memory blocks by name pattern (fallback)
-  if (verbose) console.log(`Cleaning up orphaned memory blocks...`);
+  if (verbose) output(`Cleaning up orphaned memory blocks...`);
   try {
     const blocks = await client.listBlocks();
     const blockList = normalizeResponse(blocks);
@@ -189,17 +371,17 @@ async function deleteAgentWithCleanup(
       const blockInUse = await classifier.isBlockUsedByOtherAgents(block.id, agent.id, allAgents);
       
       if (!blockInUse) {
-        if (verbose) console.log(`  Deleting orphaned block: ${block.label}`);
+        if (verbose) output(`  Deleting orphaned block: ${block.label}`);
         try {
           await client.deleteBlock(block.id);
-          if (verbose) console.log(`  Block deleted`);
-        } catch (error: any) {
-          console.warn(`  Could not delete block: ${error.message}`);
+          if (verbose) output(`  Block deleted`);
+        } catch (err: any) {
+          warn(`  Could not delete block: ${err.message}`);
         }
       }
     }
-  } catch (error: any) {
-    console.warn(`  Could not clean up blocks: ${error.message}`);
+  } catch (err: any) {
+    warn(`  Could not clean up blocks: ${err.message}`);
   }
 }
 
@@ -220,8 +402,8 @@ async function deleteMcpServer(name: string, options?: { force?: boolean }, comm
   }
 
   if (!options?.force) {
-    console.log(`This will permanently delete MCP server: ${name} (${server.id})`);
-    console.log('Use --force to confirm deletion');
+    output(`This will permanently delete MCP server: ${name} (${server.id})`);
+    output('Use --force to confirm deletion');
     process.exit(1);
   }
 
@@ -231,9 +413,9 @@ async function deleteMcpServer(name: string, options?: { force?: boolean }, comm
   try {
     await client.deleteMcpServer(server.id!);
     spinner.succeed(`MCP server ${name} deleted successfully`);
-  } catch (error) {
+  } catch (err) {
     spinner.fail(`Failed to delete MCP server ${name}`);
-    throw error;
+    throw err;
   }
 }
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -2,6 +2,7 @@ import { LettaClientWrapper } from '../lib/letta-client';
 import { AgentResolver } from '../lib/agent-resolver';
 import * as fs from 'fs';
 import * as path from 'path';
+import { log, output, error } from '../lib/logger';
 
 export default async function exportCommand(
   resource: string, 
@@ -27,7 +28,7 @@ export default async function exportCommand(
     const { agent } = await resolver.findAgentByName(name);
     
     if (verbose) {
-      console.log(`Exporting agent: ${agent.name} (${agent.id})`);
+      output(`Exporting agent: ${agent.name} (${agent.id})`);
     }
 
     // Export the agent
@@ -41,22 +42,22 @@ export default async function exportCommand(
     const resolvedPath = path.resolve(outputFile);
 
     if (verbose) {
-      console.log(`Writing export to: ${resolvedPath}`);
-      console.log(`Format: ${options.legacyFormat ? 'legacy (v1)' : 'standard (v2)'}`);
+      output(`Writing export to: ${resolvedPath}`);
+      output(`Format: ${options.legacyFormat ? 'legacy (v1)' : 'standard (v2)'}`);
     }
 
     // Write the export file
     fs.writeFileSync(resolvedPath, JSON.stringify(exportResponse, null, 2));
     
-    console.log(`Agent ${agent.name} exported to ${outputFile}`);
+    output(`Agent ${agent.name} exported to ${outputFile}`);
     
     if (verbose) {
       const stats = fs.statSync(resolvedPath);
-      console.log(`File size: ${(stats.size / 1024).toFixed(2)} KB`);
+      output(`File size: ${(stats.size / 1024).toFixed(2)} KB`);
     }
 
-  } catch (error: any) {
-    console.error(`Failed to export agent ${name}:`, error.message);
-    throw error;
+  } catch (err: any) {
+    error(`Failed to export agent ${name}:`, err.message);
+    throw err;
   }
 }

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,6 +1,7 @@
 import { LettaClientWrapper } from '../lib/letta-client';
 import { AgentResolver } from '../lib/agent-resolver';
 import { OutputFormatter } from '../lib/ux/output-formatter';
+import { output, error } from '../lib/logger';
 
 interface AgentFile {
   id: string;
@@ -20,7 +21,7 @@ export async function filesCommand(agentName: string, options: { output?: string
   // Resolve agent name to ID
   const { agent } = await resolver.findAgentByName(agentName);
   if (!agent) {
-    console.error(`Agent "${agentName}" not found`);
+    error(`Agent "${agentName}" not found`);
     process.exit(1);
   }
 
@@ -29,7 +30,7 @@ export async function filesCommand(agentName: string, options: { output?: string
   const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/files`);
 
   if (!response.ok) {
-    console.error(`Failed to fetch files: ${response.status}`);
+    error(`Failed to fetch files: ${response.status}`);
     process.exit(1);
   }
 
@@ -40,11 +41,11 @@ export async function filesCommand(agentName: string, options: { output?: string
     return;
   }
 
-  console.log(`Files for agent: ${agentName}`);
-  console.log('='.repeat(40));
+  output(`Files for agent: ${agentName}`);
+  output('='.repeat(40));
 
   if (files.length === 0) {
-    console.log('\nNo files attached');
+    output('\nNo files attached');
     return;
   }
 
@@ -61,21 +62,21 @@ export async function filesCommand(agentName: string, options: { output?: string
   // Summary
   const openCount = files.filter(f => f.is_open).length;
   const closedCount = files.length - openCount;
-  console.log(`\nTotal: ${files.length} files (${openCount} open, ${closedCount} closed)\n`);
+  output(`\nTotal: ${files.length} files (${openCount} open, ${closedCount} closed)\n`);
 
   // List by folder
   for (const [folder, folderFiles] of byFolder) {
-    console.log(`Folder: ${folder}`);
+    output(`Folder: ${folder}`);
     for (const file of folderFiles) {
       const status = file.is_open ? '[OPEN]  ' : '[CLOSED]';
       const name = file.file_name.replace(`${folder}/`, '');
-      console.log(`  ${status} ${name}`);
+      output(`  ${status} ${name}`);
 
       if (verbose) {
-        console.log(`           ID: ${file.file_id}`);
-        console.log(`           Last accessed: ${file.last_accessed_at || 'never'}`);
+        output(`           ID: ${file.file_id}`);
+        output(`           Last accessed: ${file.last_accessed_at || 'never'}`);
       }
     }
-    console.log('');
+    output('');
   }
 }

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -5,7 +5,7 @@ import { validateResourceType } from '../lib/validators';
 import { withErrorHandling } from '../lib/error-handler';
 import { createSpinner, getSpinnerEnabled } from '../lib/ux/spinner';
 import { normalizeToArray, computeAgentCounts } from '../lib/resource-usage';
-import { log } from '../lib/logger';
+import { log, output } from '../lib/logger';
 import { AgentDataFetcher, DetailLevel } from '../lib/agent-data-fetcher';
 
 const SUPPORTED_RESOURCES = ['agents', 'blocks', 'tools', 'folders', 'files', 'mcp-servers'];
@@ -108,11 +108,11 @@ async function getAgents(
 
     if (options?.output === 'yaml') {
       const rawData = agents.map(a => a.raw);
-      console.log(OutputFormatter.formatOutput(rawData, 'yaml'));
+      output(OutputFormatter.formatOutput(rawData, 'yaml'));
       return;
     }
 
-    console.log(OutputFormatter.createAgentTable(agents, isWide));
+    output(OutputFormatter.createAgentTable(agents, isWide));
   } catch (error) {
     spinner.fail('Failed to load agents');
     throw error;
@@ -162,14 +162,14 @@ async function getBlocks(
     }
 
     if (blockList.length === 0) {
-      if (agentId) console.log('No blocks attached to this agent');
-      else if (options?.shared) console.log('No shared blocks found (attached to 2+ agents)');
-      else if (options?.orphaned) console.log('No orphaned blocks found (attached to 0 agents)');
-      else console.log('No blocks found');
+      if (agentId) output('No blocks attached to this agent');
+      else if (options?.shared) output('No shared blocks found (attached to 2+ agents)');
+      else if (options?.orphaned) output('No orphaned blocks found (attached to 0 agents)');
+      else output('No blocks found');
       return;
     }
 
-    console.log(OutputFormatter.createBlockTable(blockList, isWide, agentCounts));
+    output(OutputFormatter.createBlockTable(blockList, isWide, agentCounts));
   } catch (error) {
     spinner.fail('Failed to load blocks');
     throw error;
@@ -223,14 +223,14 @@ async function getTools(
     }
 
     if (toolList.length === 0) {
-      if (agentId) console.log('No tools attached to this agent');
-      else if (options?.shared) console.log('No shared tools found (attached to 2+ agents)');
-      else if (options?.orphaned) console.log('No orphaned tools found (attached to 0 agents)');
-      else console.log('No tools found');
+      if (agentId) output('No tools attached to this agent');
+      else if (options?.shared) output('No shared tools found (attached to 2+ agents)');
+      else if (options?.orphaned) output('No orphaned tools found (attached to 0 agents)');
+      else output('No tools found');
       return;
     }
 
-    console.log(OutputFormatter.createToolTable(toolList, isWide, agentCounts));
+    output(OutputFormatter.createToolTable(toolList, isWide, agentCounts));
   } catch (error) {
     spinner.fail('Failed to load tools');
     throw error;
@@ -304,14 +304,14 @@ async function getFolders(
     }
 
     if (folderList.length === 0) {
-      if (agentId) console.log('No folders attached to this agent');
-      else if (options?.shared) console.log('No shared folders found (attached to 2+ agents)');
-      else if (options?.orphaned) console.log('No orphaned folders found (attached to 0 agents)');
-      else console.log('No folders found');
+      if (agentId) output('No folders attached to this agent');
+      else if (options?.shared) output('No shared folders found (attached to 2+ agents)');
+      else if (options?.orphaned) output('No orphaned folders found (attached to 0 agents)');
+      else output('No folders found');
       return;
     }
 
-    console.log(OutputFormatter.createFolderTable(folderList, isWide, agentCounts, fileCounts));
+    output(OutputFormatter.createFolderTable(folderList, isWide, agentCounts, fileCounts));
   } catch (error) {
     spinner.fail('Failed to load folders');
     throw error;
@@ -336,11 +336,11 @@ async function getMcpServers(
     }
 
     if (servers.length === 0) {
-      console.log('No MCP servers found');
+      output('No MCP servers found');
       return;
     }
 
-    console.log(OutputFormatter.createMcpServerTable(servers));
+    output(OutputFormatter.createMcpServerTable(servers));
   } catch (error) {
     spinner.fail('Failed to load MCP servers');
     throw error;
@@ -426,14 +426,14 @@ async function getFiles(
     }
 
     if (fileList.length === 0) {
-      if (agentId) console.log('No files attached to this agent');
-      else if (options?.shared) console.log('No shared files found (in folders attached to 2+ agents)');
-      else if (options?.orphaned) console.log('No orphaned files found (in folders attached to 0 agents)');
-      else console.log('No files found');
+      if (agentId) output('No files attached to this agent');
+      else if (options?.shared) output('No shared files found (in folders attached to 2+ agents)');
+      else if (options?.orphaned) output('No orphaned files found (in folders attached to 0 agents)');
+      else output('No files found');
       return;
     }
 
-    console.log(OutputFormatter.createFileTable(fileList, agentCounts, isWide));
+    output(OutputFormatter.createFileTable(fileList, agentCounts, isWide));
   } catch (error) {
     spinner.fail('Failed to load files');
     throw error;

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -3,6 +3,7 @@ import { LettaClientWrapper } from '../lib/letta-client';
 import { OutputFormatter } from '../lib/ux/output-formatter';
 import { shouldUseFancyUx } from '../lib/ux/box';
 import { LETTA_PURPLE, STATUS } from '../lib/ux/constants';
+import { output } from '../lib/logger';
 
 const purple = chalk.hex(LETTA_PURPLE);
 
@@ -50,26 +51,26 @@ export async function healthCommand(options: { output?: string }, command: any) 
 
   // Header
   if (fancy) {
-    console.log(purple('Letta Server Health Check'));
-    console.log(purple('─'.repeat(26)) + '\n');
+    output(purple('Letta Server Health Check'));
+    output(purple('─'.repeat(26)) + '\n');
   } else {
-    console.log('Letta Server Health Check');
-    console.log('==========================\n');
+    output('Letta Server Health Check');
+    output('==========================\n');
   }
 
   // Check environment
   if (!baseUrl) {
-    console.log(fancy ? `${STATUS.fail} LETTA_BASE_URL not set` : '[FAIL] LETTA_BASE_URL not set');
+    output(fancy ? `${STATUS.fail} LETTA_BASE_URL not set` : '[FAIL] LETTA_BASE_URL not set');
     process.exit(1);
   }
-  console.log(fancy ? `${chalk.dim('Server URL:')} ${baseUrl}` : `Server URL: ${baseUrl}`);
+  output(fancy ? `${chalk.dim('Server URL:')} ${baseUrl}` : `Server URL: ${baseUrl}`);
 
   // Check connectivity
   try {
     const response = await fetch(`${baseUrl}/v1/health/`);
 
     if (!response.ok) {
-      console.log(fancy ? `${STATUS.fail} Server returned ${response.status}` : `[FAIL] Server returned ${response.status}`);
+      output(fancy ? `${STATUS.fail} Server returned ${response.status}` : `[FAIL] Server returned ${response.status}`);
       process.exit(1);
     }
 
@@ -77,27 +78,27 @@ export async function healthCommand(options: { output?: string }, command: any) 
 
     if (fancy) {
       const statusIcon = health.status === 'ok' ? STATUS.ok : STATUS.fail;
-      console.log(`${chalk.dim('Status:')}     ${statusIcon} ${health.status}`);
-      console.log(`${chalk.dim('Version:')}    ${chalk.cyan(health.version)}`);
+      output(`${chalk.dim('Status:')}     ${statusIcon} ${health.status}`);
+      output(`${chalk.dim('Version:')}    ${chalk.cyan(health.version)}`);
     } else {
-      console.log(`Status:     ${health.status === 'ok' ? '[OK]' : '[FAIL] ' + health.status}`);
-      console.log(`Version:    ${health.version}`);
+      output(`Status:     ${health.status === 'ok' ? '[OK]' : '[FAIL] ' + health.status}`);
+      output(`Version:    ${health.version}`);
     }
 
     if (verbose) {
       // Additional checks in verbose mode
-      console.log(fancy ? '\n' + chalk.dim('Detailed Checks:') : '\nDetailed Checks:');
+      output(fancy ? '\n' + chalk.dim('Detailed Checks:') : '\nDetailed Checks:');
 
       // Check agents endpoint
       try {
         const client = new LettaClientWrapper();
         const agents = await client.listAgents();
         const agentCount = Array.isArray(agents) ? agents.length : 0;
-        console.log(fancy
+        output(fancy
           ? `  ${STATUS.ok} Agents: ${chalk.green(agentCount.toString())} found`
           : `  Agents:   [OK] ${agentCount} found`);
       } catch (e: any) {
-        console.log(fancy
+        output(fancy
           ? `  ${STATUS.fail} Agents: ${chalk.red(e.message)}`
           : `  Agents:   [FAIL] ${e.message}`);
       }
@@ -107,43 +108,43 @@ export async function healthCommand(options: { output?: string }, command: any) 
         const client = new LettaClientWrapper();
         const tools = await client.listTools();
         const toolCount = Array.isArray(tools) ? tools.length : 0;
-        console.log(fancy
+        output(fancy
           ? `  ${STATUS.ok} Tools: ${chalk.green(toolCount.toString())} found`
           : `  Tools:    [OK] ${toolCount} found`);
       } catch (e: any) {
-        console.log(fancy
+        output(fancy
           ? `  ${STATUS.fail} Tools: ${chalk.red(e.message)}`
           : `  Tools:    [FAIL] ${e.message}`);
       }
 
       // Check API key status
       if (process.env.LETTA_API_KEY) {
-        console.log(fancy
+        output(fancy
           ? `  ${STATUS.ok} API Key: ${chalk.green('configured')}`
           : `  API Key:  [OK] configured`);
       } else {
-        console.log(fancy
+        output(fancy
           ? `  ${STATUS.info} API Key: ${chalk.dim('not set (ok for self-hosted)')}`
           : `  API Key:  [--] not set (ok for self-hosted)`);
       }
     }
 
-    console.log(fancy
+    output(fancy
       ? '\n' + STATUS.ok + chalk.green(' Letta server is healthy')
       : '\nLetta server is healthy');
 
   } catch (error: any) {
     const msg = error.cause?.code || error.code || error.message;
     if (msg === 'ECONNREFUSED') {
-      console.log(fancy
+      output(fancy
         ? `${STATUS.fail} Connection refused - is Letta server running at ${baseUrl}?`
         : `[FAIL] Connection refused - is Letta server running at ${baseUrl}?`);
     } else if (msg === 'ENOTFOUND') {
-      console.log(fancy
+      output(fancy
         ? `${STATUS.fail} Host not found - check LETTA_BASE_URL`
         : `[FAIL] Host not found - check LETTA_BASE_URL`);
     } else {
-      console.log(fancy
+      output(fancy
         ? `${STATUS.fail} Cannot connect to ${baseUrl}`
         : `[FAIL] Cannot connect to ${baseUrl}`);
     }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,6 +1,7 @@
 import { LettaClientWrapper } from '../lib/letta-client';
 import * as fs from 'fs';
 import * as path from 'path';
+import { log, output, error } from '../lib/logger';
 
 export default async function importCommand(
   file: string,
@@ -27,9 +28,9 @@ export default async function importCommand(
     }
 
     if (verbose) {
-      console.log(`Importing from: ${resolvedPath}`);
+      output(`Importing from: ${resolvedPath}`);
       const stats = fs.statSync(resolvedPath);
-      console.log(`File size: ${(stats.size / 1024).toFixed(2)} KB`);
+      output(`File size: ${(stats.size / 1024).toFixed(2)} KB`);
     }
 
     // Prepare import options
@@ -44,7 +45,7 @@ export default async function importCommand(
     if (options.envVars) importOptions.env_vars_json = options.envVars;
 
     if (verbose && Object.keys(importOptions).length > 0) {
-      console.log('Import options:', JSON.stringify(importOptions, null, 2));
+      output('Import options:', JSON.stringify(importOptions, null, 2));
     }
 
     // Create file stream and import
@@ -53,20 +54,20 @@ export default async function importCommand(
     const importResponse = await client.importAgent(fileStream, importOptions);
     
     if (importResponse.agent_ids && importResponse.agent_ids.length > 0) {
-      console.log(`Successfully imported ${importResponse.agent_ids.length} agent(s):`);
+      output(`Successfully imported ${importResponse.agent_ids.length} agent(s):`);
       for (const agentId of importResponse.agent_ids) {
-        console.log(`  - ${agentId}`);
+        output(`  - ${agentId}`);
       }
     } else {
-      console.log('Import completed but no agent IDs returned');
+      output('Import completed but no agent IDs returned');
     }
     
     if (verbose) {
-      console.log('Import response:', JSON.stringify(importResponse, null, 2));
+      output('Import response:', JSON.stringify(importResponse, null, 2));
     }
 
-  } catch (error: any) {
-    console.error(`Failed to import agent from ${file}:`, error.message);
-    throw error;
+  } catch (err: any) {
+    error(`Failed to import agent from ${file}:`, err.message);
+    throw err;
   }
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,6 @@
 import { LettaClientWrapper } from '../lib/letta-client';
 import { AgentResolver } from '../lib/agent-resolver';
+import { log, output, error, warn } from '../lib/logger';
 
 export default async function updateCommand(
   resource: string, 
@@ -32,7 +33,7 @@ export default async function updateCommand(
     const { agent } = await resolver.findAgentByName(name);
     
     if (verbose) {
-      console.log(`Updating agent: ${agent.name} (${agent.id})`);
+      output(`Updating agent: ${agent.name} (${agent.id})`);
     }
 
     // Build update payload
@@ -67,15 +68,15 @@ export default async function updateCommand(
           }
           
           if (tool) {
-            if (verbose) console.log(`Attaching tool ${tool.name} (${tool.id})...`);
+            if (verbose) output(`Attaching tool ${tool.name} (${tool.id})...`);
             await client.attachToolToAgent(String(agent.id), String(tool.id));
-            console.log(`Tool attached: ${tool.name}`);
+            output(`Tool attached: ${tool.name}`);
             toolChanges = true;
           } else {
-            console.warn(`Warning: Tool '${toolName}' not found.`);
+            warn(`Warning: Tool '${toolName}' not found.`);
           }
-        } catch (error: any) {
-          console.error(`Failed to attach tool ${toolName}:`, error.message);
+        } catch (err: any) {
+          error(`Failed to attach tool ${toolName}:`, err.message);
         }
       }
     }
@@ -105,43 +106,43 @@ export default async function updateCommand(
              }
           }
           
-          if (verbose) console.log(`Detaching tool ${toolNameDisplay} (${toolId})...`);
+          if (verbose) output(`Detaching tool ${toolNameDisplay} (${toolId})...`);
           await client.detachToolFromAgent(String(agent.id), String(toolId));
-          console.log(`Tool detached: ${toolNameDisplay}`);
+          output(`Tool detached: ${toolNameDisplay}`);
           toolChanges = true;
-        } catch (error: any) {
-          console.warn(`Failed to detach tool ${toolName}:`, error.message);
+        } catch (err: any) {
+          warn(`Failed to detach tool ${toolName}:`, err.message);
         }
       }
     }
 
     if (Object.keys(updatePayload).length === 0 && !toolChanges) {
-      console.log('No updates specified. Use --help to see available options.');
+      output('No updates specified. Use --help to see available options.');
       return;
     }
 
     if (verbose) {
-      console.log('Update payload:', JSON.stringify(updatePayload, null, 2));
+      output('Update payload:', JSON.stringify(updatePayload, null, 2));
     }
 
     // Update the agent
     if (Object.keys(updatePayload).length > 0) {
       const updatedAgent = await client.updateAgent(agent.id, updatePayload);
       
-      console.log(`Agent ${agent.name} updated successfully`);
+      output(`Agent ${agent.name} updated successfully`);
       
       if (verbose) {
-        console.log(`Updated agent ID: ${updatedAgent.id}`);
-        if (updatePayload.name) console.log(`Name changed to: ${updatePayload.name}`);
-        if (updatePayload.model) console.log(`Model changed to: ${updatePayload.model}`);
-        if (updatePayload.embedding) console.log(`Embedding changed to: ${updatePayload.embedding}`);
+        output(`Updated agent ID: ${updatedAgent.id}`);
+        if (updatePayload.name) output(`Name changed to: ${updatePayload.name}`);
+        if (updatePayload.model) output(`Model changed to: ${updatePayload.model}`);
+        if (updatePayload.embedding) output(`Embedding changed to: ${updatePayload.embedding}`);
       }
     } else if (toolChanges) {
-      console.log(`Agent ${agent.name} updated successfully`);
+      output(`Agent ${agent.name} updated successfully`);
     }
 
-  } catch (error: any) {
-    console.error(`Failed to update agent ${name}:`, error.message);
-    throw error;
+  } catch (err: any) {
+    error(`Failed to update agent ${name}:`, err.message);
+    throw err;
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,9 +1,10 @@
 import { FleetParser } from '../lib/fleet-parser';
 import { SupabaseStorageBackend } from '../lib/storage-backend';
+import { output, error } from '../lib/logger';
 
 export async function validateCommand(options: { file: string }) {
   try {
-    console.log(`Validating configuration: ${options.file}`);
+    output(`Validating configuration: ${options.file}`);
     
     // Initialize Supabase backend if environment variables are available
     let supabaseBackend: SupabaseStorageBackend | undefined;
@@ -11,20 +12,20 @@ export async function validateCommand(options: { file: string }) {
     try {
       if (process.env.SUPABASE_URL || process.env.SUPABASE_ANON_KEY) {
         supabaseBackend = new SupabaseStorageBackend();
-        console.log('Supabase backend configured for validation');
+        output('Supabase backend configured for validation');
       }
-    } catch (error: any) {
-      console.error(`Supabase configuration error: ${error.message}`);
+    } catch (err: any) {
+      error(`Supabase configuration error: ${err.message}`);
       process.exit(1);
     }
     
     const parser = new FleetParser(options.file, { supabaseBackend });
     await parser.parseFleetConfig(options.file);
     
-    console.log('Configuration is valid.');
-  } catch (error: any) {
-    console.error('Configuration validation failed:');
-    console.error(error.message);
+    output('Configuration is valid.');
+  } catch (err: any) {
+    error('Configuration validation failed:');
+    error(err.message);
     process.exit(1);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { contextCommand } from './commands/context';
 import { listRunsCommand, getRunCommand, deleteRunCommand } from './commands/runs';
 import { completionCommand } from './commands/completion';
 
-import { setQuietMode } from './lib/logger';
+import { setQuietMode, output, error } from './lib/logger';
 import { printFancyHelp } from './lib/ux/help-formatter';
 
 // Global verbose flag for error handling
@@ -46,14 +46,14 @@ function validateEnvironment(thisCommand: any, actionCommand: any) {
   }
 
   if (!process.env.LETTA_BASE_URL) {
-    console.error('Error: LETTA_BASE_URL environment variable is required');
-    console.error('');
-    console.error('For self-hosting:');
-    console.error('  export LETTA_BASE_URL=http://localhost:8283');
-    console.error('');
-    console.error('For Letta Cloud:');
-    console.error('  export LETTA_BASE_URL=https://api.letta.com');
-    console.error('  export LETTA_API_KEY=your_api_key');
+    error('Error: LETTA_BASE_URL environment variable is required');
+    error('');
+    error('For self-hosting:');
+    error('  export LETTA_BASE_URL=http://localhost:8283');
+    error('');
+    error('For Letta Cloud:');
+    error('  export LETTA_BASE_URL=https://api.letta.com');
+    error('  export LETTA_API_KEY=your_api_key');
     process.exit(1);
   }
 
@@ -61,8 +61,8 @@ function validateEnvironment(thisCommand: any, actionCommand: any) {
   const isLocalhost = process.env.LETTA_BASE_URL.includes('localhost');
 
   if (!isLocalhost && !process.env.LETTA_API_KEY) {
-    console.error(`Error: LETTA_API_KEY is required for Letta Cloud (${process.env.LETTA_BASE_URL})`);
-    console.error('Set it with: export LETTA_API_KEY=your_api_key');
+    error(`Error: LETTA_API_KEY is required for Letta Cloud (${process.env.LETTA_BASE_URL})`);
+    error('Set it with: export LETTA_API_KEY=your_api_key');
     process.exit(1);
   }
 }
@@ -135,12 +135,12 @@ program
   .option('--force', 'force deletion without confirmation')
   .action(deleteCommand);
 
-// Delete all command - bulk delete agents
+// Delete all command - bulk delete resources
 program
   .command('delete-all')
-  .description('Delete multiple agents (with optional pattern matching)')
-  .argument('<resource>', 'resource type (agent|agents)')
-  .option('--pattern <pattern>', 'regex pattern to match agent names/IDs')
+  .description('Delete multiple resources (with optional pattern matching)')
+  .argument('<resource>', 'resource type (agents|folders|blocks|tools|mcp-servers)')
+  .option('--pattern <pattern>', 'regex pattern to match resource names/IDs')
   .option('--force', 'force deletion without confirmation')
   .action(deleteAllCommand);
 
@@ -276,7 +276,7 @@ program
   .command('view')
   .description('Show current Letta configuration')
   .action(async () => {
-    console.log('Config view command');
+    output('Config view command');
     // TODO: Implement config view logic
   });
 
@@ -339,9 +339,9 @@ program
 // Global error handler to prevent stack traces from leaking
 process.on('unhandledRejection', (error: any) => {
   if (verboseMode) {
-    console.error(error);
+    error(error);
   } else {
-    console.error(error?.message || error);
+    error(error?.message || error);
   }
   process.exit(1);
 });

--- a/src/lib/agent-resolver.ts
+++ b/src/lib/agent-resolver.ts
@@ -1,5 +1,6 @@
 import { LettaClientWrapper } from './letta-client';
 import { normalizeResponse } from './response-normalizer';
+import { warn } from './logger';
 
 export class AgentResolver {
   private client: LettaClientWrapper;
@@ -35,7 +36,7 @@ export class AgentResolver {
       const tools = await this.client.listAgentTools(agentId);
       agentWithDetails.tools = Array.isArray(tools) ? tools : (tools?.items || []);
     } catch (error) {
-      console.warn(`Warning: Could not fetch tools for agent ${agentId}`);
+      warn(`Warning: Could not fetch tools for agent ${agentId}`);
       agentWithDetails.tools = [];
     }
     
@@ -44,7 +45,7 @@ export class AgentResolver {
       const blocks = await this.client.listAgentBlocks(agentId);
       agentWithDetails.blocks = Array.isArray(blocks) ? blocks : (blocks?.items || []);
     } catch (error) {
-      console.warn(`Warning: Could not fetch blocks for agent ${agentId}`);
+      warn(`Warning: Could not fetch blocks for agent ${agentId}`);
       agentWithDetails.blocks = [];
     }
     
@@ -53,7 +54,7 @@ export class AgentResolver {
       const folders = await this.client.listAgentFolders(agentId);
       agentWithDetails.folders = Array.isArray(folders) ? folders : (folders?.items || []);
     } catch (error) {
-      console.warn(`Warning: Could not fetch folders for agent ${agentId}`);
+      warn(`Warning: Could not fetch folders for agent ${agentId}`);
       agentWithDetails.folders = [];
     }
 

--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -13,7 +13,7 @@ import { StorageBackendManager, SupabaseStorageBackend, hasSupabaseConfig } from
 import { FolderFileConfig } from '../types/fleet-config';
 import { isBuiltinTool } from './builtin-tools';
 import { AgentResolver } from './agent-resolver';
-import { log } from './logger';
+import { log, error } from './logger';
 
 export async function processSharedBlocks(
   config: any,
@@ -169,11 +169,11 @@ export async function processFolders(
 
                 if (verbose) log(`  Uploaded: ${filePath}`);
               }
-            } catch (error: any) {
+            } catch (err: any) {
               const fileDesc = isFromBucketConfig(fileConfig)
                 ? `${fileConfig.from_bucket.bucket}/${fileConfig.from_bucket.path}`
                 : fileConfig;
-              console.error(`  Failed to upload ${fileDesc}:`, error.message);
+              error(`  Failed to upload ${fileDesc}:`, err.message);
             }
           }
         } else {
@@ -253,7 +253,7 @@ export async function updateExistingAgent(
     agentManager.updateRegistry(existingAgent.name, agentConfig, existingAgent.id);
 
     updateSpinner.succeed(`Agent ${agent.name} updated successfully (conversation history preserved)`);
-  } catch (error) {
+  } catch (err) {
     spinner.fail(`Failed to update agent ${agent.name}`);
     throw error;
   }
@@ -389,7 +389,7 @@ export async function createNewAgent(
     const folderCount = agent.folders?.length || 0;
 
     creationSpinner.succeed(`Agent ${agentName} created (${blockCount} blocks, ${toolCount} tools, ${folderCount} folders)`);
-  } catch (error) {
+  } catch (err) {
     creationSpinner.fail(`Failed to create agent ${agentName}`);
     throw error;
   }

--- a/src/lib/diff-analyzers.ts
+++ b/src/lib/diff-analyzers.ts
@@ -3,6 +3,7 @@ import { BlockManager } from './block-manager';
 import { normalizeResponse } from './response-normalizer';
 import { ToolDiff, BlockDiff, FolderDiff } from './diff-engine';
 import { FolderFileConfig } from '../types/fleet-config';
+import { warn } from './logger';
 
 // Helper to extract file name from FolderFileConfig (string or from_bucket object)
 function getFileName(fileConfig: FolderFileConfig): string {
@@ -298,7 +299,7 @@ export async function analyzeFolderChanges(
             unchanged.push({ name: folder.name, id: folder.id });
           }
         } catch (error) {
-          console.warn(`Could not analyze files in folder ${folder.name}:`, error);
+          warn(`Could not analyze files in folder ${folder.name}:`, error);
           unchanged.push({ name: folder.name, id: folder.id });
         }
       } else {

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -1,3 +1,5 @@
+import { error } from './logger';
+
 /**
  * Wraps command functions with consistent error handling
  */
@@ -8,8 +10,8 @@ export function withErrorHandling<T extends any[], R>(
   return async (...args: T): Promise<R> => {
     try {
       return await fn(...args);
-    } catch (error: any) {
-      console.error(`${commandName} failed:`, formatLettaError(error.message || error));
+    } catch (err: any) {
+      error(`${commandName} failed:`, formatLettaError(err.message || err));
       process.exit(1);
     }
   };

--- a/src/lib/file-content-tracker.ts
+++ b/src/lib/file-content-tracker.ts
@@ -98,14 +98,14 @@ export class FileContentTracker {
       } else if (block.from_bucket) {
         // Memory block loads content from cloud bucket
         if (!this.storageManager) {
-          console.warn(`Warning: Cannot hash bucket content for block '${block.name}' - no storage manager available`);
+          warn(`Warning: Cannot hash bucket content for block '${block.name}' - no storage manager available`);
           blockHashes[block.name] = crypto.createHash('sha256').update(`bucket:${block.from_bucket.bucket}/${block.from_bucket.path}`).digest('hex').substring(0, 16);
         } else {
           try {
             const bucketContent = await this.storageManager.readFromBucket(block.from_bucket);
             blockHashes[block.name] = crypto.createHash('sha256').update(bucketContent).digest('hex').substring(0, 16);
           } catch (error) {
-            console.warn(`Warning: Could not read bucket content for block '${block.name}':`, (error as Error).message);
+            warn(`Warning: Could not read bucket content for block '${block.name}':`, (error as Error).message);
             blockHashes[block.name] = crypto.createHash('sha256').update(`bucket-error:${block.from_bucket.bucket}/${block.from_bucket.path}`).digest('hex').substring(0, 16);
           }
         }

--- a/src/lib/fleet-parser.ts
+++ b/src/lib/fleet-parser.ts
@@ -6,7 +6,7 @@ import { FleetConfig, FolderConfig, FolderFileConfig } from '../types/fleet-conf
 import { StorageBackendManager, SupabaseStorageBackend, BucketConfig } from './storage-backend';
 import { FleetConfigValidator } from './config-validators';
 import { isBuiltinTool, formatBuiltinToolWarning, CORE_MEMORY_TOOLS } from './builtin-tools';
-import { log } from './logger';
+import { log, warn } from './logger';
 
 export interface FleetParserOptions {
   supabaseBackend?: SupabaseStorageBackend;
@@ -306,7 +306,7 @@ export class FleetParser {
         // Tool doesn't exist on server
         if (isBuiltin) {
           // Built-in tool not available - show helpful warning and skip
-          console.warn(`\n${formatBuiltinToolWarning(toolName)}\n`);
+          warn(`\n${formatBuiltinToolWarning(toolName)}\n`);
           continue;
         }
 
@@ -324,8 +324,8 @@ export class FleetParser {
 
           tool = await client.createTool({ source_code: sourceCode });
           if (verbose) log(`Tool ${toolName} registered`);
-        } catch (error: any) {
-          console.warn(`Failed to register tool ${toolName}: ${error.message}`);
+        } catch (err: any) {
+          warn(`Failed to register tool ${toolName}: ${err.message}`);
           continue;
         }
       } else {
@@ -359,10 +359,10 @@ export class FleetParser {
             } else {
               if (verbose) log(`Tool ${toolName} unchanged, reusing existing`);
             }
-          } catch (error: any) {
+          } catch (err: any) {
             // Only warn if it's NOT a "file not found" error, as missing local source for existing tool is valid
-            if (!error.message.includes('not found') && !error.message.includes('no value')) {
-               console.warn(`Failed to check tool ${toolName}: ${error.message}`);
+            if (!err.message.includes('not found') && !err.message.includes('no value')) {
+               warn(`Failed to check tool ${toolName}: ${err.message}`);
             } else if (verbose) {
                log(`Using existing tool ${toolName} (local source not found)`);
             }
@@ -420,9 +420,9 @@ export class FleetParser {
           server = await client.createMcpServer(createParams);
           created.push(serverName);
           if (verbose) log(`MCP server ${serverName} created`);
-        } catch (error: any) {
+        } catch (err: any) {
           failed.push(serverName);
-          console.warn(`Failed to create MCP server ${serverName}: ${error.message}`);
+          warn(`Failed to create MCP server ${serverName}: ${err.message}`);
           continue;
         }
       } else {
@@ -436,9 +436,9 @@ export class FleetParser {
             server = await client.updateMcpServer(server.id, updateParams);
             updated.push(serverName);
             if (verbose) log(`MCP server ${serverName} updated`);
-          } catch (error: any) {
+          } catch (err: any) {
             failed.push(serverName);
-            console.warn(`Failed to update MCP server ${serverName}: ${error.message}`);
+            warn(`Failed to update MCP server ${serverName}: ${err.message}`);
             continue;
           }
         } else {

--- a/src/lib/last-applied-config.ts
+++ b/src/lib/last-applied-config.ts
@@ -8,6 +8,7 @@
  */
 
 import { generateContentHash } from '../utils/hash-utils';
+import { log, warn } from './logger';
 
 export interface LastAppliedConfig {
   tools: string[];
@@ -124,7 +125,7 @@ export function applyThreeWayMerge(
       const before = ops.tools.toRemove.length;
       ops.tools.toRemove = ops.tools.toRemove.filter(t => prevTools.has(t.name));
       if (verbose && before > ops.tools.toRemove.length) {
-        console.log(`  Preserving ${before - ops.tools.toRemove.length} user-added tool(s)`);
+        log(`  Preserving ${before - ops.tools.toRemove.length} user-added tool(s)`);
       }
     }
 
@@ -132,7 +133,7 @@ export function applyThreeWayMerge(
       const before = ops.blocks.toRemove.length;
       ops.blocks.toRemove = ops.blocks.toRemove.filter(b => prevBlocks.has(b.name));
       if (verbose && before > ops.blocks.toRemove.length) {
-        console.log(`  Preserving ${before - ops.blocks.toRemove.length} user-added block(s)`);
+        log(`  Preserving ${before - ops.blocks.toRemove.length} user-added block(s)`);
       }
     }
 
@@ -140,16 +141,16 @@ export function applyThreeWayMerge(
       const before = ops.folders.toDetach.length;
       ops.folders.toDetach = ops.folders.toDetach.filter(f => prevFolders.has(f.name));
       if (verbose && before > ops.folders.toDetach.length) {
-        console.log(`  Preserving ${before - ops.folders.toDetach.length} user-added folder(s)`);
+        log(`  Preserving ${before - ops.folders.toDetach.length} user-added folder(s)`);
       }
     }
   }
 
   // Warn about conflicts (kubectl behavior: apply anyway, but inform user)
   if (conflicts.length > 0) {
-    console.warn(`  Warning: ${conflicts.length} conflict(s) detected:`);
+    warn(`  Warning: ${conflicts.length} conflict(s) detected:`);
     for (const conflict of conflicts) {
-      console.warn(`    - ${conflict}`);
+      warn(`    - ${conflict}`);
     }
   }
 

--- a/src/lib/letta-client.ts
+++ b/src/lib/letta-client.ts
@@ -1,5 +1,6 @@
 import LettaClient from '@letta-ai/letta-client';
 import { sendMessageToAgent, MessageOptions } from './message-sender';
+import { warn } from './logger';
 
 export class LettaClientWrapper {
   private client: LettaClient;
@@ -134,7 +135,7 @@ export class LettaClientWrapper {
     } catch (e) {
       // Fallback: list all and find (though inefficient, it's a safety net)
       // But we already called listTools in the caller, so maybe just return null.
-      console.warn(`Failed to fetch tool by name '${name}':`, (e as Error).message);
+      warn(`Failed to fetch tool by name '${name}':`, (e as Error).message);
     }
     return null;
   }

--- a/src/lib/storage-backend.ts
+++ b/src/lib/storage-backend.ts
@@ -2,6 +2,7 @@
  * Storage backend interface for lettactl
  * Allows reading content from various sources (filesystem, cloud storage, etc.)
  */
+import { warn } from './logger';
 
 export interface StorageBackend {
   readContent(uri: string): Promise<string>
@@ -246,7 +247,7 @@ export class SupabaseStorageBackend {
         throw new Error(`SUPABASE_URL must use HTTPS protocol, got: ${parsed.protocol}`);
       }
       if (!url.includes('supabase.co') && !url.includes('localhost')) {
-        console.warn(`Warning: SUPABASE_URL doesn't appear to be a standard Supabase URL: ${url}`);
+        warn(`Warning: SUPABASE_URL doesn't appear to be a standard Supabase URL: ${url}`);
       }
     } catch (error) {
       if (error instanceof Error && error.message.includes('HTTPS')) {
@@ -317,11 +318,11 @@ export class SupabaseStorageBackend {
         if (fileInfo && fileInfo.metadata?.size) {
           const size = fileInfo.metadata.size;
           if (size <= 40) {
-            console.warn(
+            warn(
               `Warning: File '${filePath}' in bucket '${bucket}' is very small (${size} bytes). Check file has meaningful content.`
             );
           } else if (size > 50 * 1024 * 1024) { // 50MB
-            console.warn(
+            warn(
               `Warning: File '${filePath}' in bucket '${bucket}' is very large (${Math.round(size / 1024 / 1024 * 100) / 100}MB). This may cause memory issues or timeouts.`
             );
           }

--- a/src/lib/ux/banner.ts
+++ b/src/lib/ux/banner.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk';
 import { LETTA_PURPLE, BANNER } from './constants';
+import { output } from '../logger';
 
 export function printBanner(): void {
-  console.log(chalk.hex(LETTA_PURPLE)(BANNER));
-  console.log();
+  output(chalk.hex(LETTA_PURPLE)(BANNER));
+  output();
 }

--- a/src/lib/ux/help-formatter.ts
+++ b/src/lib/ux/help-formatter.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { printBanner } from './banner';
 import { LETTA_PURPLE } from './constants';
 import { BOX, createBox, mergeColumns, BoxRow } from './box';
+import { output } from '../logger';
 
 const purple = chalk.hex(LETTA_PURPLE);
 
@@ -104,13 +105,13 @@ export function printFancyHelp(): void {
   printBanner();
 
   // Tagline
-  console.log(chalk.dim('        kubectl-style CLI for Letta AI agent fleets'));
-  console.log(chalk.dim('        run lettactl --help --no-ux for full text help'));
-  console.log();
+  output(chalk.dim('        kubectl-style CLI for Letta AI agent fleets'));
+  output(chalk.dim('        run lettactl --help --no-ux for full text help'));
+  output();
 
   // Usage
-  console.log(purple('Usage:') + ' lettactl [options] [command]');
-  console.log();
+  output(purple('Usage:') + ' lettactl [options] [command]');
+  output();
 
   // Build boxes for each group
   const boxes: string[][] = COMMAND_GROUPS.map(group =>
@@ -142,11 +143,11 @@ export function printFancyHelp(): void {
 
   // Merge and print
   const merged = mergeColumns(col1, col2, 2);
-  merged.forEach(line => console.log(line));
+  merged.forEach(line => output(line));
 
-  console.log();
-  console.log(chalk.dim('Run') + ' lettactl <command> --help ' + chalk.dim('for detailed command info'));
-  console.log();
+  output();
+  output(chalk.dim('Run') + ' lettactl <command> --help ' + chalk.dim('for detailed command info'));
+  output();
 }
 
 export function shouldUseFancyHelp(): boolean {

--- a/src/lib/ux/spinner.ts
+++ b/src/lib/ux/spinner.ts
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import { isQuietMode } from '../logger';
+import { isQuietMode, output } from '../logger';
 
 export interface SpinnerInterface {
   text: string;
@@ -17,12 +17,12 @@ class NoSpinner implements SpinnerInterface {
   }
 
   succeed(text?: string): SpinnerInterface {
-    if (text) console.log(`[OK] ${text}`);
+    if (text) output(`[OK] ${text}`);
     return this;
   }
 
   fail(text?: string): SpinnerInterface {
-    if (text) console.log(`[FAIL] ${text}`);
+    if (text) output(`[FAIL] ${text}`);
     return this;
   }
 
@@ -57,7 +57,7 @@ export function createSpinner(text: string, enabled: boolean = true): SpinnerInt
     return new QuietSpinner();
   }
   if (!enabled) {
-    console.log(text);
+    output(text);
     return new NoSpinner();
   }
   return ora(text);

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,9 +1,11 @@
+import { error } from './logger';
+
 /**
  * Validates resource types for commands
  */
 export function validateResourceType(resource: string, validTypes: string[]): void {
   if (!validTypes.includes(resource)) {
-    console.error(`Error: Only "${validTypes.join('/')}" resource is currently supported`);
+    error(`Error: Only "${validTypes.join('/')}" resource is currently supported`);
     process.exit(1);
   }
 }
@@ -13,9 +15,9 @@ export function validateResourceType(resource: string, validTypes: string[]): vo
  */
 export function validateRequired(value: any, paramName: string, usage?: string): void {
   if (!value) {
-    console.error(`Error: ${paramName} is required`);
+    error(`Error: ${paramName} is required`);
     if (usage) {
-      console.error(`Usage: ${usage}`);
+      error(`Usage: ${usage}`);
     }
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- Adds bulk delete functionality for folders, blocks, tools, and mcp-servers via `delete-all` command
- Replaces all `console.log/error/warn` calls with custom logger functions (`log`, `output`, `error`, `warn`) for consistent output control
- Supports `--pattern` regex filtering and `--force` confirmation for bulk operations

## Test plan
- [ ] Run `lettactl delete-all folders --force` to delete all folders
- [ ] Run `lettactl delete-all blocks --pattern "test.*" --force` to delete matching blocks
- [ ] Run `lettactl delete-all tools --force` to delete all tools
- [ ] Verify `-q/--quiet` flag suppresses progress output across all commands

Closes #121