### PR TITLE
feat: #123 --force flag for strict config reconciliation

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -13,7 +13,7 @@ import { computeDryRunDiffs, displayDryRunResults } from '../lib/dry-run';
 import { log, warn, output, isQuietMode } from '../lib/logger';
 import { FILE_SEARCH_TOOLS } from '../lib/builtin-tools';
 
-export async function applyCommand(options: { file: string; agent?: string; match?: string; dryRun?: boolean; root?: string }, command: any) {
+export async function applyCommand(options: { file: string; agent?: string; match?: string; dryRun?: boolean; force?: boolean; root?: string }, command: any) {
   // Quiet mode overrides verbose
   const verbose = isQuietMode() ? false : (command.parent?.opts().verbose || false);
   const spinnerEnabled = getSpinnerEnabled(command);
@@ -256,6 +256,7 @@ export async function applyCommand(options: { file: string; agent?: string; matc
             sharedBlockIds,
             spinnerEnabled,
             verbose,
+            force: options.force || false,
             previousFolderFileHashes
           });
           succeeded.push(agent.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ program
   .option('--agent <pattern>', 'deploy only agents matching pattern')
   .option('--match <pattern>', 'apply template config to all existing agents matching glob pattern')
   .option('--dry-run', 'show what would be created without making changes')
+  .option('--force', 'remove resources not in config (strict reconciliation)')
   .option('--root <path>', 'root directory for resolving file paths')
   .action(applyCommand);
 

--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -204,10 +204,11 @@ export async function updateExistingAgent(
     sharedBlockIds: Map<string, string>;
     spinnerEnabled: boolean;
     verbose: boolean;
+    force: boolean;
     previousFolderFileHashes?: Record<string, Record<string, string>>;
   }
 ): Promise<void> {
-  const { client, diffEngine, agentManager, toolNameToId, updatedTools, builtinTools, createdFolders, sharedBlockIds, spinnerEnabled, verbose, previousFolderFileHashes } = context;
+  const { client, diffEngine, agentManager, toolNameToId, updatedTools, builtinTools, createdFolders, sharedBlockIds, spinnerEnabled, verbose, force, previousFolderFileHashes } = context;
 
   log(`Updating agent ${agent.name}:`);
 
@@ -231,7 +232,7 @@ export async function updateExistingAgent(
 
     const updateSpinner = createSpinner(`Applying updates to ${agent.name}...`, spinnerEnabled).start();
 
-    await diffEngine.applyUpdateOperations(existingAgent.id, updateOperations, verbose);
+    await diffEngine.applyUpdateOperations(existingAgent.id, updateOperations, verbose, force);
 
     // Store folder file hashes in agent metadata for next apply
     const newFolderFileHashes: Record<string, Record<string, string>> = {};

--- a/src/lib/diff-applier.ts
+++ b/src/lib/diff-applier.ts
@@ -21,11 +21,13 @@ export class DiffApplier {
 
   /**
    * Applies the update operations to the agent
+   * @param force - When true, also removes resources not in config (strict reconciliation)
    */
   async applyUpdateOperations(
     agentId: string,
     operations: AgentUpdateOperations,
-    verbose: boolean = false
+    verbose: boolean = false,
+    force: boolean = false
   ): Promise<void> {
     if (operations.operationCount === 0) {
       if (verbose) log('  No changes needed');
@@ -75,9 +77,12 @@ export class DiffApplier {
         await this.client.attachToolToAgent(agentId, tool.newId);
       }
 
-      for (const tool of operations.tools.toRemove) {
-        if (verbose) log(`  Detaching tool: ${tool.name}${getBuiltinTag(tool.name)}`);
-        await this.client.detachToolFromAgent(agentId, tool.id);
+      // Only remove tools when --force is specified
+      if (force) {
+        for (const tool of operations.tools.toRemove) {
+          if (verbose) log(`  Detaching tool: ${tool.name}${getBuiltinTag(tool.name)}`);
+          await this.client.detachToolFromAgent(agentId, tool.id);
+        }
       }
     }
 
@@ -88,9 +93,12 @@ export class DiffApplier {
         await this.client.attachBlockToAgent(agentId, block.id);
       }
 
-      for (const block of operations.blocks.toRemove) {
-        if (verbose) log(`  Detaching block: ${block.name}`);
-        await this.client.detachBlockFromAgent(agentId, block.id);
+      // Only remove blocks when --force is specified
+      if (force) {
+        for (const block of operations.blocks.toRemove) {
+          if (verbose) log(`  Detaching block: ${block.name}`);
+          await this.client.detachBlockFromAgent(agentId, block.id);
+        }
       }
 
       for (const block of operations.blocks.toUpdate) {
@@ -113,9 +121,12 @@ export class DiffApplier {
         await this.client.attachFolderToAgent(agentId, folder.id);
       }
 
-      for (const folder of operations.folders.toDetach) {
-        if (verbose) log(`  Detaching folder: ${folder.name}`);
-        await this.client.detachFolderFromAgent(agentId, folder.id);
+      // Only detach folders when --force is specified
+      if (force) {
+        for (const folder of operations.folders.toDetach) {
+          if (verbose) log(`  Detaching folder: ${folder.name}`);
+          await this.client.detachFolderFromAgent(agentId, folder.id);
+        }
       }
 
       for (const folder of operations.folders.toUpdate) {

--- a/src/lib/diff-engine.ts
+++ b/src/lib/diff-engine.ts
@@ -161,9 +161,10 @@ export class DiffEngine {
   async applyUpdateOperations(
     agentId: string,
     operations: AgentUpdateOperations,
-    verbose: boolean = false
+    verbose: boolean = false,
+    force: boolean = false
   ): Promise<void> {
     const applier = new DiffApplier(this.client, this.basePath);
-    return applier.applyUpdateOperations(agentId, operations, verbose);
+    return applier.applyUpdateOperations(agentId, operations, verbose, force);
   }
 }

--- a/src/lib/dry-run.ts
+++ b/src/lib/dry-run.ts
@@ -280,7 +280,7 @@ function displayUpdateResult(result: DryRunResult, verbose: boolean): void {
   // Tool changes
   if (ops.tools) {
     for (const t of ops.tools.toAdd) output(`    Tool [+]: ${t.name}`);
-    for (const t of ops.tools.toRemove) output(`    Tool [-]: ${t.name}`);
+    for (const t of ops.tools.toRemove) output(`    Tool [-]: ${t.name} (requires --force)`);
     for (const t of ops.tools.toUpdate) output(`    Tool [~]: ${t.name} (${t.reason})`);
     if (verbose && ops.tools.unchanged.length > 0) {
       output(`    Tools unchanged: ${ops.tools.unchanged.length}`);
@@ -290,7 +290,7 @@ function displayUpdateResult(result: DryRunResult, verbose: boolean): void {
   // Block changes
   if (ops.blocks) {
     for (const b of ops.blocks.toAdd) output(`    Block [+]: ${b.name}`);
-    for (const b of ops.blocks.toRemove) output(`    Block [-]: ${b.name}`);
+    for (const b of ops.blocks.toRemove) output(`    Block [-]: ${b.name} (requires --force)`);
     for (const b of ops.blocks.toUpdate) output(`    Block [~]: ${b.name}`);
     for (const b of ops.blocks.toUpdateValue) {
       output(`    Block [~]: ${b.name} (value sync)`);
@@ -305,7 +305,7 @@ function displayUpdateResult(result: DryRunResult, verbose: boolean): void {
   // Folder changes
   if (ops.folders) {
     for (const f of ops.folders.toAttach) output(`    Folder [+]: ${f.name}`);
-    for (const f of ops.folders.toDetach) output(`    Folder [-]: ${f.name}`);
+    for (const f of ops.folders.toDetach) output(`    Folder [-]: ${f.name} (requires --force)`);
     for (const f of ops.folders.toUpdate) {
       const changes = [];
       if (f.filesToAdd.length) changes.push(`+${f.filesToAdd.length} files`);

--- a/tests/e2e/fixtures/fleet-force-test-reduced.yml
+++ b/tests/e2e/fixtures/fleet-force-test-reduced.yml
@@ -1,0 +1,19 @@
+# Reduced fleet config for --force reconciliation testing
+# block_remove and conversation_search are removed from the original
+
+agents:
+  - name: e2e-force-test
+    description: Agent for testing --force reconciliation
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with resources to be removed.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    memory_blocks:
+      - name: block_keep
+        description: This block should remain
+        limit: 2000
+        value: "Keep this block"
+    tools:
+      - send_message

--- a/tests/e2e/fixtures/fleet-force-test.yml
+++ b/tests/e2e/fixtures/fleet-force-test.yml
@@ -1,0 +1,24 @@
+# Fleet config for --force reconciliation testing
+# Agent has multiple blocks and tools that will be removed in the reduced version
+
+agents:
+  - name: e2e-force-test
+    description: Agent for testing --force reconciliation
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with resources to be removed.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    memory_blocks:
+      - name: block_keep
+        description: This block should remain
+        limit: 2000
+        value: "Keep this block"
+      - name: block_remove
+        description: This block will be removed in reduced config
+        limit: 2000
+        value: "Remove this block"
+    tools:
+      - send_message
+      - conversation_search

--- a/tests/e2e/tests/32-force-reconciliation.sh
+++ b/tests/e2e/tests/32-force-reconciliation.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Test: --force flag for strict config reconciliation (#123)
+# Without --force: resources not in config are retained
+# With --force: resources not in config are detached
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT="e2e-force-test"
+section "Test: Force Reconciliation (--force flag)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT"
+
+# Create agent with multiple blocks
+info "Creating agent with block_keep and block_remove..."
+$CLI apply -f "$FIXTURES/fleet-force-test.yml" > $OUT 2>&1
+agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
+
+# Verify both blocks exist initially
+$CLI get blocks --agent "$AGENT" > $OUT 2>&1
+output_contains "block_keep" && pass "block_keep attached" || fail "block_keep missing"
+output_contains "block_remove" && pass "block_remove attached" || fail "block_remove missing"
+
+# Apply reduced config WITHOUT --force - block_remove should remain
+info "Applying reduced config WITHOUT --force..."
+$CLI apply -f "$FIXTURES/fleet-force-test-reduced.yml" > $OUT 2>&1
+
+$CLI get blocks --agent "$AGENT" > $OUT 2>&1
+output_contains "block_remove" && pass "block_remove retained without --force" || fail "block_remove incorrectly removed"
+
+# Verify dry-run shows "(requires --force)" for removals
+info "Checking dry-run shows --force requirement..."
+$CLI apply -f "$FIXTURES/fleet-force-test-reduced.yml" --dry-run > $OUT 2>&1
+output_contains "requires --force" && pass "Dry-run shows --force required" || fail "Dry-run missing --force indicator"
+
+# Apply reduced config WITH --force - block_remove should be detached
+info "Applying reduced config WITH --force..."
+$CLI apply -f "$FIXTURES/fleet-force-test-reduced.yml" --force > $OUT 2>&1
+
+$CLI get blocks --agent "$AGENT" > $OUT 2>&1
+output_contains "block_keep" && pass "block_keep still present" || fail "block_keep incorrectly removed"
+output_not_contains "block_remove" && pass "block_remove detached with --force" || fail "block_remove not removed with --force"
+
+delete_agent_if_exists "$AGENT"
+print_summary


### PR DESCRIPTION
## Summary
- Adds `--force` flag to `lettactl apply` for strict config reconciliation
- Without `--force`: resources not in config are retained (safe default)
- With `--force`: resources not in config are detached (kubectl-style --prune behavior)
- Dry-run output shows "(requires --force)" for pending removals

## Changes
- `src/index.ts` - Added `--force` option to apply command
- `src/commands/apply.ts` - Pass force option through
- `src/lib/apply-helpers.ts` - Pass force to diff engine
- `src/lib/diff-engine.ts` - Pass force to diff applier
- `src/lib/diff-applier.ts` - Only process removals when force=true
- `src/lib/dry-run.ts` - Show "(requires --force)" for removals

## Test plan
- [x] Run `./tests/e2e/run-single.sh 32-force-reconciliation` - 9 tests pass
- [x] Run full e2e suite - 78 tests pass
- [x] Verify blocks retained without --force
- [x] Verify blocks detached with --force
- [x] Verify dry-run shows --force requirement

Closes #123