### PR TITLE
fix: #128 scope agent blocks to prevent cross-contamination

### DIFF
--- a/src/lib/block-manager.ts
+++ b/src/lib/block-manager.ts
@@ -50,9 +50,11 @@ export class BlockManager {
 
   /**
    * Gets the registry key for a block
+   * Agent-specific blocks include agent name to prevent cross-agent collisions
    */
-  private getBlockKey(label: string, isShared: boolean): string {
-    return isShared ? `shared:${label}` : label;
+  private getBlockKey(label: string, isShared: boolean, agentName?: string): string {
+    if (isShared) return `shared:${label}`;
+    return agentName ? `${agentName}:${label}` : label;
   }
 
   /**
@@ -117,8 +119,8 @@ export class BlockManager {
   /**
    * Gets or creates an agent-specific block, updating in-place if content changed
    */
-  async getOrCreateAgentBlock(blockConfig: any, _agentName: string): Promise<string> {
-    const blockKey = this.getBlockKey(blockConfig.name, false);
+  async getOrCreateAgentBlock(blockConfig: any, agentName: string): Promise<string> {
+    const blockKey = this.getBlockKey(blockConfig.name, false, agentName);
     const contentHash = generateContentHash(blockConfig.value);
     const existing = this.blockRegistry.get(blockKey);
 
@@ -182,8 +184,9 @@ export class BlockManager {
   /**
    * Gets agent block ID by name if it exists
    */
-  getAgentBlockId(blockName: string): string | null {
-    const existing = this.blockRegistry.get(this.getBlockKey(blockName, false));
+  getAgentBlockId(blockName: string, agentName?: string): string | null {
+    const key = this.getBlockKey(blockName, false, agentName);
+    const existing = this.blockRegistry.get(key);
     return existing ? existing.id : null;
   }
 

--- a/src/lib/diff-analyzers.ts
+++ b/src/lib/diff-analyzers.ts
@@ -105,7 +105,7 @@ export async function analyzeBlockChanges(
     if (!currentBlockNames.has(blockConfig.name)) {
       let blockId = blockConfig.isShared
         ? blockManager.getSharedBlockId(blockConfig.name)
-        : blockManager.getAgentBlockId(blockConfig.name);
+        : blockManager.getAgentBlockId(blockConfig.name, agentName);
 
       // If block doesn't exist yet, create it (unless dry-run)
       if (!blockId && !blockConfig.isShared && blockConfig.description && agentName) {

--- a/tests/e2e/fixtures/fleet.yml
+++ b/tests/e2e/fixtures/fleet.yml
@@ -584,3 +584,47 @@ agents:
       - name: e2e-cleanup-folder
         files:
           - folder-files/doc1.txt
+
+  # ============================================================================
+  # BLOCK ISOLATION - Cross-Agent Contamination Prevention (#128)
+  # ============================================================================
+
+  # 33a: First agent with brand_identity block
+  - name: e2e-33-block-isolation-a
+    description: Agent A for block isolation test
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are Agent A for Alpha Corp.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    memory_blocks:
+      - name: brand_identity
+        description: Brand identity for this agent
+        limit: 2000
+        mutable: false
+        value: |
+          # Brand Identity: Alpha Corp
+          Company: Alpha Corp
+          Industry: Technology
+          Target: Enterprise customers
+
+  # 33b: Second agent with SAME block name but DIFFERENT value
+  - name: e2e-33-block-isolation-b
+    description: Agent B for block isolation test
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are Agent B for Beta Inc.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    memory_blocks:
+      - name: brand_identity
+        description: Brand identity for this agent
+        limit: 2000
+        mutable: false
+        value: |
+          # Brand Identity: Beta Inc
+          Company: Beta Inc
+          Industry: Healthcare
+          Target: Small businesses

--- a/tests/e2e/script.sh
+++ b/tests/e2e/script.sh
@@ -286,6 +286,8 @@ AGENTS=(
     "e2e-28-special-chars"
     "e2e-29-unicode-content"
     "e2e-30-cleanup-test"
+    "e2e-33-block-isolation-a"
+    "e2e-33-block-isolation-b"
 )
 
 for agent in "${AGENTS[@]}"; do

--- a/tests/e2e/tests/33-block-isolation.sh
+++ b/tests/e2e/tests/33-block-isolation.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# Test: Agent-specific blocks are isolated (not shared across agents)
+# Issue: #128
+# Bug: Blocks with same name were shared globally, causing cross-agent contamination
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT_A="e2e-33-block-isolation-a"
+AGENT_B="e2e-33-block-isolation-b"
+
+section "Test: Block Isolation Between Agents (#128)"
+
+# Setup
+preflight_check
+mkdir -p "$LOG_DIR"
+
+# Cleanup before test
+info "Cleaning up test agents..."
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+
+# Apply both agents (they have same block name but different values)
+section "Create Two Agents with Same Block Name"
+if $CLI apply -f "$FIXTURES/fleet.yml" --root "$FIXTURES" --agent "e2e-33-block-isolation" > $OUT 2>&1; then
+    pass "Applied fleet.yml for both isolation test agents"
+else
+    fail "Failed to apply fleet.yml"
+    cat $OUT
+    exit 1
+fi
+
+# Verify both agents exist
+if agent_exists "$AGENT_A"; then
+    pass "Agent A exists: $AGENT_A"
+else
+    fail "Agent A not created: $AGENT_A"
+    exit 1
+fi
+
+if agent_exists "$AGENT_B"; then
+    pass "Agent B exists: $AGENT_B"
+else
+    fail "Agent B not created: $AGENT_B"
+    exit 1
+fi
+
+# Verify Agent A has correct block value
+section "Verify Agent A Block Value"
+if $CLI get blocks --agent "$AGENT_A" > $OUT 2>&1; then
+    if output_contains "brand_identity"; then
+        pass "Agent A has brand_identity block"
+    else
+        fail "Agent A missing brand_identity block"
+        cat $OUT
+    fi
+fi
+
+# Send message to Agent A to print its block
+if $CLI send "$AGENT_A" "Print the exact content of your brand_identity memory block" > $OUT 2>&1; then
+    if output_contains "Alpha Corp"; then
+        pass "Agent A block contains 'Alpha Corp' (correct)"
+    else
+        if output_contains "Beta Inc"; then
+            fail "Agent A has Agent B's block content (CROSS-CONTAMINATION BUG)"
+        else
+            fail "Agent A block content unexpected"
+        fi
+        cat $OUT
+    fi
+else
+    fail "Failed to send message to Agent A"
+    cat $OUT
+fi
+
+# Verify Agent B has correct block value
+section "Verify Agent B Block Value"
+if $CLI get blocks --agent "$AGENT_B" > $OUT 2>&1; then
+    if output_contains "brand_identity"; then
+        pass "Agent B has brand_identity block"
+    else
+        fail "Agent B missing brand_identity block"
+        cat $OUT
+    fi
+fi
+
+# Send message to Agent B to print its block
+if $CLI send "$AGENT_B" "Print the exact content of your brand_identity memory block" > $OUT 2>&1; then
+    if output_contains "Beta Inc"; then
+        pass "Agent B block contains 'Beta Inc' (correct)"
+    else
+        if output_contains "Alpha Corp"; then
+            fail "Agent B has Agent A's block content (CROSS-CONTAMINATION BUG)"
+        else
+            fail "Agent B block content unexpected"
+        fi
+        cat $OUT
+    fi
+else
+    fail "Failed to send message to Agent B"
+    cat $OUT
+fi
+
+# Verify blocks are actually different IDs (not shared)
+section "Verify Blocks Are Separate Entities"
+$CLI get blocks --agent "$AGENT_A" -o json > "$LOG_DIR/blocks-a.json" 2>&1 || true
+$CLI get blocks --agent "$AGENT_B" -o json > "$LOG_DIR/blocks-b.json" 2>&1 || true
+
+# Extract brand_identity block IDs
+BLOCK_ID_A=$(grep -o '"id":"[^"]*"' "$LOG_DIR/blocks-a.json" | head -1 | cut -d'"' -f4)
+BLOCK_ID_B=$(grep -o '"id":"[^"]*"' "$LOG_DIR/blocks-b.json" | head -1 | cut -d'"' -f4)
+
+if [ -n "$BLOCK_ID_A" ] && [ -n "$BLOCK_ID_B" ]; then
+    if [ "$BLOCK_ID_A" != "$BLOCK_ID_B" ]; then
+        pass "Block IDs are different (not shared): A=$BLOCK_ID_A, B=$BLOCK_ID_B"
+    else
+        fail "Block IDs are SAME (shared incorrectly): $BLOCK_ID_A"
+    fi
+else
+    warn "Could not extract block IDs for comparison"
+fi
+
+# Cleanup
+section "Cleanup"
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+pass "Cleaned up test agents"
+
+# Summary
+print_summary


### PR DESCRIPTION
## Summary
- Agent-specific blocks now scoped by agent name in registry key
- Prevents cross-agent contamination when blocks have same name (e.g., `brand_identity`)
- Added e2e test `33-block-isolation` to verify isolation

Closes #128

## Test plan
- [x] Run `./tests/e2e/run-single.sh 33-block-isolation` - passes