### PR TITLE
fix: #130 protect critical memory tools from removal

### DIFF
--- a/src/lib/builtin-tools.ts
+++ b/src/lib/builtin-tools.ts
@@ -48,8 +48,22 @@ export const CORE_MEMORY_TOOLS = [
   'conversation_search',
   'memory_insert',
   'memory_replace',
-  'memory_rethink'
+  'memory_rethink',
+  'memory'
 ];
+
+/**
+ * Core tools that should never be removed from an agent.
+ * These are critical for agent memory and conversation operations.
+ * @see https://github.com/nouamanecodes/lettactl/issues/130
+ */
+export const PROTECTED_MEMORY_TOOLS = new Set([
+  'memory_insert',
+  'memory_replace',
+  'memory_rethink',
+  'memory',
+  'conversation_search'
+]);
 
 /**
  * File search tools auto-added when folders are attached

--- a/src/lib/diff-analyzers.ts
+++ b/src/lib/diff-analyzers.ts
@@ -4,6 +4,7 @@ import { normalizeResponse } from './response-normalizer';
 import { ToolDiff, BlockDiff, FolderDiff } from './diff-engine';
 import { FolderFileConfig } from '../types/fleet-config';
 import { warn } from './logger';
+import { PROTECTED_MEMORY_TOOLS } from './builtin-tools';
 
 // Helper to extract file name from FolderFileConfig (string or from_bucket object)
 function getFileName(fileConfig: FolderFileConfig): string {
@@ -77,7 +78,13 @@ export async function analyzeToolChanges(
         unchanged.push({ name: tool.name, id: tool.id });
       }
     } else {
-      toRemove.push({ name: tool.name, id: tool.id });
+      // Never remove protected memory tools - they're critical for agent operation
+      // See: https://github.com/nouamanecodes/lettactl/issues/130
+      if (PROTECTED_MEMORY_TOOLS.has(tool.name)) {
+        unchanged.push({ name: tool.name, id: tool.id });
+      } else {
+        toRemove.push({ name: tool.name, id: tool.id });
+      }
     }
   }
 

--- a/tests/e2e/fixtures/fleet-memory-tools-reduced.yml
+++ b/tests/e2e/fixtures/fleet-memory-tools-reduced.yml
@@ -1,0 +1,16 @@
+# Reduced config for protected memory tools test (#130)
+# Only specifies archival_memory_insert - memory tools should be PRESERVED
+# even though they're not listed here
+
+agents:
+  - name: e2e-memory-tools-test
+    description: Agent for testing protected memory tools
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with memory tools that should be protected.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    tools:
+      # Only specify non-memory tools - memory tools should still be preserved
+      - archival_memory_insert

--- a/tests/e2e/fixtures/fleet-memory-tools-test.yml
+++ b/tests/e2e/fixtures/fleet-memory-tools-test.yml
@@ -1,0 +1,20 @@
+# Test fixture for protected memory tools (#130)
+# Memory tools should NEVER be removed even when not in config
+
+agents:
+  - name: e2e-memory-tools-test
+    description: Agent for testing protected memory tools
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with memory tools that should be protected.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    tools:
+      # Explicitly include memory tools + a custom tool
+      - memory_insert
+      - memory_replace
+      - memory_rethink
+      - memory
+      - archival_memory_insert
+      - conversation_search

--- a/tests/e2e/tests/34-protected-memory-tools.sh
+++ b/tests/e2e/tests/34-protected-memory-tools.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Test: Protected memory tools are never removed (#130)
+# memory_insert, memory_replace, memory_rethink, memory should always be preserved
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT="e2e-memory-tools-test"
+section "Test: Protected Memory Tools (#130)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT"
+
+# Create agent with all memory tools
+info "Creating agent with memory tools..."
+$CLI apply -f "$FIXTURES/fleet-memory-tools-test.yml" > $OUT 2>&1
+agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
+
+# Verify all memory tools are attached
+$CLI get tools --agent "$AGENT" > $OUT 2>&1
+output_contains "memory_insert" && pass "memory_insert attached" || fail "memory_insert missing"
+output_contains "memory_replace" && pass "memory_replace attached" || fail "memory_replace missing"
+output_contains "memory_rethink" && pass "memory_rethink attached" || fail "memory_rethink missing"
+output_contains "memory" && pass "memory (omni) attached" || fail "memory (omni) missing"
+
+# Apply reduced config that doesn't include memory tools
+info "Applying config WITHOUT memory tools listed..."
+$CLI apply -f "$FIXTURES/fleet-memory-tools-reduced.yml" > $OUT 2>&1
+
+# All protected tools should remain (even without --force)
+$CLI get tools --agent "$AGENT" > $OUT 2>&1
+output_contains "memory_insert" && pass "memory_insert preserved" || fail "memory_insert incorrectly removed"
+output_contains "memory_replace" && pass "memory_replace preserved" || fail "memory_replace incorrectly removed"
+output_contains "memory_rethink" && pass "memory_rethink preserved" || fail "memory_rethink incorrectly removed"
+output_contains "memory" && pass "memory (omni) preserved" || fail "memory (omni) incorrectly removed"
+output_contains "conversation_search" && pass "conversation_search preserved" || fail "conversation_search incorrectly removed"
+
+# With --force: ALL protected tools should STILL stay
+info "Applying config with --force..."
+$CLI apply -f "$FIXTURES/fleet-memory-tools-reduced.yml" --force > $OUT 2>&1
+
+$CLI get tools --agent "$AGENT" > $OUT 2>&1
+output_contains "memory_insert" && pass "memory_insert preserved with --force" || fail "memory_insert removed with --force"
+output_contains "memory_replace" && pass "memory_replace preserved with --force" || fail "memory_replace removed with --force"
+output_contains "memory_rethink" && pass "memory_rethink preserved with --force" || fail "memory_rethink removed with --force"
+output_contains "memory" && pass "memory (omni) preserved with --force" || fail "memory (omni) removed with --force"
+output_contains "conversation_search" && pass "conversation_search preserved with --force" || fail "conversation_search removed with --force"
+
+delete_agent_if_exists "$AGENT"
+print_summary


### PR DESCRIPTION
## Summary
- Adds `PROTECTED_MEMORY_TOOLS` set containing critical tools that should never be removed
- Protected tools: `memory_insert`, `memory_replace`, `memory_rethink`, `memory`, `conversation_search`
- These tools are preserved even with `--force` flag

Closes #130