### PR TITLE
fix: #127 only mark files as updated when hash changes

### DIFF
--- a/src/lib/diff-analyzers.ts
+++ b/src/lib/diff-analyzers.ts
@@ -275,7 +275,9 @@ export async function analyzeFolderChanges(
               filesToAdd.push(getFileId(fileName));
             } else {
               // Exact match exists - check for content changes
-              if (currentHash && currentHash !== previousHash) {
+              // Only mark as updated if we have both hashes to compare
+              // See: https://github.com/nouamanecodes/lettactl/issues/127
+              if (currentHash && previousHash && currentHash !== previousHash) {
                 filesToUpdate.push(getFileId(fileName));
               }
               // Also clean up any _(N) variants if exact match exists

--- a/tests/e2e/fixtures/fleet-folder-files-added.yml
+++ b/tests/e2e/fixtures/fleet-folder-files-added.yml
@@ -1,0 +1,18 @@
+# Test fixture for folder file change detection (#127)
+# Adds a third file - only this should show as "Added"
+
+agents:
+  - name: e2e-folder-files-test
+    description: Agent for testing folder file change detection
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with folder files.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    folders:
+      - name: e2e-folder-test
+        files:
+          - folder-files/doc1.txt
+          - folder-files/doc2.txt
+          - folder-files/data.json

--- a/tests/e2e/fixtures/fleet-folder-files-test.yml
+++ b/tests/e2e/fixtures/fleet-folder-files-test.yml
@@ -1,0 +1,17 @@
+# Test fixture for folder file change detection (#127)
+# Tests that only changed files are marked as updated
+
+agents:
+  - name: e2e-folder-files-test
+    description: Agent for testing folder file change detection
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: Agent with folder files.
+    llm_config:
+      model: google_ai/gemini-2.5-pro
+      context_window: 32000
+    folders:
+      - name: e2e-folder-test
+        files:
+          - folder-files/doc1.txt
+          - folder-files/doc2.txt

--- a/tests/e2e/tests/35-folder-file-detection.sh
+++ b/tests/e2e/tests/35-folder-file-detection.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Test: Folder file change detection (#127)
+# Only changed files should be marked as updated, not all files
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT="e2e-folder-files-test"
+section "Test: Folder File Change Detection (#127)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT"
+
+# Create agent with 2 files
+info "Creating agent with doc1.txt and doc2.txt..."
+$CLI apply -f "$FIXTURES/fleet-folder-files-test.yml" --root "$FIXTURES" > $OUT 2>&1
+agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
+
+# Re-apply same config - should show no file changes
+info "Re-applying same config (should be idempotent)..."
+$CLI apply -f "$FIXTURES/fleet-folder-files-test.yml" --root "$FIXTURES" --dry-run > $OUT 2>&1
+if output_contains "Updated file" || output_contains "Added file"; then
+    fail "Idempotent re-apply incorrectly shows file changes"
+    cat $OUT
+else
+    pass "Idempotent re-apply shows no file changes"
+fi
+
+# Apply config with added file - only new file should show as added
+info "Applying config with additional file (data.json)..."
+$CLI apply -f "$FIXTURES/fleet-folder-files-added.yml" --root "$FIXTURES" --dry-run > $OUT 2>&1
+
+# Dry-run shows "+1 files" format, actual apply shows "Added file:"
+if output_contains "+1 files"; then
+    pass "New file detected in dry-run (+1 files)"
+else
+    fail "New file not detected in dry-run"
+    cat $OUT
+fi
+
+# Should NOT show any files as updated (would show "~X files" or "Updated file")
+if output_contains "Updated file" || grep -q "~[0-9]* files" $OUT; then
+    fail "Existing files incorrectly marked as updated"
+    cat $OUT
+else
+    pass "Existing files not marked as updated"
+fi
+
+# Actually apply the change
+info "Applying the change..."
+$CLI apply -f "$FIXTURES/fleet-folder-files-added.yml" --root "$FIXTURES" > $OUT 2>&1
+
+# Re-apply again - should be idempotent
+info "Re-applying after change (should be idempotent)..."
+$CLI apply -f "$FIXTURES/fleet-folder-files-added.yml" --root "$FIXTURES" --dry-run > $OUT 2>&1
+if output_contains "Updated file" || output_contains "Added file"; then
+    fail "Post-change re-apply incorrectly shows file changes"
+    cat $OUT
+else
+    pass "Post-change re-apply shows no file changes"
+fi
+
+delete_agent_if_exists "$AGENT"
+print_summary


### PR DESCRIPTION
## Summary
- Fixed file comparison logic to only mark files as "Updated" when both current and previous hashes exist
- Previously, files with no previous hash were incorrectly marked as updated
- This caused all files in a folder to show as "Updated" when adding a single new file

Closes #127