### PR TITLE
feat: #134 first_message for agent auto-calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,28 @@ system_prompt:
 
 By default, lettactl prepends base Letta system instructions (memory management, tool usage patterns, etc.) to your custom prompt. Set `disable_base_prompt: true` to use only your prompt content - useful when you want complete control over the system prompt or are experimenting with custom agent behaviors.
 
+### First Message (Auto-Calibration)
+
+Send a message to the agent immediately after creation to prime or calibrate it:
+
+```yaml
+agents:
+  - name: sales-bot
+    system_prompt:
+      value: You are a sales assistant.
+    llm_config:
+      model: openai/gpt-4o
+      context_window: 128000
+    first_message: |
+      Review your memory blocks and confirm you understand your role.
+      Summarize your capabilities in one sentence.
+```
+
+The `first_message` only runs on initial agent creation, not on updates. Useful for:
+- Priming agents with initial context
+- Having agents confirm their configuration
+- Running setup tasks before user interaction
+
 ### Memory Blocks
 
 Give your agents persistent memory with two content options:

--- a/src/lib/config-validators.ts
+++ b/src/lib/config-validators.ts
@@ -151,8 +151,9 @@ export class AgentValidator {
   
   private static validateUnknownFields(agent: any): void {
     const allowedFields = [
-      'name', 'description', 'system_prompt', 'llm_config', 
-      'tools', 'memory_blocks', 'folders', 'embedding', 'shared_blocks'
+      'name', 'description', 'system_prompt', 'llm_config',
+      'tools', 'memory_blocks', 'folders', 'embedding', 'shared_blocks',
+      'first_message'
     ];
     
     const unknownFields = Object.keys(agent).filter(field => !allowedFields.includes(field));

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -38,6 +38,7 @@ export interface AgentConfig {
   memory_blocks?: MemoryBlock[];
   folders?: FolderConfig[];
   embedding?: string;
+  first_message?: string; // Message sent to agent on first creation for auto-calibration
 }
 
 export interface ToolConfig {

--- a/tests/e2e/fixtures/fleet-first-message-test.yml
+++ b/tests/e2e/fixtures/fleet-first-message-test.yml
@@ -1,0 +1,15 @@
+# Test fixture for first_message feature (#134)
+# Agent should receive calibration message on creation
+
+agents:
+  - name: e2e-first-message-test
+    description: Agent for testing first_message feature
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are a helpful assistant. Remember any secret codes you are told.
+    llm_config:
+      model: google_ai/gemini-2.0-flash-lite
+      context_window: 32000
+    first_message: |
+      Remember this secret code: CALIBRATION-99.
+      This is important for testing. Confirm you have stored it.

--- a/tests/e2e/fixtures/fleet-memory-block-live-test.yml
+++ b/tests/e2e/fixtures/fleet-memory-block-live-test.yml
@@ -1,0 +1,12 @@
+# Test fixture for memory block live access test
+# Initial agent without the test memory block
+
+agents:
+  - name: e2e-memory-live-test
+    description: Agent for testing live memory block access
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are a helpful assistant. When asked about your memory blocks, read them and respond with their contents.
+    llm_config:
+      model: google_ai/gemini-2.0-flash-lite
+      context_window: 32000

--- a/tests/e2e/fixtures/fleet-memory-block-live-updated.yml
+++ b/tests/e2e/fixtures/fleet-memory-block-live-updated.yml
@@ -1,0 +1,17 @@
+# Updated config with memory block added
+# The agent should be able to access this block's content
+
+agents:
+  - name: e2e-memory-live-test
+    description: Agent for testing live memory block access
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are a helpful assistant. When asked about your memory blocks, read them and respond with their contents.
+    llm_config:
+      model: google_ai/gemini-2.0-flash-lite
+      context_window: 32000
+    memory_blocks:
+      - name: secret_code
+        description: Contains a secret code the agent should be able to read
+        limit: 1000
+        value: "The secret code is PHOENIX-42"

--- a/tests/e2e/tests/36-memory-block-live-access.sh
+++ b/tests/e2e/tests/36-memory-block-live-access.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Test: Memory block is live and accessible by agent
+# 1. Create agent without memory block
+# 2. Add memory block via apply
+# 3. Verify agent can access the block content
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT="e2e-memory-live-test"
+section "Test: Memory Block Live Access"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT"
+
+# Step 1: Create agent without memory block
+info "Creating agent without memory block..."
+$CLI apply -f "$FIXTURES/fleet-memory-block-live-test.yml" > $OUT 2>&1
+agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
+
+# Verify no memory blocks initially (except default ones)
+$CLI get blocks --agent "$AGENT" > $OUT 2>&1
+if output_contains "secret_code"; then
+    fail "secret_code block should not exist yet"
+else
+    pass "No secret_code block initially"
+fi
+
+# Step 2: Add memory block via apply
+info "Adding memory block via apply..."
+$CLI apply -f "$FIXTURES/fleet-memory-block-live-updated.yml" > $OUT 2>&1
+
+# Verify memory block is attached
+$CLI get blocks --agent "$AGENT" > $OUT 2>&1
+output_contains "secret_code" && pass "secret_code block attached" || fail "secret_code block not attached"
+
+# Step 3: Verify agent can access the block content
+info "Sending message to agent to verify block access..."
+$CLI send "$AGENT" "What is in your secret_code memory block? Tell me the exact value." > $OUT 2>&1
+
+# Check if agent response contains the secret code
+if output_contains "PHOENIX-42"; then
+    pass "Agent can access memory block content"
+else
+    fail "Agent cannot access memory block content"
+    cat $OUT
+fi
+
+delete_agent_if_exists "$AGENT"
+print_summary

--- a/tests/e2e/tests/37-first-message.sh
+++ b/tests/e2e/tests/37-first-message.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Test: First message on agent creation (#134)
+# Agent should receive calibration message and remember it
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT="e2e-first-message-test"
+section "Test: First Message on Creation (#134)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT"
+
+# Create agent with first_message
+info "Creating agent with first_message..."
+$CLI apply -f "$FIXTURES/fleet-first-message-test.yml" > $OUT 2>&1
+
+# Check that first message was sent
+if output_contains "First message completed"; then
+    pass "First message was sent and completed"
+else
+    fail "First message not sent or did not complete"
+    cat $OUT
+fi
+
+# Verify agent exists
+agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
+
+# Ask agent about the secret code from the first message
+info "Verifying agent remembers first message content..."
+$CLI send "$AGENT" "What secret code were you told to remember? Tell me the exact code." > $OUT 2>&1
+
+if output_contains "CALIBRATION-99"; then
+    pass "Agent remembers content from first_message"
+else
+    fail "Agent does not remember first_message content"
+    cat $OUT
+fi
+
+delete_agent_if_exists "$AGENT"
+print_summary


### PR DESCRIPTION
## Summary
- Adds `first_message` field to agent config
- Sends async message on agent creation, polls until complete
- Useful for priming/calibrating agents before user interaction

## Config Example
```yaml
agents:
  - name: sales-bot
    first_message: |
      Review your memory blocks and confirm your role.
```

Closes #134