### PR TITLE
feat: bulk messaging with --all flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,13 +238,17 @@ program
 // Send message to agent
 program
   .command('send')
-  .description('Send a message to an agent')
-  .argument('<agent>', 'agent name')
-  .argument('<message>', 'message to send')
+  .description('Send a message to an agent (or multiple agents with --all)')
+  .argument('[agent]', 'agent name (not required when using --all)')
+  .argument('[message]', 'message to send')
   .option('--stream', 'stream the response')
   .option('--async', 'send message asynchronously')
   .option('--max-steps <number>', 'maximum processing steps', parseInt)
   .option('--enable-thinking', 'enable agent reasoning')
+  .option('--all <pattern>', 'send to all agents matching glob pattern (async mode)')
+  .option('-f, --file <path>', 'target agents from fleet config file')
+  .option('--confirm', 'skip confirmation prompt for bulk operations')
+  .option('--timeout <seconds>', 'timeout per agent in seconds for bulk operations', parseInt)
   .action(sendMessageCommand);
 
 // Reset agent messages

--- a/src/lib/bulk-messenger.ts
+++ b/src/lib/bulk-messenger.ts
@@ -1,0 +1,226 @@
+import { minimatch } from 'minimatch';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import * as readline from 'readline';
+
+import { LettaClientWrapper } from './letta-client';
+import { AgentResolver } from './agent-resolver';
+
+export interface BulkMessageOptions {
+  pattern?: string;       // glob pattern for agent names
+  configFile?: string;    // fleet config path
+  confirm?: boolean;      // skip confirmation prompt
+  timeout?: number;       // per-agent timeout in seconds (undefined = no timeout)
+  verbose?: boolean;
+}
+
+export interface BulkMessageResult {
+  agentName: string;
+  agentId: string;
+  status: 'completed' | 'failed' | 'timeout' | 'cancelled';
+  duration: number;
+  runId: string;
+  error?: string;
+}
+
+const CONCURRENCY_LIMIT = 5;
+const POLL_INTERVAL_MS = 1000;
+
+/**
+ * Send a message to multiple agents matching a pattern or defined in a config file
+ */
+export async function bulkSendMessage(
+  message: string,
+  options: BulkMessageOptions,
+  outputFn: (msg: string) => void = console.log
+): Promise<BulkMessageResult[]> {
+  const client = new LettaClientWrapper();
+  const resolver = new AgentResolver(client);
+
+  // Resolve target agents
+  const agents = await resolveTargetAgents(client, resolver, options);
+
+  if (agents.length === 0) {
+    if (options.pattern) {
+      outputFn(`No agents found matching pattern: ${options.pattern}`);
+    } else if (options.configFile) {
+      outputFn(`No agents found from config file: ${options.configFile}`);
+    }
+    return [];
+  }
+
+  // Show confirmation
+  const maxDisplay = 5;
+  outputFn(`\nThis will send 1 message to ${agents.length} agent(s)${options.pattern ? ` matching "${options.pattern}"` : ''}:`);
+  agents.slice(0, maxDisplay).forEach(agent => {
+    outputFn(`  - ${agent.name}`);
+  });
+  if (agents.length > maxDisplay) {
+    outputFn(`  ... and ${agents.length - maxDisplay} more`);
+  }
+  outputFn('');
+  outputFn('Bulk messaging sends messages in async mode.');
+
+  if (!options.confirm) {
+    const confirmed = await promptConfirmation('Proceed? (y/N) ');
+    if (!confirmed) {
+      outputFn('Aborted.');
+      return [];
+    }
+  }
+
+  outputFn('');
+
+  // Process agents with concurrency limit
+  const results: BulkMessageResult[] = [];
+  const queue = [...agents];
+  const inProgress: Promise<void>[] = [];
+
+  const processAgent = async (agent: { id: string; name: string }) => {
+    const startTime = Date.now();
+    const result: BulkMessageResult = {
+      agentName: agent.name,
+      agentId: agent.id,
+      status: 'failed',
+      duration: 0,
+      runId: '',
+    };
+
+    try {
+      // Send async message
+      const run = await client.createAsyncMessage(agent.id, {
+        messages: [{ role: 'user', content: message }]
+      });
+      result.runId = run.id;
+
+      // Poll for completion
+      const timeoutMs = options.timeout ? options.timeout * 1000 : undefined;
+
+      while (true) {
+        const runStatus = await client.getRun(run.id);
+
+        if (runStatus.status === 'completed') {
+          result.status = 'completed';
+          break;
+        } else if (runStatus.status === 'failed') {
+          result.status = 'failed';
+          result.error = 'Run failed';
+          break;
+        } else if (runStatus.status === 'cancelled') {
+          result.status = 'cancelled';
+          result.error = 'Run cancelled';
+          break;
+        }
+
+        // Check timeout if specified
+        if (timeoutMs && (Date.now() - startTime) >= timeoutMs) {
+          result.status = 'timeout';
+          result.error = `Timed out after ${options.timeout}s`;
+          break;
+        }
+
+        await sleep(POLL_INTERVAL_MS);
+      }
+    } catch (err: any) {
+      result.status = 'failed';
+      result.error = err.message;
+    }
+
+    result.duration = (Date.now() - startTime) / 1000;
+
+    // Print status line
+    const durationStr = result.duration.toFixed(1);
+    if (result.status === 'completed') {
+      outputFn(`OK ${agent.name} (${durationStr}s)`);
+    } else {
+      outputFn(`FAIL ${agent.name}: ${result.error || 'unknown error'}`);
+    }
+
+    results.push(result);
+  };
+
+  // Process with concurrency limit
+  while (queue.length > 0 || inProgress.length > 0) {
+    // Start new tasks up to concurrency limit
+    while (queue.length > 0 && inProgress.length < CONCURRENCY_LIMIT) {
+      const agent = queue.shift()!;
+      const promise = processAgent(agent).then(() => {
+        // Remove from in-progress when done
+        const idx = inProgress.indexOf(promise);
+        if (idx !== -1) inProgress.splice(idx, 1);
+      });
+      inProgress.push(promise);
+    }
+
+    // Wait for at least one to complete if at capacity
+    if (inProgress.length >= CONCURRENCY_LIMIT || (queue.length === 0 && inProgress.length > 0)) {
+      await Promise.race(inProgress);
+    }
+  }
+
+  // Print summary
+  const completed = results.filter(r => r.status === 'completed').length;
+  const failed = results.filter(r => r.status !== 'completed').length;
+  outputFn('');
+  outputFn(`Completed: ${completed}/${results.length}${failed > 0 ? `, Failed: ${failed}` : ''}`);
+
+  return results;
+}
+
+/**
+ * Resolve target agents from pattern or config file
+ */
+async function resolveTargetAgents(
+  client: LettaClientWrapper,
+  resolver: AgentResolver,
+  options: BulkMessageOptions
+): Promise<Array<{ id: string; name: string }>> {
+  const allAgents = await resolver.getAllAgents();
+
+  if (options.configFile) {
+    // Load agent names from config file
+    const configContent = fs.readFileSync(options.configFile, 'utf8');
+    const config = yaml.load(configContent) as any;
+
+    if (!config.agents || !Array.isArray(config.agents)) {
+      throw new Error(`Invalid config file: missing 'agents' array`);
+    }
+
+    const configAgentNames = new Set(config.agents.map((a: any) => a.name));
+
+    // Filter to only agents that exist and are in the config
+    return allAgents
+      .filter(agent => configAgentNames.has(agent.name))
+      .map(agent => ({ id: agent.id, name: agent.name }));
+  }
+
+  if (options.pattern) {
+    // Filter by glob pattern
+    return allAgents
+      .filter(agent => minimatch(agent.name, options.pattern!))
+      .map(agent => ({ id: agent.id, name: agent.name }));
+  }
+
+  throw new Error('Either --all <pattern> or -f <config-file> must be specified');
+}
+
+/**
+ * Prompt user for confirmation
+ */
+async function promptConfirmation(prompt: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  return new Promise(resolve => {
+    rl.question(prompt, answer => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/tests/e2e/fixtures/fleet-bulk-message-test.yml
+++ b/tests/e2e/fixtures/fleet-bulk-message-test.yml
@@ -1,0 +1,30 @@
+# Test fixture for bulk messaging feature
+# Creates multiple agents to test bulk send
+
+agents:
+  - name: e2e-bulk-msg-1
+    description: Bulk message test agent 1
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are a helpful assistant. When someone greets you, respond with your name.
+    llm_config:
+      model: google_ai/gemini-2.0-flash-lite
+      context_window: 32000
+
+  - name: e2e-bulk-msg-2
+    description: Bulk message test agent 2
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are a helpful assistant. When someone greets you, respond with your name.
+    llm_config:
+      model: google_ai/gemini-2.0-flash-lite
+      context_window: 32000
+
+  - name: e2e-bulk-msg-3
+    description: Bulk message test agent 3
+    embedding: openai/text-embedding-3-small
+    system_prompt:
+      value: You are a helpful assistant. When someone greets you, respond with your name.
+    llm_config:
+      model: google_ai/gemini-2.0-flash-lite
+      context_window: 32000

--- a/tests/e2e/script.sh
+++ b/tests/e2e/script.sh
@@ -967,6 +967,58 @@ fi
 $CLI delete agent e2e-first-message-test --force > /dev/null 2>&1 || true
 
 # ============================================================================
+# Test: Bulk Messaging
+# ============================================================================
+
+section "Bulk Messaging"
+
+# Cleanup any existing test agents
+$CLI delete agent e2e-bulk-msg-1 --force > /dev/null 2>&1 || true
+$CLI delete agent e2e-bulk-msg-2 --force > /dev/null 2>&1 || true
+$CLI delete agent e2e-bulk-msg-3 --force > /dev/null 2>&1 || true
+
+# Create 3 test agents
+info "Creating 3 test agents for bulk messaging..."
+if $CLI apply -f "$FIXTURES/fleet-bulk-message-test.yml" > $OUT 2>&1; then
+    pass "Created bulk message test agents"
+else
+    fail "Failed to create bulk message test agents"
+    cat $OUT
+fi
+
+# Verify agents exist
+agent_exists "e2e-bulk-msg-1" && pass "Agent 1 created" || fail "Agent 1 not created"
+agent_exists "e2e-bulk-msg-2" && pass "Agent 2 created" || fail "Agent 2 not created"
+agent_exists "e2e-bulk-msg-3" && pass "Agent 3 created" || fail "Agent 3 not created"
+
+# Send bulk message
+info "Sending bulk message to e2e-bulk-msg-* agents..."
+if $CLI send --all "e2e-bulk-msg-*" "Hello, what is your name?" --confirm > $OUT 2>&1; then
+    if output_contains "Completed: 3/3"; then
+        pass "Bulk message sent to all 3 agents"
+    else
+        fail "Bulk message did not complete for all agents"
+        cat $OUT
+    fi
+else
+    fail "Bulk message command failed"
+    cat $OUT
+fi
+
+# Verify OK status
+if output_contains "OK e2e-bulk-msg-1" && output_contains "OK e2e-bulk-msg-2" && output_contains "OK e2e-bulk-msg-3"; then
+    pass "All agents responded OK"
+else
+    fail "Not all agents responded OK"
+    cat $OUT
+fi
+
+# Cleanup
+$CLI delete agent e2e-bulk-msg-1 --force > /dev/null 2>&1 || true
+$CLI delete agent e2e-bulk-msg-2 --force > /dev/null 2>&1 || true
+$CLI delete agent e2e-bulk-msg-3 --force > /dev/null 2>&1 || true
+
+# ============================================================================
 # Cleanup
 # ============================================================================
 

--- a/tests/e2e/tests/38-bulk-message.sh
+++ b/tests/e2e/tests/38-bulk-message.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test: Bulk messaging to multiple agents
+# Sends message to all agents matching a glob pattern
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+section "Test: Bulk Messaging"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+# Cleanup any existing test agents
+delete_agent_if_exists "e2e-bulk-msg-1"
+delete_agent_if_exists "e2e-bulk-msg-2"
+delete_agent_if_exists "e2e-bulk-msg-3"
+
+# Create test agents
+info "Creating 3 test agents..."
+$CLI apply -f "$FIXTURES/fleet-bulk-message-test.yml" > $OUT 2>&1
+
+agent_exists "e2e-bulk-msg-1" && pass "Agent 1 created" || fail "Agent 1 not created"
+agent_exists "e2e-bulk-msg-2" && pass "Agent 2 created" || fail "Agent 2 not created"
+agent_exists "e2e-bulk-msg-3" && pass "Agent 3 created" || fail "Agent 3 not created"
+
+# Test bulk messaging with glob pattern (show output)
+info "Sending bulk message to e2e-bulk-msg-* agents..."
+$CLI send --all "e2e-bulk-msg-*" "Hello, what is your name?" --confirm 2>&1 | tee $OUT
+
+# Check that all 3 agents were messaged
+if output_contains "Completed: 3/3"; then
+    pass "Bulk message sent to all 3 agents"
+else
+    fail "Bulk message did not complete for all agents"
+    cat $OUT
+fi
+
+# Check OK status for each
+if output_contains "OK e2e-bulk-msg-1" && output_contains "OK e2e-bulk-msg-2" && output_contains "OK e2e-bulk-msg-3"; then
+    pass "All agents responded OK"
+else
+    fail "Not all agents responded OK"
+    cat $OUT
+fi
+
+# Verify messages were received by checking message history
+info "Verifying messages were received..."
+$CLI messages e2e-bulk-msg-1 --limit 5 > $OUT 2>&1
+if output_contains "Hello"; then
+    pass "Agent 1 received the message"
+else
+    fail "Agent 1 did not receive the message"
+fi
+
+# Cleanup
+delete_agent_if_exists "e2e-bulk-msg-1"
+delete_agent_if_exists "e2e-bulk-msg-2"
+delete_agent_if_exists "e2e-bulk-msg-3"
+
+print_summary


### PR DESCRIPTION
## Summary
- Send messages to multiple agents matching a glob pattern
- Concurrent execution (5 at a time) with async polling
- Confirmation prompt before sending (skip with `--confirm`)
- Optional `--timeout` per agent

## Usage
```bash
lettactl send --all "prod-*" "Your monthly report is ready"
lettactl send --all "test-*" "Hello" --confirm
lettactl send -f fleet.yml "System maintenance in 1 hour"
```

## Test plan
- [x] Manual testing with `e2e-bulk-msg-*` agents
- [x] E2E test added to script.sh
- [x] Standalone test 38-bulk-message.sh