### PR TITLE
fix: #137 protect file tools from removal

### DIFF
--- a/src/lib/builtin-tools.ts
+++ b/src/lib/builtin-tools.ts
@@ -54,15 +54,19 @@ export const CORE_MEMORY_TOOLS = [
 
 /**
  * Core tools that should never be removed from an agent.
- * These are critical for agent memory and conversation operations.
+ * These are critical for agent memory, conversation, and file operations.
  * @see https://github.com/nouamanecodes/lettactl/issues/130
+ * @see https://github.com/nouamanecodes/lettactl/issues/137
  */
 export const PROTECTED_MEMORY_TOOLS = new Set([
   'memory_insert',
   'memory_replace',
   'memory_rethink',
   'memory',
-  'conversation_search'
+  'conversation_search',
+  'open_files',
+  'grep_files',
+  'semantic_search_files'
 ]);
 
 /**

--- a/tests/e2e/fixtures/fleet-memory-tools-test.yml
+++ b/tests/e2e/fixtures/fleet-memory-tools-test.yml
@@ -1,20 +1,24 @@
-# Test fixture for protected memory tools (#130)
-# Memory tools should NEVER be removed even when not in config
+# Test fixture for protected memory and file tools (#130, #137)
+# These tools should NEVER be removed even when not in config
 
 agents:
   - name: e2e-memory-tools-test
-    description: Agent for testing protected memory tools
+    description: Agent for testing protected memory and file tools
     embedding: openai/text-embedding-3-small
     system_prompt:
-      value: Agent with memory tools that should be protected.
+      value: Agent with memory and file tools that should be protected.
     llm_config:
       model: google_ai/gemini-2.5-pro
       context_window: 32000
     tools:
-      # Explicitly include memory tools + a custom tool
+      # Memory tools
       - memory_insert
       - memory_replace
       - memory_rethink
       - memory
       - archival_memory_insert
       - conversation_search
+      # File tools (#137)
+      - open_files
+      - grep_files
+      - semantic_search_files

--- a/tests/e2e/script.sh
+++ b/tests/e2e/script.sh
@@ -726,16 +726,16 @@ fi
 $CLI delete agent e2e-force-test --force > /dev/null 2>&1 || true
 
 # ============================================================================
-# Test: Protected Memory Tools (#130)
+# Test: Protected Memory and File Tools (#130, #137)
 # ============================================================================
 
-section "Protected Memory Tools (#130)"
+section "Protected Memory and File Tools (#130, #137)"
 
 # Cleanup any existing test agent
 $CLI delete agent e2e-memory-tools-test --force > /dev/null 2>&1 || true
 
-# Create agent with all memory tools
-info "Creating agent with memory tools..."
+# Create agent with all memory and file tools
+info "Creating agent with memory and file tools..."
 if $CLI apply -f "$FIXTURES/fleet-memory-tools-test.yml" > $OUT 2>&1; then
     pass "Created memory tools test agent"
 else
@@ -760,9 +760,20 @@ if output_contains "memory_rethink"; then
 else
     fail "memory_rethink not attached"
 fi
+# Verify file tools are attached (#137)
+if output_contains "open_files"; then
+    pass "open_files attached"
+else
+    fail "open_files not attached"
+fi
+if output_contains "grep_files"; then
+    pass "grep_files attached"
+else
+    fail "grep_files not attached"
+fi
 
-# Apply reduced config that doesn't list memory tools (no --force)
-info "Applying config WITHOUT memory tools listed (no --force)..."
+# Apply reduced config that doesn't list memory/file tools (no --force)
+info "Applying config WITHOUT memory/file tools listed (no --force)..."
 $CLI apply -f "$FIXTURES/fleet-memory-tools-reduced.yml" > $OUT 2>&1
 
 # All protected tools should remain
@@ -786,6 +797,17 @@ if output_contains "conversation_search"; then
     pass "conversation_search preserved"
 else
     fail "conversation_search incorrectly removed"
+fi
+# File tools should also be preserved (#137)
+if output_contains "open_files"; then
+    pass "open_files preserved"
+else
+    fail "open_files incorrectly removed"
+fi
+if output_contains "grep_files"; then
+    pass "grep_files preserved"
+else
+    fail "grep_files incorrectly removed"
 fi
 
 # With --force: ALL protected tools should STILL stay
@@ -812,6 +834,17 @@ if output_contains "conversation_search"; then
     pass "conversation_search preserved with --force"
 else
     fail "conversation_search removed despite being protected"
+fi
+# File tools with --force (#137)
+if output_contains "open_files"; then
+    pass "open_files preserved with --force"
+else
+    fail "open_files removed despite being protected"
+fi
+if output_contains "grep_files"; then
+    pass "grep_files preserved with --force"
+else
+    fail "grep_files removed despite being protected"
 fi
 
 # Cleanup

--- a/tests/e2e/tests/34-protected-memory-tools.sh
+++ b/tests/e2e/tests/34-protected-memory-tools.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-# Test: Protected memory tools are never removed (#130)
-# memory_insert, memory_replace, memory_rethink, memory should always be preserved
+# Test: Protected memory and file tools are never removed (#130, #137)
+# memory_insert, memory_replace, memory_rethink, memory, open_files, grep_files should always be preserved
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
 
 AGENT="e2e-memory-tools-test"
-section "Test: Protected Memory Tools (#130)"
+section "Test: Protected Memory and File Tools (#130, #137)"
 preflight_check
 mkdir -p "$LOG_DIR"
 
 delete_agent_if_exists "$AGENT"
 
-# Create agent with all memory tools
-info "Creating agent with memory tools..."
+# Create agent with all memory and file tools
+info "Creating agent with memory and file tools..."
 $CLI apply -f "$FIXTURES/fleet-memory-tools-test.yml" > $OUT 2>&1
 agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
 
@@ -23,9 +23,12 @@ output_contains "memory_insert" && pass "memory_insert attached" || fail "memory
 output_contains "memory_replace" && pass "memory_replace attached" || fail "memory_replace missing"
 output_contains "memory_rethink" && pass "memory_rethink attached" || fail "memory_rethink missing"
 output_contains "memory" && pass "memory (omni) attached" || fail "memory (omni) missing"
+# File tools (#137)
+output_contains "open_files" && pass "open_files attached" || fail "open_files missing"
+output_contains "grep_files" && pass "grep_files attached" || fail "grep_files missing"
 
-# Apply reduced config that doesn't include memory tools
-info "Applying config WITHOUT memory tools listed..."
+# Apply reduced config that doesn't include memory/file tools
+info "Applying config WITHOUT memory/file tools listed..."
 $CLI apply -f "$FIXTURES/fleet-memory-tools-reduced.yml" > $OUT 2>&1
 
 # All protected tools should remain (even without --force)
@@ -35,6 +38,9 @@ output_contains "memory_replace" && pass "memory_replace preserved" || fail "mem
 output_contains "memory_rethink" && pass "memory_rethink preserved" || fail "memory_rethink incorrectly removed"
 output_contains "memory" && pass "memory (omni) preserved" || fail "memory (omni) incorrectly removed"
 output_contains "conversation_search" && pass "conversation_search preserved" || fail "conversation_search incorrectly removed"
+# File tools (#137)
+output_contains "open_files" && pass "open_files preserved" || fail "open_files incorrectly removed"
+output_contains "grep_files" && pass "grep_files preserved" || fail "grep_files incorrectly removed"
 
 # With --force: ALL protected tools should STILL stay
 info "Applying config with --force..."
@@ -46,6 +52,9 @@ output_contains "memory_replace" && pass "memory_replace preserved with --force"
 output_contains "memory_rethink" && pass "memory_rethink preserved with --force" || fail "memory_rethink removed with --force"
 output_contains "memory" && pass "memory (omni) preserved with --force" || fail "memory (omni) removed with --force"
 output_contains "conversation_search" && pass "conversation_search preserved with --force" || fail "conversation_search removed with --force"
+# File tools with --force (#137)
+output_contains "open_files" && pass "open_files preserved with --force" || fail "open_files removed with --force"
+output_contains "grep_files" && pass "grep_files preserved with --force" || fail "grep_files removed with --force"
 
 delete_agent_if_exists "$AGENT"
 print_summary


### PR DESCRIPTION
## Summary
- Add `open_files`, `grep_files`, `semantic_search_files` to protected tools set
- These tools will no longer be removed during apply, even with `--force`

## Test plan
- [x] Updated test fixture to include file tools
- [x] Updated standalone test 34-protected-memory-tools.sh
- [x] Updated main script.sh test section