### PR TITLE
feat: make send command async by default with polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,17 @@ lettactl import my-agent-backup.json \
 # List agent conversation history
 lettactl messages my-agent --limit 10
 
-# Send a message to an agent
+# Send a message to an agent (async by default, polls until complete)
 lettactl send my-agent "Hello, how are you?"
 
 # Send with streaming response
 lettactl send my-agent "Tell me about Tokyo" --stream
 
-# Send asynchronous message
-lettactl send my-agent "Plan a 7-day itinerary" --async
+# Send and return immediately (fire-and-forget, prints run ID)
+lettactl send my-agent "Plan a 7-day itinerary" --no-wait
+
+# Send synchronously (old behavior, may timeout on long responses)
+lettactl send my-agent "Quick question" --sync
 
 # Reset agent's conversation history
 lettactl reset-messages my-agent --add-default

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -1,11 +1,12 @@
 import { LettaClientWrapper } from '../lib/letta-client';
 import { AgentResolver } from '../lib/agent-resolver';
-import { normalizeResponse } from '../lib/response-normalizer';
+import { normalizeResponse, sleep } from '../lib/response-normalizer';
 import { OutputFormatter } from '../lib/ux/output-formatter';
 import { createSpinner, getSpinnerEnabled } from '../lib/ux/spinner';
 import { sendMessageToAgent } from '../lib/message-sender';
 import { bulkSendMessage } from '../lib/bulk-messenger';
 import { log, output, error } from '../lib/logger';
+import { Run } from '../types/run';
 
 /**
  * Safely extracts content from different message types
@@ -108,13 +109,15 @@ export async function sendMessageCommand(
   messageOrUndefined: string | undefined,
   options: {
     stream?: boolean;
-    async?: boolean;
+    sync?: boolean;
+    noWait?: boolean;
     maxSteps?: number;
     enableThinking?: boolean;
     all?: string;
     file?: string;
     confirm?: boolean;
     timeout?: number;
+    output?: string;
   },
   command: any
 ) {
@@ -154,43 +157,32 @@ export async function sendMessageCommand(
   try {
     const client = new LettaClientWrapper();
     const resolver = new AgentResolver(client);
+    const spinnerEnabled = getSpinnerEnabled(command);
 
     // Find the agent
     const { agent } = await resolver.findAgentByName(agentName);
-    
+
     if (verbose) {
       output(`Sending message to agent: ${agent.name} (${agent.id})`);
       output(`Message: ${message}`);
       output(`Options: ${JSON.stringify(options, null, 2)}`);
     }
 
-    // Use the modular message sender
-    const result = await sendMessageToAgent(client, agent.id, message, options);
-    
-    if (!result.success) {
-      throw new Error(result.error);
-    }
+    // Streaming mode
+    if (options.stream) {
+      const result = await sendMessageToAgent(client, agent.id, message, { stream: true });
 
-    const response = result.response;
-
-    if (options.async) {
-      // Async message
-      output(`Message sent asynchronously. Run ID: ${response.id}`);
-      output(`Status: ${response.status}`);
-      if (verbose) {
-        output('Full response:', JSON.stringify(response, null, 2));
+      if (!result.success) {
+        throw new Error(result.error);
       }
-    } else if (options.stream) {
-      // Streaming message
+
       output(`Streaming response from ${agent.name}:`);
       output('---');
-      
-      // Handle streaming response 
+
       try {
-        for await (const chunk of response) {
-          // Use type assertion to handle dynamic chunk types
+        for await (const chunk of result.response) {
           const chunkData = chunk as any;
-          
+
           if (chunkData.type === 'message_delta' && chunkData.content) {
             process.stdout.write(chunkData.content);
           } else if (chunkData.text) {
@@ -198,74 +190,223 @@ export async function sendMessageCommand(
           } else if (typeof chunk === 'string') {
             process.stdout.write(chunk);
           } else {
-            // For debugging: show chunk structure
             const content = getMessageContent(chunkData);
             if (content) {
               process.stdout.write(content);
             }
           }
         }
-        output(); // New line after streaming
+        output();
       } catch (streamError) {
         output('\n[Streaming completed]');
       }
       output('---');
-      output('Stream completed');
-    } else {
-      // Regular synchronous message
-      const spinnerEnabled = getSpinnerEnabled(command);
+      return;
+    }
+
+    // Sync mode (old behavior) - blocks until response
+    if (options.sync) {
       const spinner = createSpinner(`Sending message to ${agent.name}...`, spinnerEnabled).start();
-      
-      try {
-        spinner.succeed(`Response from ${agent.name}:`);
-      } catch (error) {
+
+      const result = await sendMessageToAgent(client, agent.id, message, {
+        maxSteps: options.maxSteps,
+        enableThinking: options.enableThinking,
+      });
+
+      if (!result.success) {
         spinner.fail(`Failed to send message to ${agent.name}`);
-        throw error;
+        throw new Error(result.error);
       }
-      output('---');
 
-      if (response.messages && response.messages.length > 0) {
-        // Filter for assistant messages, excluding system alerts and internal messages
-        const assistantMessages = response.messages.filter((msg: any) =>
-          msg.message_type === 'assistant_message' ||
-          msg.type === 'assistant_message' ||
-          (msg.role === 'assistant' && !msg.type?.includes('system'))
-        );
+      spinner.succeed(`Response from ${agent.name}:`);
+      displaySyncResponse(result.response, verbose, options.output);
+      return;
+    }
 
-        if (assistantMessages.length > 0) {
-          // Show the last assistant message
-          const lastAssistant = assistantMessages[assistantMessages.length - 1];
-          const messageContent = getMessageContent(lastAssistant);
-          if (messageContent) {
-            output(messageContent);
-          } else {
-            output(JSON.stringify(lastAssistant, null, 2));
-          }
-        } else {
-          // Fallback: show last message if no assistant messages found
-          const lastMessage = response.messages[response.messages.length - 1];
-          const messageContent = getMessageContent(lastMessage);
-          if (messageContent) {
-            output(messageContent);
-          } else {
-            output(JSON.stringify(lastMessage, null, 2));
-          }
+    // Default: Async mode with polling (runs indefinitely until complete)
+    const spinner = createSpinner(`Sending message to ${agent.name}...`, spinnerEnabled).start();
+
+    // Send async message
+    const result = await sendMessageToAgent(client, agent.id, message, {
+      async: true,
+      maxSteps: options.maxSteps,
+      enableThinking: options.enableThinking,
+    });
+
+    if (!result.success) {
+      spinner.fail(`Failed to send message to ${agent.name}`);
+      throw new Error(result.error);
+    }
+
+    const runId = result.response.id;
+
+    // If --no-wait, just return the run ID
+    if (options.noWait) {
+      spinner.succeed(`Message sent. Run ID: ${runId}`);
+      output(`Check status with: lettactl run ${runId}`);
+      return;
+    }
+
+    // Poll for completion
+    spinner.text = `Processing message... (run: ${runId.slice(0, 8)}...)`;
+
+    const pollInterval = 3000; // 3 seconds
+    let lastStatus = '';
+    const startTime = Date.now();
+
+    while (true) {
+      const run = await client.getRun(runId) as Run;
+
+      // Update spinner with status changes
+      if (run.status !== lastStatus) {
+        lastStatus = run.status;
+        if (verbose) {
+          log(`Status changed to: ${run.status}`);
         }
-      } else {
-        output('[No response content]');
       }
 
-      output('---');
-      
-      if (verbose && response.usage) {
-        output(`Tokens used: ${response.usage.total_tokens || 'unknown'}`);
-        output(`Stop reason: ${response.stop_reason || 'unknown'}`);
+      // Update spinner text with elapsed time
+      const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
+      const timeStr = formatElapsedTime(elapsedSeconds);
+      spinner.text = `${agent.name} is thinking... ${timeStr} (${run.status})`;
+
+      if (run.status === 'completed') {
+        spinner.succeed(`Response from ${agent.name} (${timeStr}):`);
+        await displayRunMessages(client, runId, verbose, options.output);
+        return;
       }
+
+      if (run.status === 'failed') {
+        spinner.fail(`Message failed after ${timeStr}`);
+        if (run.stop_reason) {
+          error(`Reason: ${run.stop_reason}`);
+        }
+        process.exit(1);
+      }
+
+      if (run.status === 'cancelled') {
+        spinner.fail(`Message was cancelled after ${timeStr}`);
+        process.exit(1);
+      }
+
+      await sleep(pollInterval);
     }
 
   } catch (err: any) {
     error(`Failed to send message to agent ${agentName}:`, err.message);
     throw err;
+  }
+}
+
+/**
+ * Format elapsed time as human-readable string
+ */
+function formatElapsedTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}m ${secs}s`;
+}
+
+/**
+ * Display response from sync message
+ */
+function displaySyncResponse(response: any, verbose: boolean, outputFormat?: string): void {
+  if (outputFormat === 'json') {
+    output(JSON.stringify(response, null, 2));
+    return;
+  }
+
+  output('---');
+
+  if (response.messages && response.messages.length > 0) {
+    const assistantMessages = response.messages.filter((msg: any) =>
+      msg.message_type === 'assistant_message' ||
+      msg.type === 'assistant_message' ||
+      (msg.role === 'assistant' && !msg.type?.includes('system'))
+    );
+
+    if (assistantMessages.length > 0) {
+      const lastAssistant = assistantMessages[assistantMessages.length - 1];
+      const messageContent = getMessageContent(lastAssistant);
+      if (messageContent) {
+        output(messageContent);
+      } else {
+        output(JSON.stringify(lastAssistant, null, 2));
+      }
+    } else {
+      const lastMessage = response.messages[response.messages.length - 1];
+      const messageContent = getMessageContent(lastMessage);
+      if (messageContent) {
+        output(messageContent);
+      } else {
+        output(JSON.stringify(lastMessage, null, 2));
+      }
+    }
+  } else {
+    output('[No response content]');
+  }
+
+  output('---');
+
+  if (verbose && response.usage) {
+    output(`Tokens used: ${response.usage.total_tokens || 'unknown'}`);
+    output(`Stop reason: ${response.stop_reason || 'unknown'}`);
+  }
+}
+
+/**
+ * Display messages from a completed run
+ */
+async function displayRunMessages(client: LettaClientWrapper, runId: string, verbose: boolean, outputFormat?: string): Promise<void> {
+  const messagesResponse = await client.getRunMessages(runId);
+  const messages = normalizeResponse(messagesResponse);
+
+  if (outputFormat === 'json') {
+    output(JSON.stringify(messages, null, 2));
+    return;
+  }
+
+  output('---');
+
+  if (messages.length === 0) {
+    output('[No response content]');
+    output('---');
+    return;
+  }
+
+  // Find assistant messages
+  const assistantMessages = messages.filter((msg: any) =>
+    msg.message_type === 'assistant_message' ||
+    msg.type === 'assistant_message' ||
+    (msg.role === 'assistant' && !msg.type?.includes('system'))
+  );
+
+  if (assistantMessages.length > 0) {
+    // Show all assistant messages from this run
+    for (const msg of assistantMessages) {
+      const content = getMessageContent(msg);
+      if (content) {
+        output(content);
+      }
+    }
+  } else {
+    // Fallback: show last message
+    const lastMessage = messages[messages.length - 1];
+    const content = getMessageContent(lastMessage);
+    if (content) {
+      output(content);
+    } else {
+      output(JSON.stringify(lastMessage, null, 2));
+    }
+  }
+
+  output('---');
+
+  if (verbose) {
+    output(`Total messages in run: ${messages.length}`);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,14 +241,16 @@ program
   .description('Send a message to an agent (or multiple agents with --all)')
   .argument('[agent]', 'agent name (not required when using --all)')
   .argument('[message]', 'message to send')
-  .option('--stream', 'stream the response')
-  .option('--async', 'send message asynchronously')
+  .option('--stream', 'stream the response in real-time')
+  .option('--sync', 'use synchronous mode (blocks until response, may timeout)')
+  .option('--no-wait', 'send async and return immediately (prints run ID)')
   .option('--max-steps <number>', 'maximum processing steps', parseInt)
   .option('--enable-thinking', 'enable agent reasoning')
-  .option('--all <pattern>', 'send to all agents matching glob pattern (async mode)')
+  .option('--all <pattern>', 'send to all agents matching glob pattern')
   .option('-f, --file <path>', 'target agents from fleet config file')
   .option('--confirm', 'skip confirmation prompt for bulk operations')
   .option('--timeout <seconds>', 'timeout per agent in seconds for bulk operations', parseInt)
+  .option('-o, --output <format>', 'output format (table|json)', 'table')
   .action(sendMessageCommand);
 
 // Reset agent messages


### PR DESCRIPTION
## Summary
- Default `send` command now uses async mode with polling (no more timeouts)
- Added `--sync` flag for old blocking behavior
- Added `--no-wait` flag for fire-and-forget mode
- Polls every 3 seconds with elapsed time display

Closes #140