### PR TITLE
fix: skip folder processing when none configured

### DIFF
--- a/skills/release-cycle/SKILL.md
+++ b/skills/release-cycle/SKILL.md
@@ -84,7 +84,7 @@ git commit -m "build: bump v0.9.2" --no-verify
 
 Rules:
 - 5-7 words max
-- No author attribution
+- NO Co-Authored-By or any author attribution
 - No emojis
 - Lowercase start
 - Run `pnpm test` before committing

--- a/src/lib/apply-helpers.ts
+++ b/src/lib/apply-helpers.ts
@@ -123,6 +123,15 @@ export async function processFolders(
 ): Promise<Map<string, string>> {
   const createdFolders = new Map<string, string>();
 
+  // Check if any agents have folders - skip API call if not
+  const hasAnyFolders = config.agents.some((agent: any) =>
+    agent.folders && agent.folders.length > 0
+  );
+  if (!hasAnyFolders) {
+    if (verbose) log('No folders configured, skipping folder processing');
+    return createdFolders;
+  }
+
   if (verbose) log('Processing folders...');
   const foldersResponse = await client.listFolders();
   const existingFolders = Array.isArray(foldersResponse) ? foldersResponse : (foldersResponse as any).items || [];

--- a/tests/e2e/fixtures/fleet-no-folders-test.yml
+++ b/tests/e2e/fixtures/fleet-no-folders-test.yml
@@ -1,0 +1,72 @@
+# Test: Apply with tools and memory blocks but NO folders
+# Regression test for issue #146 - folders hang on processing
+
+agents:
+  # Test Agent 1
+  - name: e2e-39-agent-one
+    description: "Test agent one for no-folders regression test"
+
+    llm_config:
+      model: "openai/gpt-4o-mini"
+      context_window: 32000
+
+    embedding: "openai/text-embedding-3-small"
+
+    system_prompt:
+      from_file: "system-prompt.txt"
+
+    # Auto-discover tools from tools/ directory
+    tools:
+      - tools/*
+
+    memory_blocks:
+      - name: persona
+        description: "Who I am - my personality, background, daily routine, goals"
+        limit: 3000
+        from_file: "block-content.txt"
+
+      - name: relationships
+        description: "People I know and my feelings about them"
+        limit: 2000
+        value: "I don't know anyone yet. Looking forward to making friends!"
+
+      - name: recent-events
+        description: "What happened recently that I should remember"
+        limit: 2000
+        value: "Just started my day. Time to see what happens!"
+
+  # Test Agent 2
+  - name: e2e-39-agent-two
+    description: "Test agent two for no-folders regression test"
+
+    llm_config:
+      model: "openai/gpt-4o-mini"
+      context_window: 32000
+
+    embedding: "openai/text-embedding-3-small"
+
+    system_prompt:
+      from_file: "system-prompt.txt"
+
+    # Auto-discover tools from tools/ directory
+    tools:
+      - tools/*
+
+    memory_blocks:
+      - name: persona
+        description: "Who I am - my personality, background, daily routine, goals"
+        limit: 3000
+        value: |
+          I'm a test agent for e2e testing purposes.
+          I help verify that lettactl works correctly.
+          I enjoy running tests and finding bugs.
+
+      - name: relationships
+        description: "People I know and my feelings about them"
+        limit: 2000
+        value: "I don't know anyone yet. Looking forward to meeting new people!"
+
+      - name: recent-events
+        description: "What happened recently that I should remember"
+        limit: 2000
+        value: "Just started running tests. Let's see how it goes!"

--- a/tests/e2e/fixtures/tools/end_conversation.py
+++ b/tests/e2e/fixtures/tools/end_conversation.py
@@ -1,0 +1,8 @@
+def end_conversation() -> str:
+    """
+    End the current conversation.
+
+    Returns:
+        Confirmation message
+    """
+    return "Conversation ended."

--- a/tests/e2e/fixtures/tools/look_around.py
+++ b/tests/e2e/fixtures/tools/look_around.py
@@ -1,0 +1,8 @@
+def look_around() -> str:
+    """
+    Look around the current location.
+
+    Returns:
+        Description of surroundings
+    """
+    return "You see nothing special."

--- a/tests/e2e/fixtures/tools/move_to_agent.py
+++ b/tests/e2e/fixtures/tools/move_to_agent.py
@@ -1,0 +1,11 @@
+def move_to_agent(agent_name: str) -> str:
+    """
+    Move to another agent's location.
+
+    Args:
+        agent_name: Name of the agent to move to
+
+    Returns:
+        Result of the movement
+    """
+    return f"Moved to {agent_name}."

--- a/tests/e2e/fixtures/tools/move_to_location.py
+++ b/tests/e2e/fixtures/tools/move_to_location.py
@@ -1,0 +1,11 @@
+def move_to_location(location: str) -> str:
+    """
+    Move to a specified location.
+
+    Args:
+        location: Name of the location to move to
+
+    Returns:
+        Result of the movement
+    """
+    return f"Moved to {location}."

--- a/tests/e2e/fixtures/tools/start_conversation.py
+++ b/tests/e2e/fixtures/tools/start_conversation.py
@@ -1,0 +1,12 @@
+def start_conversation(agent_name: str, message: str) -> str:
+    """
+    Start a conversation with another agent.
+
+    Args:
+        agent_name: Name of the agent to talk to
+        message: Opening message
+
+    Returns:
+        Response from the other agent
+    """
+    return f"Started conversation with {agent_name}: {message}"

--- a/tests/e2e/fixtures/tools/wander.py
+++ b/tests/e2e/fixtures/tools/wander.py
@@ -1,0 +1,8 @@
+def wander() -> str:
+    """
+    Wander around randomly.
+
+    Returns:
+        Description of where you wandered to
+    """
+    return "You wandered to a new location."

--- a/tests/e2e/fixtures/tools/wave_at.py
+++ b/tests/e2e/fixtures/tools/wave_at.py
@@ -1,0 +1,11 @@
+def wave_at(agent_name: str) -> str:
+    """
+    Wave at another agent.
+
+    Args:
+        agent_name: Name of the agent to wave at
+
+    Returns:
+        Result of waving
+    """
+    return f"You waved at {agent_name}."

--- a/tests/e2e/tests/39-no-folders.sh
+++ b/tests/e2e/tests/39-no-folders.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Test: Apply with tools and memory blocks but NO folders
+# Regression test for issue #146 - folders hang on processing
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT1="e2e-39-agent-one"
+AGENT2="e2e-39-agent-two"
+section "Test: No Folders (Issue #146 Regression)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT1"
+delete_agent_if_exists "$AGENT2"
+
+# Apply config with tools/* glob and memory blocks but NO folders
+# Before fix: this would hang indefinitely on "Processing folders..."
+# After fix: should complete quickly
+$CLI apply -f "$FIXTURES/fleet-no-folders-test.yml" --root "$FIXTURES" > $OUT 2>&1
+agent_exists "$AGENT1" && pass "Agent 1 created" || fail "Agent 1 not created"
+agent_exists "$AGENT2" && pass "Agent 2 created" || fail "Agent 2 not created"
+
+# Verify tools were attached
+$CLI describe agent "$AGENT1" -o json > $OUT 2>&1
+output_contains "end_conversation" && pass "Tools attached to agent 1" || fail "Tools not attached to agent 1"
+
+# Verify memory blocks exist
+output_contains "persona" && pass "Memory blocks created for agent 1" || fail "Memory blocks not created for agent 1"
+
+# Cleanup
+delete_agent_if_exists "$AGENT1"
+delete_agent_if_exists "$AGENT2"
+print_summary


### PR DESCRIPTION
## Summary
- Fixes #146 - apply command hanging on "Processing folders..." even when no folders defined
- Added early return in `processFolders()` to skip `client.listFolders()` API call when no agents have folders

## Test plan
- [x] Unit tests pass
- [x] E2E test `39-no-folders.sh` added and passing