### PR TITLE
feat: tag blocks as shared/unique/orphaned in all views

### DIFF
--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -190,6 +190,7 @@ async function describeBlock(
       created: block.created_at,
       attachedAgents: attachedAgents.map((a: any) => ({ name: a.name, id: a.id })),
       valuePreview: block.value?.length > 500 ? block.value.substring(0, 500) + '...' : block.value,
+      agentCount: attachedAgents.length,
     };
 
     output(displayBlockDetails(displayData));

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -167,11 +167,9 @@ async function getBlocks(
       blockList = await client.listBlocks();
     }
 
-    // Always compute agent counts for block listing (unless agent-specific)
-    if (!agentId) {
-      spinner.text = 'Computing block usage...';
-      agentCounts = await computeAgentCounts(client, resolver, 'blocks', blockList.map((b: any) => b.id));
-    }
+    // Always compute agent counts for block type tagging
+    spinner.text = 'Computing block usage...';
+    agentCounts = await computeAgentCounts(client, resolver, 'blocks', blockList.map((b: any) => b.id));
 
     spinner.stop();
 
@@ -189,7 +187,7 @@ async function getBlocks(
 
     // Full content view when agent specified
     if (agentId && agentName) {
-      output(OutputFormatter.createBlockContentView(blockList, agentName, options?.short || false));
+      output(OutputFormatter.createBlockContentView(blockList, agentName, options?.short || false, agentCounts));
       return;
     }
 

--- a/src/lib/ux/constants.ts
+++ b/src/lib/ux/constants.ts
@@ -17,3 +17,21 @@ export const STATUS = {
   warn: chalk.yellow('●'),
   info: chalk.dim('○'),
 };
+
+// Block type classification based on agent count
+export type BlockType = 'shared' | 'unique' | 'orphaned';
+
+export function getBlockType(agentCount: number): BlockType {
+  if (agentCount === 0) return 'orphaned';
+  if (agentCount === 1) return 'unique';
+  return 'shared';
+}
+
+export function blockTypeTag(agentCount?: number, fancy: boolean = true): string {
+  if (agentCount === undefined) return '';
+  const type = getBlockType(agentCount);
+  if (!fancy) return type;
+  if (type === 'shared') return purple(type);
+  if (type === 'orphaned') return chalk.yellow(type);
+  return chalk.dim(type);
+}

--- a/src/lib/ux/display/block-contents.ts
+++ b/src/lib/ux/display/block-contents.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { blockTypeTag } from '../constants';
 import { createBoxWithRows, stripAnsi, shouldUseFancyUx } from '../box';
 
 export interface BlockContentData {
@@ -6,6 +7,7 @@ export interface BlockContentData {
   description?: string;
   limit?: number;
   value: string;
+  agentCount?: number;
 }
 
 export function displayBlockContents(agentName: string, blocks: BlockContentData[], short: boolean): string {
@@ -16,9 +18,11 @@ export function displayBlockContents(agentName: string, blocks: BlockContentData
   const lines: string[] = [];
 
   for (const block of blocks) {
-    const meta = block.description
-      ? `${block.description} | limit: ${block.limit || 'none'}`
-      : `limit: ${block.limit || 'none'}`;
+    const parts = [block.description, `limit: ${block.limit || 'none'}`].filter(Boolean);
+    if (block.agentCount !== undefined) {
+      parts.push(blockTypeTag(block.agentCount));
+    }
+    const meta = parts.join(' | ');
 
     let value = block.value || '(empty)';
     if (short && value.length > 300) {
@@ -49,7 +53,8 @@ function displayBlockContentsPlain(agentName: string, blocks: BlockContentData[]
   lines.push('');
 
   for (const block of blocks) {
-    lines.push(`--- ${block.label} ---`);
+    const type = block.agentCount !== undefined ? ` [${blockTypeTag(block.agentCount, false)}]` : '';
+    lines.push(`--- ${block.label}${type} ---`);
     if (block.description) lines.push(`Description: ${block.description}`);
     lines.push(`Limit: ${block.limit || 'none'}`);
     lines.push('');

--- a/src/lib/ux/display/details.ts
+++ b/src/lib/ux/display/details.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { purple, STATUS } from '../constants';
+import { purple, STATUS, getBlockType } from '../constants';
 import { BOX, BoxRow, createBox, createBoxWithRows, truncate, formatDate, shouldUseFancyUx } from '../box';
 
 // ============================================================================
@@ -31,6 +31,7 @@ export interface BlockDetailsData {
   created?: string;
   attachedAgents?: { name: string; id: string }[];
   valuePreview?: string;
+  agentCount?: number;
 }
 
 export interface ToolDetailsData {
@@ -261,6 +262,7 @@ export function displayBlockDetails(data: BlockDetailsData): string {
   const headerRows: BoxRow[] = [
     { key: 'ID', value: data.id },
     { key: 'Label', value: data.label },
+    { key: 'Type', value: data.agentCount !== undefined ? getBlockType(data.agentCount) : '-' },
     { key: 'Description', value: data.description || '-' },
     { key: 'Limit', value: `${data.limit || 'No limit'} characters` },
     { key: 'Current Size', value: `${data.currentSize || 0} characters` },
@@ -296,6 +298,7 @@ function displayBlockDetailsPlain(data: BlockDetailsData): string {
   lines.push('='.repeat(50));
   lines.push(`ID:            ${data.id}`);
   lines.push(`Label:         ${data.label || '-'}`);
+  lines.push(`Type:          ${data.agentCount !== undefined ? getBlockType(data.agentCount) : '-'}`);
   lines.push(`Description:   ${data.description || '-'}`);
   lines.push(`Limit:         ${data.limit || 'No limit'} characters`);
   lines.push(`Current Size:  ${data.currentSize || 0} characters`);

--- a/src/lib/ux/output-formatter.ts
+++ b/src/lib/ux/output-formatter.ts
@@ -95,12 +95,13 @@ export class OutputFormatter {
     return displayBlocks(data);
   }
 
-  static createBlockContentView(blocks: any[], agentName: string, short: boolean): string {
+  static createBlockContentView(blocks: any[], agentName: string, short: boolean, agentCounts?: Map<string, number>): string {
     const data: BlockContentData[] = blocks.map(block => ({
       label: block.label || block.name || 'Unknown',
       description: block.description,
       limit: block.limit,
       value: block.value || '',
+      agentCount: agentCounts?.get(block.id),
     }));
 
     return displayBlockContents(agentName, data, short);


### PR DESCRIPTION
## Summary
- Adds shared/unique/orphaned type classification to all block display surfaces
- `get blocks` table shows a TYPE column (purple "shared", yellow "orphaned", dim "unique")
- `get blocks <agent>` content view shows type tag in metadata line
- `describe block` detail view shows Type row
- Always computes agent counts for blocks (even agent-specific views) to enable type tagging

Closes #156