### PR TITLE
fix: SDK fleet file management and agent deletion

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -419,5 +419,6 @@ async function deleteMcpServer(name: string, options?: { force?: boolean }, comm
   }
 }
 
+export { deleteAgentWithCleanup };
 export default withErrorHandling('Delete command', deleteCommandImpl);
 export const deleteAllCommand = withErrorHandling('Delete all command', deleteAllCommandImpl);

--- a/tests/e2e/lib/common.js
+++ b/tests/e2e/lib/common.js
@@ -1,0 +1,67 @@
+/**
+ * Shared test helpers for SDK E2E tests.
+ * Mirrors the bash common.sh pattern but for Node.js SDK tests.
+ */
+
+let PASSED = 0;
+let FAILED = 0;
+
+function pass(msg) {
+  console.log(`[PASS] ${msg}`);
+  PASSED++;
+}
+
+function fail(msg) {
+  console.log(`[FAIL] ${msg}`);
+  FAILED++;
+}
+
+function info(msg) {
+  console.log(`[INFO] ${msg}`);
+}
+
+function warn(msg) {
+  console.log(`[WARN] ${msg}`);
+}
+
+function section(title) {
+  console.log('');
+  console.log('================================================================');
+  console.log(` ${title}`);
+  console.log('================================================================');
+}
+
+function printSummary() {
+  section('Summary');
+  console.log('');
+  console.log(`  Passed: ${PASSED}`);
+  console.log(`  Failed: ${FAILED}`);
+  console.log(`  Total:  ${PASSED + FAILED}`);
+  console.log('');
+
+  if (FAILED === 0) {
+    console.log('ALL TESTS PASSED');
+    process.exit(0);
+  } else {
+    console.log('TESTS FAILED');
+    process.exit(1);
+  }
+}
+
+function preflightCheck() {
+  if (!process.env.LETTA_BASE_URL) {
+    console.error('ERROR: LETTA_BASE_URL not set');
+    console.error('');
+    console.error('SDK E2E tests require a running Letta server.');
+    console.error('');
+    console.error('  1. Start server:  letta server');
+    console.error('  2. Set URL:       export LETTA_BASE_URL=http://localhost:8283');
+    console.error('  3. Run tests:     ./tests/e2e/sdk/run.sh');
+    console.error('');
+    process.exit(1);
+  }
+
+  info(`LETTA_BASE_URL: ${process.env.LETTA_BASE_URL}`);
+}
+
+module.exports = { pass, fail, info, warn, section, printSummary, preflightCheck };

--- a/tests/e2e/run-single.sh
+++ b/tests/e2e/run-single.sh
@@ -2,27 +2,31 @@
 
 # Run a single e2e test by name
 # Usage: ./run-single.sh 25-immutable-block
+# Supports both .sh (CLI) and .js (SDK) tests
 
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ -z "$1" ]; then
     echo "Usage: $0 <test-name>"
     echo ""
     echo "Available tests:"
-    ls -1 "$(dirname "$0")/tests/" | sed 's/\.sh$//'
+    ls -1 "$SCRIPT_DIR/tests/" | sed -e 's/\.sh$//' -e 's/\.js$//'
     exit 1
 fi
 
 TEST_NAME="$1"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TEST_FILE="$SCRIPT_DIR/tests/${TEST_NAME}.sh"
 
-if [ ! -f "$TEST_FILE" ]; then
+# Try .sh first, then .js
+if [ -f "$SCRIPT_DIR/tests/${TEST_NAME}.sh" ]; then
+    exec "$SCRIPT_DIR/tests/${TEST_NAME}.sh"
+elif [ -f "$SCRIPT_DIR/tests/${TEST_NAME}.js" ]; then
+    exec node "$SCRIPT_DIR/tests/${TEST_NAME}.js"
+else
     echo "Test not found: $TEST_NAME"
     echo ""
     echo "Available tests:"
-    ls -1 "$SCRIPT_DIR/tests/" | sed 's/\.sh$//'
+    ls -1 "$SCRIPT_DIR/tests/" | sed -e 's/\.sh$//' -e 's/\.js$//'
     exit 1
 fi
-
-exec "$TEST_FILE"

--- a/tests/e2e/tests/42-sdk-fleet-management.js
+++ b/tests/e2e/tests/42-sdk-fleet-management.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Test: SDK fleet file management and agent deletion (#158)
+ *
+ * Verifies:
+ *   1. deployFleet() writes .lettactl/fleet.yaml
+ *   2. deployFleet() with dryRun does NOT write fleet file
+ *   3. deleteAgent() removes agent from Letta + updates fleet file
+ *   4. deleteAgent() on last agent removes fleet file entirely
+ *   5. deleteAgent() without fleet file still works
+ *   6. root option controls .lettactl/ location
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { pass, fail, info, section, printSummary, preflightCheck } = require('../lib/common');
+
+// Import SDK and internals from compiled dist
+const distDir = path.join(__dirname, '..', '..', '..', 'dist');
+const { LettaCtl } = require(path.join(distDir, 'sdk'));
+const { LettaClientWrapper } = require(path.join(distDir, 'lib', 'letta-client'));
+const { AgentResolver } = require(path.join(distDir, 'lib', 'agent-resolver'));
+
+const AGENT_A = 'e2e-sdk-fleet-a';
+const AGENT_B = 'e2e-sdk-fleet-b';
+
+async function agentExistsOnServer(name) {
+  try {
+    const client = new LettaClientWrapper();
+    const resolver = new AgentResolver(client);
+    await resolver.findAgentByName(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeFleetConfig(agentNames) {
+  return {
+    agents: agentNames.map(name => ({
+      name,
+      description: `SDK E2E test agent ${name}`,
+      system_prompt: { value: 'You are a test assistant.' },
+      llm_config: { model: 'google_ai/gemini-2.0-flash-lite', context_window: 32000 },
+      embedding: 'openai/text-embedding-3-small',
+    })),
+  };
+}
+
+function makeTempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lettactl-sdk-e2e-'));
+}
+
+function fleetFileExists(root) {
+  return fs.existsSync(path.join(root, '.lettactl', 'fleet.yaml'));
+}
+
+function readFleetFile(root) {
+  return fs.readFileSync(path.join(root, '.lettactl', 'fleet.yaml'), 'utf8');
+}
+
+function cleanup(root) {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch {}
+}
+
+// Helper: delete agents via a fresh SDK instance (no fleet file involvement)
+async function deleteAgentSilent(name) {
+  try {
+    const ctl = new LettaCtl();
+    await ctl.deleteAgent(name);
+  } catch {}
+}
+
+async function run() {
+  section('Test: SDK Fleet Management (#158)');
+  preflightCheck();
+
+  // Clean up any leftover agents from prior runs
+  info('Cleaning up prior test agents...');
+  await deleteAgentSilent(AGENT_A);
+  await deleteAgentSilent(AGENT_B);
+
+  // ── Test 1: deployFleet() creates agents and writes fleet file ──────────
+  info('Test 1: deployFleet() creates agents and writes fleet file...');
+  const root1 = makeTempRoot();
+  try {
+    const ctl = new LettaCtl({ root: root1 });
+    await ctl.deployFleet(makeFleetConfig([AGENT_A, AGENT_B]));
+
+    // Verify server state
+    if (await agentExistsOnServer(AGENT_A)) {
+      pass('Agent A exists on server');
+    } else {
+      fail('Agent A NOT found on server after deploy');
+    }
+    if (await agentExistsOnServer(AGENT_B)) {
+      pass('Agent B exists on server');
+    } else {
+      fail('Agent B NOT found on server after deploy');
+    }
+
+    // Verify fleet file
+    if (fleetFileExists(root1)) {
+      pass('Fleet file created after deploy');
+    } else {
+      fail('Fleet file NOT created after deploy');
+    }
+
+    const content = readFleetFile(root1);
+    if (content.includes(AGENT_A) && content.includes(AGENT_B)) {
+      pass('Fleet file contains both agents');
+    } else {
+      fail('Fleet file missing agent names');
+    }
+  } finally {
+    cleanup(root1);
+  }
+
+  // ── Test 2: dryRun does NOT write fleet file ───────────────────────────
+  info('Test 2: dryRun does not write fleet file...');
+  const root2 = makeTempRoot();
+  try {
+    const ctl = new LettaCtl({ root: root2 });
+    await ctl.deployFleet(makeFleetConfig([AGENT_A, AGENT_B]), { dryRun: true });
+
+    if (!fleetFileExists(root2)) {
+      pass('Fleet file NOT created on dry run');
+    } else {
+      fail('Fleet file should not exist after dry run');
+    }
+  } finally {
+    cleanup(root2);
+  }
+
+  // ── Test 3: deleteAgent() removes from server and updates fleet file ──
+  info('Test 3: deleteAgent() removes agent from server and fleet file...');
+  const root3 = makeTempRoot();
+  try {
+    const ctl = new LettaCtl({ root: root3 });
+
+    // Deploy both agents first
+    await ctl.deployFleet(makeFleetConfig([AGENT_A, AGENT_B]));
+
+    // Delete one agent
+    await ctl.deleteAgent(AGENT_A);
+
+    // Verify server state
+    if (!(await agentExistsOnServer(AGENT_A))) {
+      pass('Deleted agent gone from server');
+    } else {
+      fail('Deleted agent still on server');
+    }
+    if (await agentExistsOnServer(AGENT_B)) {
+      pass('Remaining agent still on server');
+    } else {
+      fail('Remaining agent missing from server');
+    }
+
+    // Verify fleet file
+    if (fleetFileExists(root3)) {
+      pass('Fleet file still exists after deleting one agent');
+    } else {
+      fail('Fleet file should still exist with remaining agent');
+    }
+
+    const content = readFleetFile(root3);
+    if (!content.includes(AGENT_A)) {
+      pass('Deleted agent removed from fleet file');
+    } else {
+      fail('Deleted agent still in fleet file');
+    }
+
+    if (content.includes(AGENT_B)) {
+      pass('Remaining agent still in fleet file');
+    } else {
+      fail('Remaining agent missing from fleet file');
+    }
+
+    // ── Test 4: deleteAgent() on last agent removes fleet file ─────────
+    info('Test 4: deleteAgent() on last agent removes fleet file...');
+    await ctl.deleteAgent(AGENT_B);
+
+    if (!(await agentExistsOnServer(AGENT_B))) {
+      pass('Last agent gone from server');
+    } else {
+      fail('Last agent still on server');
+    }
+
+    if (!fleetFileExists(root3)) {
+      pass('Fleet file removed after deleting last agent');
+    } else {
+      fail('Fleet file should be removed when no agents remain');
+    }
+  } finally {
+    cleanup(root3);
+  }
+
+  // ── Test 5: deleteAgent() works without fleet file ─────────────────────
+  info('Test 5: deleteAgent() works without fleet file...');
+  const root5 = makeTempRoot();
+  try {
+    // Deploy agent via one SDK instance (writes fleet file to root5)
+    const ctl1 = new LettaCtl({ root: root5 });
+    await ctl1.deployFleet(makeFleetConfig([AGENT_A]));
+
+    // Delete via different root (no fleet file there)
+    const root5b = makeTempRoot();
+    const ctl2 = new LettaCtl({ root: root5b });
+    try {
+      await ctl2.deleteAgent(AGENT_A);
+      pass('deleteAgent() succeeds without fleet file');
+
+      if (!(await agentExistsOnServer(AGENT_A))) {
+        pass('Agent deleted from server despite no fleet file');
+      } else {
+        fail('Agent still on server after delete without fleet file');
+      }
+    } catch (err) {
+      fail(`deleteAgent() threw without fleet file: ${err.message}`);
+    } finally {
+      cleanup(root5b);
+    }
+  } finally {
+    cleanup(root5);
+  }
+
+  // ── Test 6: root option controls .lettactl/ location ───────────────────
+  info('Test 6: root option controls fleet file location...');
+  const root6 = makeTempRoot();
+  try {
+    const ctl = new LettaCtl({ root: root6 });
+    await ctl.deployFleet(makeFleetConfig([AGENT_A]));
+
+    const expectedPath = path.join(root6, '.lettactl', 'fleet.yaml');
+    if (fs.existsSync(expectedPath)) {
+      pass('Fleet file written to custom root');
+    } else {
+      fail('Fleet file not at custom root path');
+    }
+
+    // Cleanup agent
+    await ctl.deleteAgent(AGENT_A);
+  } finally {
+    cleanup(root6);
+  }
+
+  // Final cleanup
+  info('Final cleanup...');
+  await deleteAgentSilent(AGENT_A);
+  await deleteAgentSilent(AGENT_B);
+
+  printSummary();
+}
+
+run().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Export `deleteAgentWithCleanup` from `src/commands/delete.ts`
- Add `root` option, fleet file helpers, `deleteAgent()` method to SDK
- `deployFleet()` now persists `.lettactl/fleet.yaml` after successful deploy
- `deleteAgent()` removes agent from Letta server and updates fleet file
- SDK E2E test infrastructure: `.js` tests alongside `.sh` tests in `tests/e2e/tests/`
- `run-single.sh` auto-detects `.sh` vs `.js` tests

Closes #158

## Test plan
- [x] `pnpm test` — 64/64 unit tests pass
- [x] `pnpm run build` — compiles clean
- [x] `./tests/e2e/run-single.sh 42-sdk-fleet-management` — 15/15 E2E assertions pass