### PR TITLE
refactor: rename mutable flag to agent_owned

### DIFF
--- a/.skills/fleet-deployment/SKILL.md
+++ b/.skills/fleet-deployment/SKILL.md
@@ -45,7 +45,7 @@ MemoryBlock {
   limit: number
   value?: string
   from_file?: string
-  mutable?: boolean  // default: true
+  agent_owned?: boolean  // default: true
 }
 ```
 

--- a/.skills/release-cycle/SKILL.md
+++ b/.skills/release-cycle/SKILL.md
@@ -90,15 +90,15 @@ Fixtures in `tests/e2e/fixtures/`:
 - `fleet.yml` - Initial state for most tests
 - `fleet-updated.yml` - Modified state for update/diff tests
 
-**Memory block value sync** requires `mutable: false`:
+**Memory block value sync** requires `agent_owned: false`:
 ```yaml
 memory_blocks:
   - name: policies
     value: "Policy content..."
-    mutable: false  # Required for lettactl to sync value on apply
+    agent_owned: false  # Required for lettactl to sync value on apply
 ```
 
-Without `mutable: false`, block values won't sync (agent could have modified them at runtime).
+Without `agent_owned: false`, block values won't sync (agent owns and could have modified them).
 
 ### Test Output
 

--- a/README.md
+++ b/README.md
@@ -807,28 +807,28 @@ memory_blocks:
     from_file: "memory-blocks/company-info.md"
 ```
 
-**Controlling Block Mutability:**
+**Controlling Block Ownership:**
 
-By default, memory blocks are mutable - the agent can modify them and those changes persist across applies. Use `mutable: false` when you want the YAML to be the source of truth:
+By default, memory blocks are agent-owned - the agent can modify them and those changes persist across applies. Use `agent_owned: false` when you want the YAML to be the source of truth:
 
 ```yaml
 memory_blocks:
-  # Mutable (default): Agent can modify, changes preserved on re-apply
+  # Agent-owned (default): Agent can modify, changes preserved on re-apply
   - name: learned_preferences
     description: "User preferences the agent learns over time"
     limit: 2000
     value: "No preferences yet"
-    # mutable: true (default, not needed)
+    # agent_owned: true (default, not needed)
 
-  # Immutable: YAML value syncs to server on every apply
+  # YAML-owned: YAML value syncs to server on every apply
   - name: policies
     description: "Agent policies from config"
     limit: 2000
     value: "Always be helpful and concise."
-    mutable: false  # Value resets to YAML on every apply
+    agent_owned: false  # Value resets to YAML on every apply
 ```
 
-Use `mutable: false` for:
+Use `agent_owned: false` for:
 - Configuration/policies that should be version-controlled
 - Content that needs to sync from YAML on every deploy
 - Blocks where the developer, not the agent, controls the content
@@ -930,7 +930,7 @@ agents:
         description: "What this block stores"
         limit: 5000                     # Character limit
         version: "optional-tag"         # Optional: your version tag
-        mutable: true                   # Optional: if false, value syncs from YAML on every apply
+        agent_owned: true               # Optional: if false, value syncs from YAML on every apply
         value: "Direct content"         # Option 1: inline
         from_file: "blocks/file.md"    # Option 2: from file
 

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -236,7 +236,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
             description: block.description,
             limit: block.limit,
             value: block.value || '',
-            mutable: block.mutable
+            agent_owned: block.agent_owned
           })),
           archives: (agent.archives || []).map((archive: any) => {
             const resolved: any = {

--- a/src/lib/apply/apply-helpers.ts
+++ b/src/lib/apply/apply-helpers.ts
@@ -414,7 +414,7 @@ export async function createNewAgent(
         description: block.description,
         limit: block.limit,
         value: block.value || '',
-        mutable: block.mutable
+        agent_owned: block.agent_owned
       })),
       archives: agent.archives || [],
       folders: agent.folders || [],

--- a/src/lib/apply/diff-analyzers.ts
+++ b/src/lib/apply/diff-analyzers.ts
@@ -94,7 +94,7 @@ export async function analyzeToolChanges(
 
 export async function analyzeBlockChanges(
   currentBlocks: any[],
-  desiredBlocks: Array<{ name: string; isShared?: boolean; description?: string; limit?: number; value?: string; mutable?: boolean }>,
+  desiredBlocks: Array<{ name: string; isShared?: boolean; description?: string; limit?: number; value?: string; agent_owned?: boolean }>,
   blockManager: BlockManager,
   agentName?: string,
   dryRun: boolean = false
@@ -145,8 +145,8 @@ export async function analyzeBlockChanges(
       // Block exists on both sides - check if value needs updating
       const desiredConfig = desiredBlocks.find(b => b.name === block.label);
 
-      // For mutable: false blocks, compare values and update if different
-      if (desiredConfig && desiredConfig.mutable === false && !desiredConfig.isShared) {
+      // For agent_owned: false blocks, compare values and update if different
+      if (desiredConfig && desiredConfig.agent_owned === false && !desiredConfig.isShared) {
         const desiredValue = desiredConfig.value || '';
         const currentValue = block.value || '';
 

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -134,7 +134,7 @@ async function computeAgentDiff(
       description: b.description,
       limit: b.limit,
       value: b.value || '',
-      mutable: b.mutable
+      agent_owned: b.agent_owned
     })),
     archives: (agent.archives || []).map((a: any) => {
       const resolved: any = {

--- a/src/lib/managers/block-manager.ts
+++ b/src/lib/managers/block-manager.ts
@@ -63,7 +63,7 @@ export class BlockManager {
   async getOrCreateSharedBlock(blockConfig: any): Promise<string> {
     const blockKey = this.getBlockKey(blockConfig.name, true);
     const contentHash = generateContentHash(blockConfig.value);
-    const isMutable = blockConfig.mutable !== false;
+    const isAgentOwned = blockConfig.agent_owned !== false;
 
     // Check both shared and non-shared keys
     let existing = this.blockRegistry.get(blockKey);
@@ -72,7 +72,7 @@ export class BlockManager {
     }
 
     if (existing) {
-      if (isMutable) {
+      if (isAgentOwned) {
         log(`Using existing shared block: ${existing.label}`);
         return existing.id;
       }
@@ -82,7 +82,7 @@ export class BlockManager {
         return existing.id;
       }
 
-      // Content changed - update in-place when mutable is false
+      // Content changed - update in-place when agent_owned is false
       log(`Updating shared block: ${existing.label}`);
       await this.client.updateBlock(existing.id, {
         value: blockConfig.value,

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -9,7 +9,7 @@ export interface BlockDiff {
   toAdd: Array<{ name: string; id: string }>;
   toRemove: Array<{ name: string; id: string }>;
   toUpdate: Array<{ name: string; currentId: string; newId: string }>;
-  toUpdateValue: Array<{ name: string; id: string; oldValue: string; newValue: string }>; // For mutable: false blocks
+  toUpdateValue: Array<{ name: string; id: string; oldValue: string; newValue: string }>; // For agent_owned: false blocks
   unchanged: Array<{ name: string; id: string }>;
 }
 

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -26,7 +26,7 @@ export interface SharedBlock {
   value?: string;
   from_file?: string;
   version?: string; // Optional user-defined version tag
-  mutable?: boolean; // Default: true. If false, value syncs from YAML on every apply
+  agent_owned?: boolean; // Default: true. If false, value syncs from YAML on every apply
 }
 
 export interface AgentConfig {
@@ -86,7 +86,7 @@ export interface MemoryBlock {
   value?: string;
   from_file?: string;
   version?: string; // Optional user-defined version tag
-  mutable?: boolean; // Default: true. If false, value syncs from YAML on every apply
+  agent_owned?: boolean; // Default: true. If false, value syncs from YAML on every apply
 }
 
 export interface ArchiveConfig {

--- a/tests/e2e/fixtures/fleet-block-contents-test.yml
+++ b/tests/e2e/fixtures/fleet-block-contents-test.yml
@@ -32,7 +32,7 @@ agents:
 
           Block descriptions provide metadata about the block's purpose. While the description is not included in the agent's context window, it serves as documentation for system administrators and helps tools like lettactl display meaningful information about each block.
 
-          The mutable flag indicates whether an agent is allowed to modify the block's content during a conversation. Immutable blocks are useful for storing reference information that should remain constant, such as API documentation, company policies, or factual knowledge bases.
+          The agent_owned flag indicates whether an agent owns the block's content (agent_owned: true, the default) or whether YAML owns it (agent_owned: false). When YAML owns the block, its value syncs from the config file on every apply. This is useful for storing reference information that should remain constant, such as API documentation, company policies, or factual knowledge bases.
 
           CHAPTER 3: CONTENT MANAGEMENT STRATEGIES
 

--- a/tests/e2e/fixtures/fleet-updated.yml
+++ b/tests/e2e/fixtures/fleet-updated.yml
@@ -458,13 +458,13 @@ agents:
               path: test-doc.txt
 
   # ============================================================================
-  # MUTABLE BLOCKS - Value Sync (#101)
+  # YAML-OWNED BLOCKS - Value Sync (#101)
   # ============================================================================
 
-  # 25: Updated policy value - should sync to server because mutable: false
-  # The learned_data block should NOT sync because mutable: true (default)
+  # 25: Updated policy value - should sync to server because agent_owned: false
+  # The learned_data block should NOT sync because agent_owned: true (default)
   - name: e2e-25-immutable-block
-    description: Tests mutable false block value sync
+    description: Tests agent_owned false block value sync
     embedding: openai/text-embedding-3-small
     system_prompt:
       value: Agent with immutable block.
@@ -476,9 +476,9 @@ agents:
         description: Agent policies that sync from YAML
         limit: 2000
         value: "Policy version 2: Be helpful, concise, and professional."
-        mutable: false
+        agent_owned: false
       - name: learned_data
-        description: Data the agent learns (mutable by default)
+        description: Data the agent learns (agent_owned by default)
         limit: 2000
         value: "Initial state"
 
@@ -500,7 +500,7 @@ agents:
         description: Notes block with minimal initial value
         limit: 2000
         value: "Now has content!"
-        mutable: false
+        agent_owned: false
       - name: populated_notes
         description: Notes block with value
         limit: 2000

--- a/tests/e2e/fixtures/fleet.yml
+++ b/tests/e2e/fixtures/fleet.yml
@@ -453,12 +453,12 @@ agents:
               path: test-doc.txt
 
   # ============================================================================
-  # MUTABLE BLOCKS - Value Sync (#101)
+  # YAML-OWNED BLOCKS - Value Sync (#101)
   # ============================================================================
 
-  # 25: Mutable: false blocks - value syncs from YAML on every apply
+  # 25: agent_owned: false blocks - value syncs from YAML on every apply
   - name: e2e-25-immutable-block
-    description: Tests mutable false block value sync
+    description: Tests agent_owned false block value sync
     embedding: openai/text-embedding-3-small
     system_prompt:
       value: Agent with immutable block.
@@ -470,9 +470,9 @@ agents:
         description: Agent policies that sync from YAML
         limit: 2000
         value: "Policy version 1: Be helpful and concise."
-        mutable: false
+        agent_owned: false
       - name: learned_data
-        description: Data the agent learns (mutable by default)
+        description: Data the agent learns (agent_owned by default)
         limit: 2000
         value: "Initial state"
 
@@ -494,7 +494,7 @@ agents:
         description: Notes block with minimal initial value
         limit: 2000
         value: "-"
-        mutable: false
+        agent_owned: false
       - name: populated_notes
         description: Notes block with value
         limit: 2000
@@ -603,7 +603,7 @@ agents:
       - name: brand_identity
         description: Brand identity for this agent
         limit: 2000
-        mutable: false
+        agent_owned: false
         value: |
           # Brand Identity: Alpha Corp
           Company: Alpha Corp
@@ -623,7 +623,7 @@ agents:
       - name: brand_identity
         description: Brand identity for this agent
         limit: 2000
-        mutable: false
+        agent_owned: false
         value: |
           # Brand Identity: Beta Inc
           Company: Beta Inc

--- a/tests/e2e/tests/25-immutable-block.sh
+++ b/tests/e2e/tests/25-immutable-block.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Test: mutable: false blocks sync value from YAML on every apply
+# Test: agent_owned: false blocks sync value from YAML on every apply
 # Issue: #101
 
 set -e
@@ -62,11 +62,11 @@ else
     exit 1
 fi
 
-# Verify block value synced (mutable: false should sync to "version 2")
+# Verify block value synced (agent_owned: false should sync to "version 2")
 section "Verify Block Value Synced"
 if $CLI describe block policies > $OUT 2>&1; then
     if output_contains "version 2"; then
-        pass "Block value synced to 'version 2' (mutable: false works)"
+        pass "Block value synced to 'version 2' (agent_owned: false works)"
     else
         fail "Block value not synced (should contain 'version 2')"
         cat $OUT

--- a/tests/unit/lib/block-manager.test.ts
+++ b/tests/unit/lib/block-manager.test.ts
@@ -44,14 +44,14 @@ describe('BlockManager', () => {
       });
     });
 
-    it('updates existing block when content changes and mutable is false', async () => {
+    it('updates existing block when content changes and agent_owned is false', async () => {
       mockClient.listBlocks.mockResolvedValue([
         { id: 'id-1', label: 'test', value: 'old-val', description: 'desc', limit: 1000 }
       ] as any);
       mockClient.updateBlock.mockResolvedValue({ id: 'id-1' } as any);
       await manager.loadExistingBlocks();
 
-      const result = await manager.getOrCreateSharedBlock({ name: 'test', description: 'new-desc', limit: 2000, value: 'new-val', mutable: false });
+      const result = await manager.getOrCreateSharedBlock({ name: 'test', description: 'new-desc', limit: 2000, value: 'new-val', agent_owned: false });
 
       expect(result).toBe('id-1');
       expect(mockClient.updateBlock).toHaveBeenCalledWith('id-1', {
@@ -59,13 +59,13 @@ describe('BlockManager', () => {
       });
     });
 
-    it('returns existing block when mutable is true even if content changes', async () => {
+    it('returns existing block when agent_owned is true even if content changes', async () => {
       mockClient.listBlocks.mockResolvedValue([
         { id: 'id-1', label: 'test', value: 'old-val', description: 'desc', limit: 1000 }
       ] as any);
       await manager.loadExistingBlocks();
 
-      const result = await manager.getOrCreateSharedBlock({ name: 'test', description: 'new-desc', limit: 2000, value: 'new-val', mutable: true });
+      const result = await manager.getOrCreateSharedBlock({ name: 'test', description: 'new-desc', limit: 2000, value: 'new-val', agent_owned: true });
 
       expect(result).toBe('id-1');
       expect(mockClient.updateBlock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Renames `mutable` flag to `agent_owned` for memory blocks
- `agent_owned: true` (default) = agent owns block, YAML won't overwrite
- `agent_owned: false` = YAML owns block, syncs on every apply

Breaking change - clearer semantics.

Closes #189