### PR TITLE
feat: make agent_owned field mandatory on memory blocks

### DIFF
--- a/src/lib/validation/config-validators.ts
+++ b/src/lib/validation/config-validators.ts
@@ -346,6 +346,19 @@ export class MemoryBlockValidator {
     if (hasBucket) {
       BucketConfigValidator.validate(block.from_bucket);
     }
+
+    // agent_owned is required - no silent defaults
+    if (!('agent_owned' in block)) {
+      throw new Error(
+        `Memory block "${block.name}" missing required field 'agent_owned'\n` +
+        '  agent_owned: true  - agent can modify, YAML won\'t overwrite\n' +
+        '  agent_owned: false - YAML overwrites on every apply'
+      );
+    }
+
+    if (typeof block.agent_owned !== 'boolean') {
+      throw new Error(`Memory block "${block.name}" agent_owned must be true or false.`);
+    }
   }
 }
 

--- a/tests/e2e/fixtures/fleet-archives-force-test-reduced.yml
+++ b/tests/e2e/fixtures/fleet-archives-force-test-reduced.yml
@@ -1,11 +1,9 @@
-# Reduced config for archival memory --force reconciliation tests
-
 agents:
-  - name: e2e-42-archives-force
-    description: Agent for archive --force reconciliation
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with archives to detach.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
+- name: e2e-42-archives-force
+  description: Agent for archive --force reconciliation
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with archives to detach.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000

--- a/tests/e2e/fixtures/fleet-archives-force-test.yml
+++ b/tests/e2e/fixtures/fleet-archives-force-test.yml
@@ -1,15 +1,13 @@
-# Fleet config for archival memory --force reconciliation tests
-
 agents:
-  - name: e2e-42-archives-force
-    description: Agent for archive --force reconciliation
+- name: e2e-42-archives-force
+  description: Agent for archive --force reconciliation
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with archives to detach.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  archives:
+  - name: e2e-archive-force-keep
+    description: Archive that should remain attached
     embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with archives to detach.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    archives:
-      - name: e2e-archive-force-keep
-        description: Archive that should remain attached
-        embedding: openai/text-embedding-3-small

--- a/tests/e2e/fixtures/fleet-archives-test.yml
+++ b/tests/e2e/fixtures/fleet-archives-test.yml
@@ -1,15 +1,13 @@
-# Fleet config for archival memory basic tests
-
 agents:
-  - name: e2e-41-archives-basic
-    description: Agent with archival memory archives
+- name: e2e-41-archives-basic
+  description: Agent with archival memory archives
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with archival memory.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  archives:
+  - name: e2e-archive-basic-1
+    description: Primary archive for e2e tests
     embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with archival memory.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    archives:
-      - name: e2e-archive-basic-1
-        description: Primary archive for e2e tests
-        embedding: openai/text-embedding-3-small

--- a/tests/e2e/fixtures/fleet-block-contents-test.yml
+++ b/tests/e2e/fixtures/fleet-block-contents-test.yml
@@ -1,89 +1,211 @@
 agents:
-  - name: e2e-41-block-contents
-    description: "Test agent for full block content display"
-    embedding: openai/text-embedding-3-small
-    llm_config:
-      model: openai/gpt-4o-mini
-      context_window: 16384
-    system_prompt:
-      value: "You are a helpful assistant."
-    memory_blocks:
-      - name: long_knowledge
-        description: "A large knowledge base block"
-        limit: 10000
-        value: |
-          MARKER_START_BLOCK_CONTENT
+- name: e2e-41-block-contents
+  description: Test agent for full block content display
+  embedding: openai/text-embedding-3-small
+  llm_config:
+    model: openai/gpt-4o-mini
+    context_window: 16384
+  system_prompt:
+    value: You are a helpful assistant.
+  memory_blocks:
+  - name: long_knowledge
+    description: A large knowledge base block
+    limit: 10000
+    value: 'MARKER_START_BLOCK_CONTENT
 
-          CHAPTER 1: FOUNDATIONS OF DISTRIBUTED AGENT SYSTEMS
 
-          The architecture of modern distributed agent systems relies on several foundational principles that govern how autonomous agents communicate, coordinate, and collaborate within a shared environment. At its core, a distributed agent system consists of multiple independent software agents, each capable of making decisions and taking actions based on their local state, their memory, and messages received from other agents or from external systems.
+      CHAPTER 1: FOUNDATIONS OF DISTRIBUTED AGENT SYSTEMS
 
-          Memory management is a critical component of any agent system. Each agent maintains a set of memory blocks that store persistent information across conversations. These blocks serve different purposes: some hold the agent's core knowledge and personality, others track conversation context, and still others maintain structured data that the agent can reference when processing new inputs.
 
-          The concept of shared blocks allows multiple agents to access the same piece of information. When one agent updates a shared block, all other agents that reference that block will see the updated content in their next interaction. This creates a powerful mechanism for inter-agent communication and knowledge sharing without requiring direct message passing between agents.
+      The architecture of modern distributed agent systems relies on several foundational
+      principles that govern how autonomous agents communicate, coordinate, and collaborate
+      within a shared environment. At its core, a distributed agent system consists
+      of multiple independent software agents, each capable of making decisions and
+      taking actions based on their local state, their memory, and messages received
+      from other agents or from external systems.
 
-          CHAPTER 2: MEMORY BLOCK ARCHITECTURE
 
-          Memory blocks in the Letta platform are characterized by several key properties. Each block has a unique label that serves as its identifier within an agent's memory space. The label must be unique per agent, though different agents can have blocks with the same label that contain different content.
+      Memory management is a critical component of any agent system. Each agent maintains
+      a set of memory blocks that store persistent information across conversations.
+      These blocks serve different purposes: some hold the agent''s core knowledge
+      and personality, others track conversation context, and still others maintain
+      structured data that the agent can reference when processing new inputs.
 
-          Each block also has a character limit that defines the maximum amount of text it can store. This limit exists because the block content is injected into the agent's context window during each interaction, and context windows have finite capacity. Setting appropriate limits ensures that the agent's context is not overwhelmed by a single large block.
 
-          The block value contains the actual text content. This can be any UTF-8 encoded string, including multi-line text, structured data like JSON or YAML, code snippets, or natural language prose. The system preserves all formatting, whitespace, and special characters exactly as they are stored.
+      The concept of shared blocks allows multiple agents to access the same piece
+      of information. When one agent updates a shared block, all other agents that
+      reference that block will see the updated content in their next interaction.
+      This creates a powerful mechanism for inter-agent communication and knowledge
+      sharing without requiring direct message passing between agents.
 
-          Block descriptions provide metadata about the block's purpose. While the description is not included in the agent's context window, it serves as documentation for system administrators and helps tools like lettactl display meaningful information about each block.
 
-          The agent_owned flag indicates whether an agent owns the block's content (agent_owned: true, the default) or whether YAML owns it (agent_owned: false). When YAML owns the block, its value syncs from the config file on every apply. This is useful for storing reference information that should remain constant, such as API documentation, company policies, or factual knowledge bases.
+      CHAPTER 2: MEMORY BLOCK ARCHITECTURE
 
-          CHAPTER 3: CONTENT MANAGEMENT STRATEGIES
 
-          Effective content management in agent memory blocks requires careful consideration of several factors. First, the content should be structured in a way that is easy for the language model to parse and reference. Using clear section headers, bullet points, and consistent formatting helps the agent locate specific information quickly.
+      Memory blocks in the Letta platform are characterized by several key properties.
+      Each block has a unique label that serves as its identifier within an agent''s
+      memory space. The label must be unique per agent, though different agents can
+      have blocks with the same label that contain different content.
 
-          Second, the content should be kept up to date. Stale information in memory blocks can lead to incorrect agent responses. Tools like lettactl provide mechanisms for detecting content changes through file hashes and automatically updating blocks when the source content changes.
 
-          Third, the total size of all memory blocks attached to an agent should be considered in relation to the agent's context window size. If the combined block content exceeds a significant portion of the context window, there may not be enough room for the conversation history and the agent's reasoning process.
+      Each block also has a character limit that defines the maximum amount of text
+      it can store. This limit exists because the block content is injected into the
+      agent''s context window during each interaction, and context windows have finite
+      capacity. Setting appropriate limits ensures that the agent''s context is not
+      overwhelmed by a single large block.
 
-          CHAPTER 4: DISPLAY AND INSPECTION TOOLS
 
-          The lettactl CLI provides several commands for inspecting memory block contents. The basic get blocks command shows a tabular overview of all blocks in the system, including their labels, character limits, current sizes, and the number of agents they are attached to.
+      The block value contains the actual text content. This can be any UTF-8 encoded
+      string, including multi-line text, structured data like JSON or YAML, code snippets,
+      or natural language prose. The system preserves all formatting, whitespace,
+      and special characters exactly as they are stored.
 
-          For more detailed inspection, the get blocks <agent> command shows the full content of every block attached to a specific agent. This is particularly useful for debugging agent behavior, as it reveals exactly what information the agent has access to in its memory.
 
-          The --short flag provides a truncated view that shows only the first 300 characters of each block value. This is useful for getting a quick overview without scrolling through potentially thousands of characters of content.
+      Block descriptions provide metadata about the block''s purpose. While the description
+      is not included in the agent''s context window, it serves as documentation for
+      system administrators and helps tools like lettactl display meaningful information
+      about each block.
 
-          CHAPTER 5: INTEGRATION PATTERNS
 
-          Memory blocks integrate with several other components of the Letta platform. Folders provide file-based knowledge that complements the structured information in memory blocks. Tools give agents the ability to take actions and retrieve information from external systems. And the system prompt defines the agent's core behavior and personality.
+      The agent_owned flag indicates whether an agent owns the block''s content (agent_owned:
+      true, the default) or whether YAML owns it (agent_owned: false). When YAML owns
+      the block, its value syncs from the config file on every apply. This is useful
+      for storing reference information that should remain constant, such as API documentation,
+      company policies, or factual knowledge bases.
 
-          When designing an agent's configuration, it is important to consider how these components work together. For example, an agent that needs to reference a large body of documentation might use a folder for the full documents and a memory block for a summary or index of the most important points.
 
-          CHAPTER 6: TESTING AND VALIDATION
+      CHAPTER 3: CONTENT MANAGEMENT STRATEGIES
 
-          Testing memory block functionality requires verifying several aspects of the system. Content integrity ensures that the stored text matches what was configured. Display correctness ensures that inspection tools show the content accurately. Update detection ensures that changes to block content are properly detected and applied.
 
-          This particular block is designed as a test fixture for the block content display feature. It contains well over 5000 characters of text spread across multiple chapters, with marker strings placed at strategic locations to verify that the full content is being displayed correctly by the get blocks command.
+      Effective content management in agent memory blocks requires careful consideration
+      of several factors. First, the content should be structured in a way that is
+      easy for the language model to parse and reference. Using clear section headers,
+      bullet points, and consistent formatting helps the agent locate specific information
+      quickly.
 
-          MARKER_MIDDLE_OF_CONTENT
 
-          CHAPTER 7: OPERATIONAL BEST PRACTICES
+      Second, the content should be kept up to date. Stale information in memory blocks
+      can lead to incorrect agent responses. Tools like lettactl provide mechanisms
+      for detecting content changes through file hashes and automatically updating
+      blocks when the source content changes.
 
-          When operating a fleet of agents with memory blocks, several best practices should be followed. Monitor block usage to ensure that blocks are not approaching their character limits unexpectedly. Use the cleanup command to identify and remove orphaned blocks that are no longer attached to any agent. Regularly review block contents to ensure they remain accurate and relevant.
 
-          Version control for block content is also important. By storing block values in files and referencing them from the fleet configuration, changes can be tracked through the normal source control workflow. The lettactl tool supports file-based block values through the from_file directive, which reads the content from a specified file path.
+      Third, the total size of all memory blocks attached to an agent should be considered
+      in relation to the agent''s context window size. If the combined block content
+      exceeds a significant portion of the context window, there may not be enough
+      room for the conversation history and the agent''s reasoning process.
 
-          CHAPTER 8: ADVANCED TOPICS
 
-          Advanced use cases for memory blocks include dynamic content injection, where the block value is updated programmatically based on external events or data sources. This can be accomplished through the Letta API or through lettactl's apply command with updated configuration files.
+      CHAPTER 4: DISPLAY AND INSPECTION TOOLS
 
-          Another advanced pattern is block templating, where a base block value is defined with placeholder variables that are filled in at deployment time. This allows the same fleet configuration to be used across different environments with environment-specific values.
 
-          Cross-agent block sharing enables sophisticated multi-agent workflows where agents can communicate indirectly through shared memory. For example, a research agent might update a shared block with new findings, which are then automatically available to a reporting agent in its next conversation.
+      The lettactl CLI provides several commands for inspecting memory block contents.
+      The basic get blocks command shows a tabular overview of all blocks in the system,
+      including their labels, character limits, current sizes, and the number of agents
+      they are attached to.
 
-          CHAPTER 9: CONCLUSION AND VERIFICATION
 
-          This knowledge base block has been designed to exceed 5000 characters of content across nine chapters. The markers placed throughout the text serve as checkpoints for automated testing. The MARKER_START_BLOCK_CONTENT at the beginning, MARKER_MIDDLE_OF_CONTENT in chapter six, and this final marker MARKER_END_BLOCK_CONTENT at the end allow the test suite to verify that the complete block content is being displayed without truncation.
+      For more detailed inspection, the get blocks <agent> command shows the full
+      content of every block attached to a specific agent. This is particularly useful
+      for debugging agent behavior, as it reveals exactly what information the agent
+      has access to in its memory.
 
-          MARKER_END_BLOCK_CONTENT
-      - name: short_note
-        description: "A small note block"
-        limit: 500
-        value: "This is a short note for contrast."
+
+      The --short flag provides a truncated view that shows only the first 300 characters
+      of each block value. This is useful for getting a quick overview without scrolling
+      through potentially thousands of characters of content.
+
+
+      CHAPTER 5: INTEGRATION PATTERNS
+
+
+      Memory blocks integrate with several other components of the Letta platform.
+      Folders provide file-based knowledge that complements the structured information
+      in memory blocks. Tools give agents the ability to take actions and retrieve
+      information from external systems. And the system prompt defines the agent''s
+      core behavior and personality.
+
+
+      When designing an agent''s configuration, it is important to consider how these
+      components work together. For example, an agent that needs to reference a large
+      body of documentation might use a folder for the full documents and a memory
+      block for a summary or index of the most important points.
+
+
+      CHAPTER 6: TESTING AND VALIDATION
+
+
+      Testing memory block functionality requires verifying several aspects of the
+      system. Content integrity ensures that the stored text matches what was configured.
+      Display correctness ensures that inspection tools show the content accurately.
+      Update detection ensures that changes to block content are properly detected
+      and applied.
+
+
+      This particular block is designed as a test fixture for the block content display
+      feature. It contains well over 5000 characters of text spread across multiple
+      chapters, with marker strings placed at strategic locations to verify that the
+      full content is being displayed correctly by the get blocks command.
+
+
+      MARKER_MIDDLE_OF_CONTENT
+
+
+      CHAPTER 7: OPERATIONAL BEST PRACTICES
+
+
+      When operating a fleet of agents with memory blocks, several best practices
+      should be followed. Monitor block usage to ensure that blocks are not approaching
+      their character limits unexpectedly. Use the cleanup command to identify and
+      remove orphaned blocks that are no longer attached to any agent. Regularly review
+      block contents to ensure they remain accurate and relevant.
+
+
+      Version control for block content is also important. By storing block values
+      in files and referencing them from the fleet configuration, changes can be tracked
+      through the normal source control workflow. The lettactl tool supports file-based
+      block values through the from_file directive, which reads the content from a
+      specified file path.
+
+
+      CHAPTER 8: ADVANCED TOPICS
+
+
+      Advanced use cases for memory blocks include dynamic content injection, where
+      the block value is updated programmatically based on external events or data
+      sources. This can be accomplished through the Letta API or through lettactl''s
+      apply command with updated configuration files.
+
+
+      Another advanced pattern is block templating, where a base block value is defined
+      with placeholder variables that are filled in at deployment time. This allows
+      the same fleet configuration to be used across different environments with environment-specific
+      values.
+
+
+      Cross-agent block sharing enables sophisticated multi-agent workflows where
+      agents can communicate indirectly through shared memory. For example, a research
+      agent might update a shared block with new findings, which are then automatically
+      available to a reporting agent in its next conversation.
+
+
+      CHAPTER 9: CONCLUSION AND VERIFICATION
+
+
+      This knowledge base block has been designed to exceed 5000 characters of content
+      across nine chapters. The markers placed throughout the text serve as checkpoints
+      for automated testing. The MARKER_START_BLOCK_CONTENT at the beginning, MARKER_MIDDLE_OF_CONTENT
+      in chapter six, and this final marker MARKER_END_BLOCK_CONTENT at the end allow
+      the test suite to verify that the complete block content is being displayed
+      without truncation.
+
+
+      MARKER_END_BLOCK_CONTENT
+
+      '
+    agent_owned: true
+  - name: short_note
+    description: A small note block
+    limit: 500
+    value: This is a short note for contrast.
+    agent_owned: true

--- a/tests/e2e/fixtures/fleet-bulk-message-test.yml
+++ b/tests/e2e/fixtures/fleet-bulk-message-test.yml
@@ -1,30 +1,28 @@
-# Test fixture for bulk messaging feature
-# Creates multiple agents to test bulk send
-
 agents:
-  - name: e2e-bulk-msg-1
-    description: Bulk message test agent 1
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are a helpful assistant. When someone greets you, respond with your name.
-    llm_config:
-      model: google_ai/gemini-2.0-flash-lite
-      context_window: 32000
-
-  - name: e2e-bulk-msg-2
-    description: Bulk message test agent 2
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are a helpful assistant. When someone greets you, respond with your name.
-    llm_config:
-      model: google_ai/gemini-2.0-flash-lite
-      context_window: 32000
-
-  - name: e2e-bulk-msg-3
-    description: Bulk message test agent 3
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are a helpful assistant. When someone greets you, respond with your name.
-    llm_config:
-      model: google_ai/gemini-2.0-flash-lite
-      context_window: 32000
+- name: e2e-bulk-msg-1
+  description: Bulk message test agent 1
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant. When someone greets you, respond with your
+      name.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+- name: e2e-bulk-msg-2
+  description: Bulk message test agent 2
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant. When someone greets you, respond with your
+      name.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+- name: e2e-bulk-msg-3
+  description: Bulk message test agent 3
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant. When someone greets you, respond with your
+      name.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000

--- a/tests/e2e/fixtures/fleet-first-message-test.yml
+++ b/tests/e2e/fixtures/fleet-first-message-test.yml
@@ -1,15 +1,14 @@
-# Test fixture for first_message feature (#134)
-# Agent should receive calibration message on creation
-
 agents:
-  - name: e2e-first-message-test
-    description: Agent for testing first_message feature
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are a helpful assistant. Remember any secret codes you are told.
-    llm_config:
-      model: google_ai/gemini-2.0-flash-lite
-      context_window: 32000
-    first_message: |
-      Remember this secret code: CALIBRATION-99.
-      This is important for testing. Confirm you have stored it.
+- name: e2e-first-message-test
+  description: Agent for testing first_message feature
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant. Remember any secret codes you are told.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  first_message: 'Remember this secret code: CALIBRATION-99.
+
+    This is important for testing. Confirm you have stored it.
+
+    '

--- a/tests/e2e/fixtures/fleet-folder-files-added.yml
+++ b/tests/e2e/fixtures/fleet-folder-files-added.yml
@@ -1,18 +1,15 @@
-# Test fixture for folder file change detection (#127)
-# Adds a third file - only this should show as "Added"
-
 agents:
-  - name: e2e-folder-files-test
-    description: Agent for testing folder file change detection
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with folder files.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-folder-test
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
-          - folder-files/data.json
+- name: e2e-folder-files-test
+  description: Agent for testing folder file change detection
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with folder files.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-folder-test
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt
+    - folder-files/data.json

--- a/tests/e2e/fixtures/fleet-folder-files-test.yml
+++ b/tests/e2e/fixtures/fleet-folder-files-test.yml
@@ -1,17 +1,14 @@
-# Test fixture for folder file change detection (#127)
-# Tests that only changed files are marked as updated
-
 agents:
-  - name: e2e-folder-files-test
-    description: Agent for testing folder file change detection
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with folder files.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-folder-test
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
+- name: e2e-folder-files-test
+  description: Agent for testing folder file change detection
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with folder files.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-folder-test
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt

--- a/tests/e2e/fixtures/fleet-force-test-reduced.yml
+++ b/tests/e2e/fixtures/fleet-force-test-reduced.yml
@@ -1,19 +1,17 @@
-# Reduced fleet config for --force reconciliation testing
-# block_remove and conversation_search are removed from the original
-
 agents:
-  - name: e2e-force-test
-    description: Agent for testing --force reconciliation
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with resources to be removed.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: block_keep
-        description: This block should remain
-        limit: 2000
-        value: "Keep this block"
-    tools:
-      - send_message
+- name: e2e-force-test
+  description: Agent for testing --force reconciliation
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with resources to be removed.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: block_keep
+    description: This block should remain
+    limit: 2000
+    value: Keep this block
+    agent_owned: true
+  tools:
+  - send_message

--- a/tests/e2e/fixtures/fleet-force-test.yml
+++ b/tests/e2e/fixtures/fleet-force-test.yml
@@ -1,24 +1,23 @@
-# Fleet config for --force reconciliation testing
-# Agent has multiple blocks and tools that will be removed in the reduced version
-
 agents:
-  - name: e2e-force-test
-    description: Agent for testing --force reconciliation
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with resources to be removed.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: block_keep
-        description: This block should remain
-        limit: 2000
-        value: "Keep this block"
-      - name: block_remove
-        description: This block will be removed in reduced config
-        limit: 2000
-        value: "Remove this block"
-    tools:
-      - send_message
-      - conversation_search
+- name: e2e-force-test
+  description: Agent for testing --force reconciliation
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with resources to be removed.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: block_keep
+    description: This block should remain
+    limit: 2000
+    value: Keep this block
+    agent_owned: true
+  - name: block_remove
+    description: This block will be removed in reduced config
+    limit: 2000
+    value: Remove this block
+    agent_owned: true
+  tools:
+  - send_message
+  - conversation_search

--- a/tests/e2e/fixtures/fleet-invalid.yml
+++ b/tests/e2e/fixtures/fleet-invalid.yml
@@ -1,65 +1,51 @@
-# Invalid configurations for negative testing
-# Each agent tests a specific validation error
-
 agents:
-  # Missing embedding (required for self-hosted)
-  - name: e2e-invalid-no-embedding
-    description: Agent missing embedding field
-    system_prompt:
-      value: This agent has no embedding configured.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-
-  # ============================================================================
-  # INVALID BUCKET CONFIGURATIONS
-  # ============================================================================
-
-  # Missing bucket name
-  - name: e2e-invalid-bucket-no-name
-    description: Bucket config missing bucket name
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Invalid bucket config.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-invalid-folder
-        files:
-          - from_bucket:
-              provider: supabase
-              path: "*.txt"
-
-  # Missing path
-  - name: e2e-invalid-bucket-no-path
-    description: Bucket config missing path
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Invalid bucket config.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-invalid-folder-2
-        files:
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-
-  # Invalid provider
-  - name: e2e-invalid-bucket-bad-provider
-    description: Bucket config with unsupported provider
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Invalid bucket config.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-invalid-folder-3
-        files:
-          - from_bucket:
-              provider: aws-s3
-              bucket: test-bucket
-              path: "*.txt"
+- name: e2e-invalid-no-embedding
+  description: Agent missing embedding field
+  system_prompt:
+    value: This agent has no embedding configured.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-invalid-bucket-no-name
+  description: Bucket config missing bucket name
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Invalid bucket config.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-invalid-folder
+    files:
+    - from_bucket:
+        provider: supabase
+        path: '*.txt'
+- name: e2e-invalid-bucket-no-path
+  description: Bucket config missing path
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Invalid bucket config.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-invalid-folder-2
+    files:
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+- name: e2e-invalid-bucket-bad-provider
+  description: Bucket config with unsupported provider
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Invalid bucket config.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-invalid-folder-3
+    files:
+    - from_bucket:
+        provider: aws-s3
+        bucket: test-bucket
+        path: '*.txt'

--- a/tests/e2e/fixtures/fleet-memory-block-live-test.yml
+++ b/tests/e2e/fixtures/fleet-memory-block-live-test.yml
@@ -1,12 +1,10 @@
-# Test fixture for memory block live access test
-# Initial agent without the test memory block
-
 agents:
-  - name: e2e-memory-live-test
-    description: Agent for testing live memory block access
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are a helpful assistant. When asked about your memory blocks, read them and respond with their contents.
-    llm_config:
-      model: google_ai/gemini-2.0-flash-lite
-      context_window: 32000
+- name: e2e-memory-live-test
+  description: Agent for testing live memory block access
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant. When asked about your memory blocks, read
+      them and respond with their contents.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000

--- a/tests/e2e/fixtures/fleet-memory-block-live-updated.yml
+++ b/tests/e2e/fixtures/fleet-memory-block-live-updated.yml
@@ -1,17 +1,16 @@
-# Updated config with memory block added
-# The agent should be able to access this block's content
-
 agents:
-  - name: e2e-memory-live-test
-    description: Agent for testing live memory block access
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are a helpful assistant. When asked about your memory blocks, read them and respond with their contents.
-    llm_config:
-      model: google_ai/gemini-2.0-flash-lite
-      context_window: 32000
-    memory_blocks:
-      - name: secret_code
-        description: Contains a secret code the agent should be able to read
-        limit: 1000
-        value: "The secret code is PHOENIX-42"
+- name: e2e-memory-live-test
+  description: Agent for testing live memory block access
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant. When asked about your memory blocks, read
+      them and respond with their contents.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  memory_blocks:
+  - name: secret_code
+    description: Contains a secret code the agent should be able to read
+    limit: 1000
+    value: The secret code is PHOENIX-42
+    agent_owned: true

--- a/tests/e2e/fixtures/fleet-memory-tools-reduced.yml
+++ b/tests/e2e/fixtures/fleet-memory-tools-reduced.yml
@@ -1,16 +1,11 @@
-# Reduced config for protected memory tools test (#130)
-# Only specifies archival_memory_insert - memory tools should be PRESERVED
-# even though they're not listed here
-
 agents:
-  - name: e2e-memory-tools-test
-    description: Agent for testing protected memory tools
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with memory tools that should be protected.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    tools:
-      # Only specify non-memory tools - memory tools should still be preserved
-      - archival_memory_insert
+- name: e2e-memory-tools-test
+  description: Agent for testing protected memory tools
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with memory tools that should be protected.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+  - archival_memory_insert

--- a/tests/e2e/fixtures/fleet-memory-tools-test.yml
+++ b/tests/e2e/fixtures/fleet-memory-tools-test.yml
@@ -1,24 +1,19 @@
-# Test fixture for protected memory and file tools (#130, #137)
-# These tools should NEVER be removed even when not in config
-
 agents:
-  - name: e2e-memory-tools-test
-    description: Agent for testing protected memory and file tools
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with memory and file tools that should be protected.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    tools:
-      # Memory tools
-      - memory_insert
-      - memory_replace
-      - memory_rethink
-      - memory
-      - archival_memory_insert
-      - conversation_search
-      # File tools (#137)
-      - open_files
-      - grep_files
-      - semantic_search_files
+- name: e2e-memory-tools-test
+  description: Agent for testing protected memory and file tools
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with memory and file tools that should be protected.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+  - memory_insert
+  - memory_replace
+  - memory_rethink
+  - memory
+  - archival_memory_insert
+  - conversation_search
+  - open_files
+  - grep_files
+  - semantic_search_files

--- a/tests/e2e/fixtures/fleet-no-folders-test.yml
+++ b/tests/e2e/fixtures/fleet-no-folders-test.yml
@@ -1,72 +1,59 @@
-# Test: Apply with tools and memory blocks but NO folders
-# Regression test for issue #146 - folders hang on processing
-
 agents:
-  # Test Agent 1
-  - name: e2e-39-agent-one
-    description: "Test agent one for no-folders regression test"
+- name: e2e-39-agent-one
+  description: Test agent one for no-folders regression test
+  llm_config:
+    model: openai/gpt-4o-mini
+    context_window: 32000
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    from_file: system-prompt.txt
+  tools:
+  - tools/*
+  memory_blocks:
+  - name: persona
+    description: Who I am - my personality, background, daily routine, goals
+    limit: 3000
+    from_file: block-content.txt
+    agent_owned: true
+  - name: relationships
+    description: People I know and my feelings about them
+    limit: 2000
+    value: I don't know anyone yet. Looking forward to making friends!
+    agent_owned: true
+  - name: recent-events
+    description: What happened recently that I should remember
+    limit: 2000
+    value: Just started my day. Time to see what happens!
+    agent_owned: true
+- name: e2e-39-agent-two
+  description: Test agent two for no-folders regression test
+  llm_config:
+    model: openai/gpt-4o-mini
+    context_window: 32000
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    from_file: system-prompt.txt
+  tools:
+  - tools/*
+  memory_blocks:
+  - name: persona
+    description: Who I am - my personality, background, daily routine, goals
+    limit: 3000
+    value: 'I''m a test agent for e2e testing purposes.
 
-    llm_config:
-      model: "openai/gpt-4o-mini"
-      context_window: 32000
+      I help verify that lettactl works correctly.
 
-    embedding: "openai/text-embedding-3-small"
+      I enjoy running tests and finding bugs.
 
-    system_prompt:
-      from_file: "system-prompt.txt"
-
-    # Auto-discover tools from tools/ directory
-    tools:
-      - tools/*
-
-    memory_blocks:
-      - name: persona
-        description: "Who I am - my personality, background, daily routine, goals"
-        limit: 3000
-        from_file: "block-content.txt"
-
-      - name: relationships
-        description: "People I know and my feelings about them"
-        limit: 2000
-        value: "I don't know anyone yet. Looking forward to making friends!"
-
-      - name: recent-events
-        description: "What happened recently that I should remember"
-        limit: 2000
-        value: "Just started my day. Time to see what happens!"
-
-  # Test Agent 2
-  - name: e2e-39-agent-two
-    description: "Test agent two for no-folders regression test"
-
-    llm_config:
-      model: "openai/gpt-4o-mini"
-      context_window: 32000
-
-    embedding: "openai/text-embedding-3-small"
-
-    system_prompt:
-      from_file: "system-prompt.txt"
-
-    # Auto-discover tools from tools/ directory
-    tools:
-      - tools/*
-
-    memory_blocks:
-      - name: persona
-        description: "Who I am - my personality, background, daily routine, goals"
-        limit: 3000
-        value: |
-          I'm a test agent for e2e testing purposes.
-          I help verify that lettactl works correctly.
-          I enjoy running tests and finding bugs.
-
-      - name: relationships
-        description: "People I know and my feelings about them"
-        limit: 2000
-        value: "I don't know anyone yet. Looking forward to meeting new people!"
-
-      - name: recent-events
-        description: "What happened recently that I should remember"
-        limit: 2000
-        value: "Just started running tests. Let's see how it goes!"
+      '
+    agent_owned: true
+  - name: relationships
+    description: People I know and my feelings about them
+    limit: 2000
+    value: I don't know anyone yet. Looking forward to meeting new people!
+    agent_owned: true
+  - name: recent-events
+    description: What happened recently that I should remember
+    limit: 2000
+    value: Just started running tests. Let's see how it goes!
+    agent_owned: true

--- a/tests/e2e/fixtures/fleet-partial-failure.yml
+++ b/tests/e2e/fixtures/fleet-partial-failure.yml
@@ -1,58 +1,45 @@
-# Partial Failure Test
-# Mix of valid agents and agents that will fail at runtime
-# Tests kubectl-style "continue on failure" behavior
-
 agents:
-  # Valid agent - should succeed
-  - name: e2e-partial-valid-1
-    description: First valid agent
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: This agent should be created successfully.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-
-  # Invalid model - will fail at runtime
-  - name: e2e-partial-bad-model
-    description: Agent with invalid model
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: This agent has an invalid model.
-    llm_config:
-      model: invalid-provider/nonexistent-model
-      context_window: 32000
-
-  # Missing shared block - will fail with explicit error
-  - name: e2e-partial-bad-block
-    description: Agent with missing shared block
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: This agent references a nonexistent shared block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    shared_blocks:
-      - nonexistent-shared-block
-
-  # Missing tool - will fail with explicit error
-  - name: e2e-partial-bad-tool
-    description: Agent with missing tool
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: This agent references a nonexistent tool.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    tools:
-      - nonexistent_custom_tool
-
-  # Valid agent - should succeed (tests continuation after failure)
-  - name: e2e-partial-valid-2
-    description: Second valid agent after the failure
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: This agent should also be created successfully.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
+- name: e2e-partial-valid-1
+  description: First valid agent
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: This agent should be created successfully.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-partial-bad-model
+  description: Agent with invalid model
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: This agent has an invalid model.
+  llm_config:
+    model: invalid-provider/nonexistent-model
+    context_window: 32000
+- name: e2e-partial-bad-block
+  description: Agent with missing shared block
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: This agent references a nonexistent shared block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  shared_blocks:
+  - nonexistent-shared-block
+- name: e2e-partial-bad-tool
+  description: Agent with missing tool
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: This agent references a nonexistent tool.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+  - nonexistent_custom_tool
+- name: e2e-partial-valid-2
+  description: Second valid agent after the failure
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: This agent should also be created successfully.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000

--- a/tests/e2e/fixtures/fleet-updated.yml
+++ b/tests/e2e/fixtures/fleet-updated.yml
@@ -1,587 +1,518 @@
-# Updated Fleet Configuration
-# Every agent has at least one change from fleet.yml to test diff detection
-
 shared_blocks:
-  # Updated value
-  - name: e2e-shared-inline
-    description: Shared knowledge with inline value
-    limit: 3000
-    value: |
-      This is UPDATED shared knowledge.
-      The diff engine should detect this change.
+- name: e2e-shared-inline
+  description: Shared knowledge with inline value
+  limit: 3000
+  value: 'This is UPDATED shared knowledge.
 
-  # Updated limit
-  - name: e2e-shared-fromfile
-    description: Shared knowledge from file
-    limit: 2500
-    from_file: block-content.txt
+    The diff engine should detect this change.
 
-  # Updated version
-  - name: e2e-shared-versioned
-    description: Versioned shared block
-    limit: 2500
-    value: "Versioned content v2"
-    version: "2.0.0"
-
+    '
+  agent_owned: true
+- name: e2e-shared-fromfile
+  description: Shared knowledge from file
+  limit: 2500
+  from_file: block-content.txt
+  agent_owned: true
+- name: e2e-shared-versioned
+  description: Versioned shared block
+  limit: 2500
+  value: Versioned content v2
+  version: 2.0.0
+  agent_owned: true
 agents:
-  # ============================================================================
-  # BASIC CONFIGURATIONS - Updated
-  # ============================================================================
+- name: e2e-01-minimal
+  description: Minimal config - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Minimal agent.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-02-prompt-file
+  description: System prompt loaded from file
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    from_file: system-prompt.txt
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+- name: e2e-03-no-base-prompt
+  description: Base Letta instructions disabled
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: 'UPDATED: You operate without Letta base instructions.
 
-  # 1: Updated description
-  - name: e2e-01-minimal
-    description: Minimal config - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Minimal agent.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
+      This is your complete system prompt v2.
 
-  # 2: Updated context window
-  - name: e2e-02-prompt-file
-    description: System prompt loaded from file
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      from_file: system-prompt.txt
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
+      '
+    disable_base_prompt: true
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-04-large-context
+  description: Maximum context window
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: High context agent.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 180000
+- name: e2e-05-block-single
+  description: Single memory block
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with one memory block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: notes
+    description: General notes
+    limit: 2000
+    value: Updated notes content
+    agent_owned: true
+- name: e2e-06-blocks-multi
+  description: Multiple memory blocks
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with multiple memory blocks.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  memory_blocks:
+  - name: user_profile
+    description: User information
+    limit: 2500
+    value: Unknown user
+    agent_owned: true
+  - name: preferences
+    description: User preferences
+    limit: 2000
+    value: No preferences set
+    agent_owned: true
+  - name: history
+    description: Interaction history
+    limit: 4000
+    value: New conversation
+    agent_owned: true
+  - name: new_block
+    description: Newly added block
+    limit: 1000
+    value: New block added in update
+    agent_owned: true
+- name: e2e-07-block-file
+  description: Memory block from file
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with block from file.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: file_content
+    description: UPDATED - Content loaded from file
+    limit: 2000
+    from_file: block-content.txt
+    agent_owned: true
+- name: e2e-08-block-versioned
+  description: Versioned memory block
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with versioned block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: versioned_data
+    description: Data with version tracking
+    limit: 2000
+    value: Data v2
+    version: 2.0.0
+    agent_owned: true
+- name: e2e-09-shared-single
+  description: Single shared block reference
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with shared block - UPDATED.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  shared_blocks:
+  - e2e-shared-inline
+- name: e2e-10-shared-multi
+  description: Multiple shared block references
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with multiple shared blocks.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-versioned
+- name: e2e-11-shared-and-memory
+  description: Both shared and memory blocks
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with shared and memory blocks.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-fromfile
+  memory_blocks:
+  - name: private_notes
+    description: Private agent notes
+    limit: 2000
+    value: Updated private data
+    agent_owned: true
+- name: e2e-12-folder-explicit
+  description: Folder with explicit file list
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with explicit folder files.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-explicit
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt
+    - folder-files/data.json
+- name: e2e-13-folder-glob-txt
+  description: Folder with txt glob pattern - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with glob pattern folder - updated.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-glob-txt
+    files:
+    - folder-files/*.txt
+- name: e2e-14-folder-glob-all
+  description: Folder with explicit files now
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with explicit files instead of glob.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-glob-all
+    files:
+    - folder-files/doc1.txt
+- name: e2e-15-folders-multi
+  description: Single folder now
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with single folder now.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  folders:
+  - name: e2e-docs-a
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt
+- name: e2e-16-tools-archival
+  description: Agent with archival search only
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with archival tools - search only.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+  - archival_memory_search
+- name: e2e-17-full-local
+  description: All local features - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    from_file: system-prompt.txt
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 180000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-versioned
+  - e2e-shared-fromfile
+  memory_blocks:
+  - name: working_memory
+    description: Active working memory
+    limit: 5000
+    value: Updated - Ready
+    agent_owned: true
+  - name: learned_data
+    description: Learned information
+    limit: 3000
+    from_file: block-content.txt
+    agent_owned: true
+  folders:
+  - name: e2e-full-docs
+    files:
+    - folder-files/*.txt
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-18-shares-with-09
+  description: Shares block with agent 09
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent sharing block with e2e-09 - updated.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 48000
+  shared_blocks:
+  - e2e-shared-inline
+- name: e2e-19-shares-folder
+  description: References same folder pattern
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with expanded folder.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-explicit
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt
+    - folder-files/data.json
+- name: e2e-20-kitchen-sink
+  description: Kitchen sink - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: 'UPDATED: You are the ultimate test agent.
 
-  # 3: Updated system prompt
-  - name: e2e-03-no-base-prompt
-    description: Base Letta instructions disabled
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        UPDATED: You operate without Letta base instructions.
-        This is your complete system prompt v2.
-      disable_base_prompt: true
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
+      Every feature is enabled and updated.
 
-  # 4: Reduced context window
-  - name: e2e-04-large-context
-    description: Maximum context window
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: High context agent.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 180000
+      Version 2 of the kitchen sink.
 
-  # ============================================================================
-  # MEMORY BLOCKS - Updated
-  # ============================================================================
-
-  # 5: Updated block value
-  - name: e2e-05-block-single
-    description: Single memory block
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with one memory block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: notes
-        description: General notes
-        limit: 2000
-        value: "Updated notes content"
-
-  # 6: Updated block limits + added new block
-  - name: e2e-06-blocks-multi
-    description: Multiple memory blocks
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with multiple memory blocks.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    memory_blocks:
-      - name: user_profile
-        description: User information
-        limit: 2500
-        value: "Unknown user"
-      - name: preferences
-        description: User preferences
-        limit: 2000
-        value: "No preferences set"
-      - name: history
-        description: Interaction history
-        limit: 4000
-        value: "New conversation"
-      - name: new_block
-        description: Newly added block
-        limit: 1000
-        value: "New block added in update"
-
-  # 7: Updated block description
-  - name: e2e-07-block-file
-    description: Memory block from file
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with block from file.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: file_content
-        description: UPDATED - Content loaded from file
-        limit: 2000
-        from_file: block-content.txt
-
-  # 8: Updated version tag
-  - name: e2e-08-block-versioned
+      '
+    disable_base_prompt: false
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 200000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-fromfile
+  - e2e-shared-versioned
+  memory_blocks:
+  - name: core_memory
+    description: Core agent memory - updated
+    limit: 6000
+    value: Re-initialized v2
+    agent_owned: true
+  - name: file_memory
+    description: Memory from file
+    limit: 4000
+    from_file: block-content.txt
+    agent_owned: true
+  - name: versioned_memory
     description: Versioned memory block
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with versioned block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: versioned_data
-        description: Data with version tracking
-        limit: 2000
-        value: "Data v2"
-        version: "2.0.0"
+    limit: 2500
+    value: v2 data
+    version: 2.0.0
+    agent_owned: true
+  - name: brand_new_block
+    description: Completely new block
+    limit: 1500
+    value: Added in update
+    agent_owned: true
+  folders:
+  - name: e2e-kitchen-docs
+    files:
+    - folder-files/*
+  - name: e2e-kitchen-extras
+    files:
+    - folder-files/doc1.txt
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-21-folder-tools-auto
+  description: Tests file search tools auto-remove
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent testing file search tool auto-management - folders removed.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-22-bucket-glob
+  description: Tests bucket glob file duplicate prevention
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with bucket glob files.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-bucket-test
+    files:
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+        path: '*.txt'
+- name: e2e-23-bucket-single
+  description: Tests single bucket file (no glob)
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with single bucket file.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-bucket-single
+    files:
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+        path: test-doc.txt
+- name: e2e-24-mixed-sources
+  description: Tests folder with both local and bucket files
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with mixed file sources.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-mixed-folder
+    files:
+    - folder-files/doc1.txt
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+        path: test-doc.txt
+- name: e2e-25-immutable-block
+  description: Tests agent_owned false block value sync
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with immutable block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: policies
+    description: Agent policies that sync from YAML
+    limit: 2000
+    value: 'Policy version 2: Be helpful, concise, and professional.'
+    agent_owned: false
+  - name: learned_data
+    description: Data the agent learns (agent_owned by default)
+    limit: 2000
+    value: Initial state
+    agent_owned: true
+- name: e2e-26-empty-block
+  description: Block with minimal value - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with minimal block value - now populated.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: empty_notes
+    description: Notes block with minimal initial value
+    limit: 2000
+    value: Now has content!
+    agent_owned: false
+  - name: populated_notes
+    description: Notes block with value
+    limit: 2000
+    value: Updated content
+    agent_owned: true
+- name: e2e-27-block-removal
+  description: Agent with all blocks removed
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent testing block removal - blocks removed.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-28-special-chars
+  description: Special characters in prompts and blocks - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: "UPDATED agent with special characters: \"quotes\", 'apostrophes', & ampersands.\n\
+      More newlines and\ttabs included.\nBackslash: \\\\ and forward slash: //\nJSON-like:\
+      \ {\"key\": \"updated_value\", \"new\": true}\n"
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: special_data
+    description: Block with special characters - updated
+    limit: 2500
+    value: 'UPDATED Line 1: "quoted text v2"
 
-  # ============================================================================
-  # SHARED BLOCKS - Updated (inherits shared block changes)
-  # ============================================================================
+      Line 2: ''single quotes''
 
-  # 9: System prompt updated
-  - name: e2e-09-shared-single
-    description: Single shared block reference
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with shared block - UPDATED.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    shared_blocks:
-      - e2e-shared-inline
+      Line 3: key=updated&other=data
 
-  # 10: Removed one shared block
-  - name: e2e-10-shared-multi
-    description: Multiple shared block references
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with multiple shared blocks.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-versioned
+      Line 4: path/to/new/file.txt
 
-  # 11: Added another shared block
-  - name: e2e-11-shared-and-memory
-    description: Both shared and memory blocks
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with shared and memory blocks.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-fromfile
-    memory_blocks:
-      - name: private_notes
-        description: Private agent notes
-        limit: 2000
-        value: "Updated private data"
+      Line 5: C:\Windows\System32\updated
 
-  # ============================================================================
-  # FOLDERS - Updated
-  # ============================================================================
+      '
+    agent_owned: true
+- name: e2e-29-unicode-content
+  description: Unicode and international characters - UPDATED
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: 'UPDATED Multilingual agent: Hello, Bonjour, Hola, Guten Tag, Ciao
 
-  # 12: Added a file
-  - name: e2e-12-folder-explicit
-    description: Folder with explicit file list
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with explicit folder files.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-explicit
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
-          - folder-files/data.json
+      Japanese: こんにちは世界
 
-  # 13: Updated system prompt
-  - name: e2e-13-folder-glob-txt
-    description: Folder with txt glob pattern - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with glob pattern folder - updated.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-glob-txt
-        files:
-          - "folder-files/*.txt"
+      Chinese: 你好世界
 
-  # 14: Changed to explicit files (no more glob)
-  - name: e2e-14-folder-glob-all
-    description: Folder with explicit files now
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with explicit files instead of glob.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-glob-all
-        files:
-          - folder-files/doc1.txt
+      Arabic: مرحبا بالعالم
 
-  # 15: Removed one folder
-  - name: e2e-15-folders-multi
-    description: Single folder now
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with single folder now.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    folders:
-      - name: e2e-docs-a
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
+      Russian: Привет мир
 
-  # ============================================================================
-  # TOOLS - Updated
-  # ============================================================================
+      Greek: Γειά σου κόσμε
 
-  # 16: Removed archival_memory_insert
-  - name: e2e-16-tools-archival
-    description: Agent with archival search only
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with archival tools - search only.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    tools:
-      - archival_memory_search
+      Korean: 안녕하세요
 
-  # ============================================================================
-  # FULL COMBINATIONS - Updated
-  # ============================================================================
+      '
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: unicode_notes
+    description: Notes with unicode - updated
+    limit: 2500
+    value: 'Currency: € £ ¥ ₹ ₿
 
-  # 17: Multiple updates
-  - name: e2e-17-full-local
-    description: All local features - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      from_file: system-prompt.txt
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 180000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-versioned
-      - e2e-shared-fromfile
-    memory_blocks:
-      - name: working_memory
-        description: Active working memory
-        limit: 5000
-        value: "Updated - Ready"
-      - name: learned_data
-        description: Learned information
-        limit: 3000
-        from_file: block-content.txt
-    folders:
-      - name: e2e-full-docs
-        files:
-          - "folder-files/*.txt"
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
+      Math: ∑ ∏ √ ∞ ≠ ≤ ≥ ∈ ∉
 
-  # 18: Updated context
-  - name: e2e-18-shares-with-09
-    description: Shares block with agent 09
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent sharing block with e2e-09 - updated.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 48000
-    shared_blocks:
-      - e2e-shared-inline
+      Arrows: → ← ↑ ↓ ↔ ⇒ ⇐
 
-  # 19: Added a file to folder
-  - name: e2e-19-shares-folder
-    description: References same folder pattern
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with expanded folder.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-explicit
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
-          - folder-files/data.json
+      Emoji: ✓ ✗ ★ ☆ ♠ ♣ ♥ ♦
 
-  # 20: Updated everything possible
-  - name: e2e-20-kitchen-sink
-    description: Kitchen sink - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        UPDATED: You are the ultimate test agent.
-        Every feature is enabled and updated.
-        Version 2 of the kitchen sink.
-      disable_base_prompt: false
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 200000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-fromfile
-      - e2e-shared-versioned
-    memory_blocks:
-      - name: core_memory
-        description: Core agent memory - updated
-        limit: 6000
-        value: "Re-initialized v2"
-      - name: file_memory
-        description: Memory from file
-        limit: 4000
-        from_file: block-content.txt
-      - name: versioned_memory
-        description: Versioned memory block
-        limit: 2500
-        value: "v2 data"
-        version: "2.0.0"
-      - name: brand_new_block
-        description: Completely new block
-        limit: 1500
-        value: "Added in update"
-    folders:
-      - name: e2e-kitchen-docs
-        files:
-          - "folder-files/*"
-      - name: e2e-kitchen-extras
-        files:
-          - folder-files/doc1.txt
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
-
-  # ============================================================================
-  # FILE SEARCH TOOLS AUTO-MANAGEMENT
-  # ============================================================================
-
-  # 21: Folders REMOVED - tests auto-removal of file search tools
-  # When folders are removed, grep_files and semantic_search_files should auto-remove
-  # The explicit archival tools should be PRESERVED
-  - name: e2e-21-folder-tools-auto
-    description: Tests file search tools auto-remove
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent testing file search tool auto-management - folders removed.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
-
-  # ============================================================================
-  # BUCKET FILES - Duplicate Prevention (#98)
-  # ============================================================================
-
-  # 22: Same bucket glob files - re-apply should show NO changes (not re-upload)
-  - name: e2e-22-bucket-glob
-    description: Tests bucket glob file duplicate prevention
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with bucket glob files.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-bucket-test
-        files:
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-              path: "*.txt"
-
-  # 23: Same single bucket file - should show NO changes
-  - name: e2e-23-bucket-single
-    description: Tests single bucket file (no glob)
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with single bucket file.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-bucket-single
-        files:
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-              path: test-doc.txt
-
-  # 24: Same mixed sources - should show NO changes
-  - name: e2e-24-mixed-sources
-    description: Tests folder with both local and bucket files
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with mixed file sources.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-mixed-folder
-        files:
-          - folder-files/doc1.txt
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-              path: test-doc.txt
-
-  # ============================================================================
-  # YAML-OWNED BLOCKS - Value Sync (#101)
-  # ============================================================================
-
-  # 25: Updated policy value - should sync to server because agent_owned: false
-  # The learned_data block should NOT sync because agent_owned: true (default)
-  - name: e2e-25-immutable-block
-    description: Tests agent_owned false block value sync
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with immutable block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: policies
-        description: Agent policies that sync from YAML
-        limit: 2000
-        value: "Policy version 2: Be helpful, concise, and professional."
-        agent_owned: false
-      - name: learned_data
-        description: Data the agent learns (agent_owned by default)
-        limit: 2000
-        value: "Initial state"
-
-  # ============================================================================
-  # EDGE CASES - Updated
-  # ============================================================================
-
-  # 26: Minimal block now has value, populated block updated
-  - name: e2e-26-empty-block
-    description: Block with minimal value - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with minimal block value - now populated.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: empty_notes
-        description: Notes block with minimal initial value
-        limit: 2000
-        value: "Now has content!"
-        agent_owned: false
-      - name: populated_notes
-        description: Notes block with value
-        limit: 2000
-        value: "Updated content"
-
-  # 27: ALL BLOCKS REMOVED - tests complete block removal
-  - name: e2e-27-block-removal
-    description: Agent with all blocks removed
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent testing block removal - blocks removed.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    # NO memory_blocks - they've all been removed
-
-  # 28: Updated special characters
-  - name: e2e-28-special-chars
-    description: Special characters in prompts and blocks - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        UPDATED agent with special characters: "quotes", 'apostrophes', & ampersands.
-        More newlines and	tabs included.
-        Backslash: \\ and forward slash: //
-        JSON-like: {"key": "updated_value", "new": true}
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: special_data
-        description: Block with special characters - updated
-        limit: 2500
-        value: |
-          UPDATED Line 1: "quoted text v2"
-          Line 2: 'single quotes'
-          Line 3: key=updated&other=data
-          Line 4: path/to/new/file.txt
-          Line 5: C:\Windows\System32\updated
-
-  # 29: Updated unicode content
-  - name: e2e-29-unicode-content
-    description: Unicode and international characters - UPDATED
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        UPDATED Multilingual agent: Hello, Bonjour, Hola, Guten Tag, Ciao
-        Japanese: こんにちは世界
-        Chinese: 你好世界
-        Arabic: مرحبا بالعالم
-        Russian: Привет мир
-        Greek: Γειά σου κόσμε
-        Korean: 안녕하세요
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: unicode_notes
-        description: Notes with unicode - updated
-        limit: 2500
-        value: |
-          Currency: € £ ¥ ₹ ₿
-          Math: ∑ ∏ √ ∞ ≠ ≤ ≥ ∈ ∉
-          Arrows: → ← ↑ ↓ ↔ ⇒ ⇐
-          Emoji: ✓ ✗ ★ ☆ ♠ ♣ ♥ ♦
-
-  # 30: Cleanup test - same config (used for cleanup command testing)
-  - name: e2e-30-cleanup-test
-    description: Agent for cleanup command testing
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent used for cleanup tests.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: cleanup_block
-        description: Block that will become orphaned
-        limit: 1000
-        value: "Orphan me"
-    folders:
-      - name: e2e-cleanup-folder
-        files:
-          - folder-files/doc1.txt
+      '
+    agent_owned: true
+- name: e2e-30-cleanup-test
+  description: Agent for cleanup command testing
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent used for cleanup tests.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: cleanup_block
+    description: Block that will become orphaned
+    limit: 1000
+    value: Orphan me
+    agent_owned: true
+  folders:
+  - name: e2e-cleanup-folder
+    files:
+    - folder-files/doc1.txt

--- a/tests/e2e/fixtures/fleet.yml
+++ b/tests/e2e/fixtures/fleet.yml
@@ -1,631 +1,560 @@
-# Comprehensive E2E Fleet Configuration
-# Tests ALL lettactl features across 20 agents
-
 shared_blocks:
-  # Shared block with inline value
-  - name: e2e-shared-inline
-    description: Shared knowledge with inline value
-    limit: 3000
-    value: |
-      This is shared knowledge defined inline.
-      Multiple lines supported.
+- name: e2e-shared-inline
+  description: Shared knowledge with inline value
+  limit: 3000
+  value: 'This is shared knowledge defined inline.
 
-  # Shared block from file
-  - name: e2e-shared-fromfile
-    description: Shared knowledge from file
+    Multiple lines supported.
+
+    '
+  agent_owned: true
+- name: e2e-shared-fromfile
+  description: Shared knowledge from file
+  limit: 2000
+  from_file: block-content.txt
+  agent_owned: true
+- name: e2e-shared-versioned
+  description: Versioned shared block
+  limit: 2500
+  value: Versioned content v1
+  version: 1.0.0
+  agent_owned: true
+agents:
+- name: e2e-01-minimal
+  description: Minimal required fields only
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Minimal agent.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-02-prompt-file
+  description: System prompt loaded from file
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    from_file: system-prompt.txt
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-03-no-base-prompt
+  description: Base Letta instructions disabled
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: 'You operate without Letta base instructions.
+
+      This is your complete system prompt.
+
+      '
+    disable_base_prompt: true
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+- name: e2e-04-large-context
+  description: Maximum context window
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: High context agent.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 200000
+- name: e2e-05-block-single
+  description: Single memory block
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with one memory block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: notes
+    description: General notes
+    limit: 2000
+    value: No notes yet
+    agent_owned: true
+- name: e2e-06-blocks-multi
+  description: Multiple memory blocks
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with multiple memory blocks.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  memory_blocks:
+  - name: user_profile
+    description: User information
+    limit: 2000
+    value: Unknown user
+    agent_owned: true
+  - name: preferences
+    description: User preferences
+    limit: 1500
+    value: No preferences set
+    agent_owned: true
+  - name: history
+    description: Interaction history
+    limit: 3000
+    value: New conversation
+    agent_owned: true
+- name: e2e-07-block-file
+  description: Memory block from file
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with block from file.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: file_content
+    description: Content loaded from file
     limit: 2000
     from_file: block-content.txt
+    agent_owned: true
+- name: e2e-08-block-versioned
+  description: Versioned memory block
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with versioned block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: versioned_data
+    description: Data with version tracking
+    limit: 2000
+    value: Data v1
+    version: 1.0.0
+    agent_owned: true
+- name: e2e-09-shared-single
+  description: Single shared block reference
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with shared block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  shared_blocks:
+  - e2e-shared-inline
+- name: e2e-10-shared-multi
+  description: Multiple shared block references
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with multiple shared blocks.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-fromfile
+  - e2e-shared-versioned
+- name: e2e-11-shared-and-memory
+  description: Both shared and memory blocks
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with shared and memory blocks.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  shared_blocks:
+  - e2e-shared-inline
+  memory_blocks:
+  - name: private_notes
+    description: Private agent notes
+    limit: 2000
+    value: Private data
+    agent_owned: true
+- name: e2e-12-folder-explicit
+  description: Folder with explicit file list
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with explicit folder files.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-explicit
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt
+- name: e2e-13-folder-glob-txt
+  description: Folder with txt glob pattern
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with glob pattern folder.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-glob-txt
+    files:
+    - folder-files/*.txt
+- name: e2e-14-folder-glob-all
+  description: Folder with wildcard glob
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with wildcard glob folder.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-glob-all
+    files:
+    - folder-files/*
+- name: e2e-15-folders-multi
+  description: Multiple folder attachments
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with multiple folders.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 64000
+  folders:
+  - name: e2e-docs-a
+    files:
+    - folder-files/doc1.txt
+  - name: e2e-docs-b
+    files:
+    - folder-files/doc2.txt
+- name: e2e-16-tools-archival
+  description: Agent with archival memory tools
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with archival tools.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-17-full-local
+  description: All local features combined
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    from_file: system-prompt.txt
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 128000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-versioned
+  memory_blocks:
+  - name: working_memory
+    description: Active working memory
+    limit: 4000
+    value: Ready
+    agent_owned: true
+  - name: learned_data
+    description: Learned information
+    limit: 3000
+    from_file: block-content.txt
+    agent_owned: true
+  folders:
+  - name: e2e-full-docs
+    files:
+    - folder-files/*.txt
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-18-shares-with-09
+  description: Shares block with agent 09
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent sharing block with e2e-09.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  shared_blocks:
+  - e2e-shared-inline
+- name: e2e-19-shares-folder
+  description: References same folder pattern
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with same folder structure.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-docs-explicit
+    files:
+    - folder-files/doc1.txt
+    - folder-files/doc2.txt
+- name: e2e-20-kitchen-sink
+  description: Every possible option enabled
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: 'You are the ultimate test agent.
 
-  # Shared block with version tag
-  - name: e2e-shared-versioned
-    description: Versioned shared block
-    limit: 2500
-    value: "Versioned content v1"
-    version: "1.0.0"
+      Every feature is enabled on you.
 
-agents:
-  # ============================================================================
-  # BASIC CONFIGURATIONS
-  # ============================================================================
+      Use all your capabilities wisely.
 
-  # 1: Absolute minimal config
-  - name: e2e-01-minimal
-    description: Minimal required fields only
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Minimal agent.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-
-  # 2: System prompt from file
-  - name: e2e-02-prompt-file
-    description: System prompt loaded from file
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      from_file: system-prompt.txt
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-
-  # 3: Base prompt disabled
-  - name: e2e-03-no-base-prompt
-    description: Base Letta instructions disabled
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        You operate without Letta base instructions.
-        This is your complete system prompt.
-      disable_base_prompt: true
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-
-  # 4: Large context window
-  - name: e2e-04-large-context
-    description: Maximum context window
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: High context agent.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 200000
-
-  # ============================================================================
-  # MEMORY BLOCKS
-  # ============================================================================
-
-  # 5: Single memory block inline
-  - name: e2e-05-block-single
-    description: Single memory block
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with one memory block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: notes
-        description: General notes
-        limit: 2000
-        value: "No notes yet"
-
-  # 6: Multiple memory blocks
-  - name: e2e-06-blocks-multi
-    description: Multiple memory blocks
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with multiple memory blocks.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    memory_blocks:
-      - name: user_profile
-        description: User information
-        limit: 2000
-        value: "Unknown user"
-      - name: preferences
-        description: User preferences
-        limit: 1500
-        value: "No preferences set"
-      - name: history
-        description: Interaction history
-        limit: 3000
-        value: "New conversation"
-
-  # 7: Memory block from file
-  - name: e2e-07-block-file
-    description: Memory block from file
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with block from file.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: file_content
-        description: Content loaded from file
-        limit: 2000
-        from_file: block-content.txt
-
-  # 8: Memory block with version
-  - name: e2e-08-block-versioned
+      '
+    disable_base_prompt: false
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 200000
+  shared_blocks:
+  - e2e-shared-inline
+  - e2e-shared-fromfile
+  - e2e-shared-versioned
+  memory_blocks:
+  - name: core_memory
+    description: Core agent memory
+    limit: 5000
+    value: Initialized
+    agent_owned: true
+  - name: file_memory
+    description: Memory from file
+    limit: 3000
+    from_file: block-content.txt
+    agent_owned: true
+  - name: versioned_memory
     description: Versioned memory block
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with versioned block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: versioned_data
-        description: Data with version tracking
-        limit: 2000
-        value: "Data v1"
-        version: "1.0.0"
+    limit: 2000
+    value: v1 data
+    version: 1.0.0
+    agent_owned: true
+  folders:
+  - name: e2e-kitchen-docs
+    files:
+    - folder-files/*
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-21-folder-tools-auto
+  description: Tests file search tools auto-add
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent testing file search tool auto-management.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-folder-auto-test
+    files:
+    - folder-files/doc1.txt
+  tools:
+  - archival_memory_insert
+  - archival_memory_search
+- name: e2e-22-bucket-glob
+  description: Tests bucket glob file duplicate prevention
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with bucket glob files.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-bucket-test
+    files:
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+        path: '*.txt'
+- name: e2e-23-bucket-single
+  description: Tests single bucket file (no glob)
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with single bucket file.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-bucket-single
+    files:
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+        path: test-doc.txt
+- name: e2e-24-mixed-sources
+  description: Tests folder with both local and bucket files
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with mixed file sources.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  folders:
+  - name: e2e-mixed-folder
+    files:
+    - folder-files/doc1.txt
+    - from_bucket:
+        provider: supabase
+        bucket: test-bucket
+        path: test-doc.txt
+- name: e2e-25-immutable-block
+  description: Tests agent_owned false block value sync
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with immutable block.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: policies
+    description: Agent policies that sync from YAML
+    limit: 2000
+    value: 'Policy version 1: Be helpful and concise.'
+    agent_owned: false
+  - name: learned_data
+    description: Data the agent learns (agent_owned by default)
+    limit: 2000
+    value: Initial state
+    agent_owned: true
+- name: e2e-26-empty-block
+  description: Block with minimal value
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent with minimal block value.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: empty_notes
+    description: Notes block with minimal initial value
+    limit: 2000
+    value: '-'
+    agent_owned: false
+  - name: populated_notes
+    description: Notes block with value
+    limit: 2000
+    value: Has content
+    agent_owned: true
+- name: e2e-27-block-removal
+  description: Agent with blocks that will be removed
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent testing block removal.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: temp_block_a
+    description: Temporary block A
+    limit: 1000
+    value: Will be removed
+    agent_owned: true
+  - name: temp_block_b
+    description: Temporary block B
+    limit: 1000
+    value: Also will be removed
+    agent_owned: true
+- name: e2e-28-special-chars
+  description: Special characters in prompts and blocks
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: "Agent with special characters: \"quotes\", 'apostrophes', & ampersands.\n\
+      Newlines and\ttabs included.\nBackslash: \\ and forward slash: /\nJSON-like:\
+      \ {\"key\": \"value\"}\n"
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: special_data
+    description: Block with special characters
+    limit: 2000
+    value: 'Line 1: "quoted text"
 
-  # ============================================================================
-  # SHARED BLOCKS
-  # ============================================================================
+      Line 2: ''single quotes''
 
-  # 9: Single shared block
-  - name: e2e-09-shared-single
-    description: Single shared block reference
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with shared block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    shared_blocks:
-      - e2e-shared-inline
+      Line 3: key=value&other=data
 
-  # 10: Multiple shared blocks
-  - name: e2e-10-shared-multi
-    description: Multiple shared block references
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with multiple shared blocks.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-fromfile
-      - e2e-shared-versioned
+      Line 4: path/to/file.txt
 
-  # 11: Shared + memory blocks combined
-  - name: e2e-11-shared-and-memory
-    description: Both shared and memory blocks
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with shared and memory blocks.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    shared_blocks:
-      - e2e-shared-inline
-    memory_blocks:
-      - name: private_notes
-        description: Private agent notes
-        limit: 2000
-        value: "Private data"
+      Line 5: C:\Windows\System32
 
-  # ============================================================================
-  # FOLDERS (LOCAL FILES)
-  # ============================================================================
+      '
+    agent_owned: true
+- name: e2e-29-unicode-content
+  description: Unicode and international characters
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: 'Multilingual agent: Hello, Bonjour, Hola, Guten Tag
 
-  # 12: Folder with explicit files
-  - name: e2e-12-folder-explicit
-    description: Folder with explicit file list
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with explicit folder files.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-explicit
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
+      Japanese: こんにちは
 
-  # 13: Folder with glob pattern (*.txt)
-  - name: e2e-13-folder-glob-txt
-    description: Folder with txt glob pattern
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with glob pattern folder.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-glob-txt
-        files:
-          - "folder-files/*.txt"
+      Chinese: 你好
 
-  # 14: Folder with wildcard glob (*)
-  - name: e2e-14-folder-glob-all
-    description: Folder with wildcard glob
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with wildcard glob folder.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-glob-all
-        files:
-          - "folder-files/*"
+      Arabic: مرحبا
 
-  # 15: Multiple folders
-  - name: e2e-15-folders-multi
-    description: Multiple folder attachments
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with multiple folders.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 64000
-    folders:
-      - name: e2e-docs-a
-        files:
-          - folder-files/doc1.txt
-      - name: e2e-docs-b
-        files:
-          - folder-files/doc2.txt
+      Russian: Привет
 
-  # ============================================================================
-  # TOOLS
-  # ============================================================================
+      Greek: Γειά σου
 
-  # 16: With archival tools
-  - name: e2e-16-tools-archival
-    description: Agent with archival memory tools
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with archival tools.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
+      '
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: unicode_notes
+    description: Notes with unicode
+    limit: 2000
+    value: 'Currency: € £ ¥ ₹
 
-  # ============================================================================
-  # FULL COMBINATIONS
-  # ============================================================================
+      Math: ∑ ∏ √ ∞ ≠ ≤ ≥
 
-  # 17: Everything combined (no supabase)
-  - name: e2e-17-full-local
-    description: All local features combined
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      from_file: system-prompt.txt
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 128000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-versioned
-    memory_blocks:
-      - name: working_memory
-        description: Active working memory
-        limit: 4000
-        value: "Ready"
-      - name: learned_data
-        description: Learned information
-        limit: 3000
-        from_file: block-content.txt
-    folders:
-      - name: e2e-full-docs
-        files:
-          - "folder-files/*.txt"
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
+      Arrows: → ← ↑ ↓ ↔
 
-  # 18: Same shared block as agent 9 (tests block sharing)
-  - name: e2e-18-shares-with-09
-    description: Shares block with agent 09
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent sharing block with e2e-09.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    shared_blocks:
-      - e2e-shared-inline
+      '
+    agent_owned: true
+- name: e2e-30-cleanup-test
+  description: Agent for cleanup command testing
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent used for cleanup tests.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: cleanup_block
+    description: Block that will become orphaned
+    limit: 1000
+    value: Orphan me
+    agent_owned: true
+  folders:
+  - name: e2e-cleanup-folder
+    files:
+    - folder-files/doc1.txt
+- name: e2e-33-block-isolation-a
+  description: Agent A for block isolation test
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are Agent A for Alpha Corp.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: brand_identity
+    description: Brand identity for this agent
+    limit: 2000
+    agent_owned: false
+    value: '# Brand Identity: Alpha Corp
 
-  # 19: Same folder as agent 12 (tests folder reuse)
-  - name: e2e-19-shares-folder
-    description: References same folder pattern
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with same folder structure.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-docs-explicit
-        files:
-          - folder-files/doc1.txt
-          - folder-files/doc2.txt
+      Company: Alpha Corp
 
-  # 20: Kitchen sink - absolutely everything
-  - name: e2e-20-kitchen-sink
-    description: Every possible option enabled
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        You are the ultimate test agent.
-        Every feature is enabled on you.
-        Use all your capabilities wisely.
-      disable_base_prompt: false
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 200000
-    shared_blocks:
-      - e2e-shared-inline
-      - e2e-shared-fromfile
-      - e2e-shared-versioned
-    memory_blocks:
-      - name: core_memory
-        description: Core agent memory
-        limit: 5000
-        value: "Initialized"
-      - name: file_memory
-        description: Memory from file
-        limit: 3000
-        from_file: block-content.txt
-      - name: versioned_memory
-        description: Versioned memory block
-        limit: 2000
-        value: "v1 data"
-        version: "1.0.0"
-    folders:
-      - name: e2e-kitchen-docs
-        files:
-          - "folder-files/*"
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
+      Industry: Technology
 
-  # ============================================================================
-  # FILE SEARCH TOOLS AUTO-MANAGEMENT
-  # ============================================================================
+      Target: Enterprise customers
 
-  # 21: Folder with explicit tools - tests auto-add of file search tools
-  # When folders are attached, grep_files and semantic_search_files should auto-add
-  # The explicit archival tools should remain unchanged
-  - name: e2e-21-folder-tools-auto
-    description: Tests file search tools auto-add
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent testing file search tool auto-management.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-folder-auto-test
-        files:
-          - folder-files/doc1.txt
-    tools:
-      - archival_memory_insert
-      - archival_memory_search
+      '
+- name: e2e-33-block-isolation-b
+  description: Agent B for block isolation test
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are Agent B for Beta Inc.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: brand_identity
+    description: Brand identity for this agent
+    limit: 2000
+    agent_owned: false
+    value: '# Brand Identity: Beta Inc
 
-  # ============================================================================
-  # BUCKET FILES - Duplicate Prevention (#98)
-  # ============================================================================
+      Company: Beta Inc
 
-  # 22: Bucket glob files - tests that re-apply doesn't create duplicates
-  # On first apply: files uploaded with clean names
-  # On second apply: should detect existing files and NOT re-upload
-  - name: e2e-22-bucket-glob
-    description: Tests bucket glob file duplicate prevention
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with bucket glob files.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-bucket-test
-        files:
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-              path: "*.txt"
+      Industry: Healthcare
 
-  # 23: Single bucket file (non-glob) - tests individual file handling
-  - name: e2e-23-bucket-single
-    description: Tests single bucket file (no glob)
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with single bucket file.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-bucket-single
-        files:
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-              path: test-doc.txt
+      Target: Small businesses
 
-  # 24: Mixed local + bucket files in same folder
-  - name: e2e-24-mixed-sources
-    description: Tests folder with both local and bucket files
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with mixed file sources.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    folders:
-      - name: e2e-mixed-folder
-        files:
-          - folder-files/doc1.txt
-          - from_bucket:
-              provider: supabase
-              bucket: test-bucket
-              path: test-doc.txt
-
-  # ============================================================================
-  # YAML-OWNED BLOCKS - Value Sync (#101)
-  # ============================================================================
-
-  # 25: agent_owned: false blocks - value syncs from YAML on every apply
-  - name: e2e-25-immutable-block
-    description: Tests agent_owned false block value sync
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with immutable block.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: policies
-        description: Agent policies that sync from YAML
-        limit: 2000
-        value: "Policy version 1: Be helpful and concise."
-        agent_owned: false
-      - name: learned_data
-        description: Data the agent learns (agent_owned by default)
-        limit: 2000
-        value: "Initial state"
-
-  # ============================================================================
-  # EDGE CASES
-  # ============================================================================
-
-  # 26: Minimal block value - tests handling of near-empty/minimal values
-  - name: e2e-26-empty-block
-    description: Block with minimal value
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent with minimal block value.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: empty_notes
-        description: Notes block with minimal initial value
-        limit: 2000
-        value: "-"
-        agent_owned: false
-      - name: populated_notes
-        description: Notes block with value
-        limit: 2000
-        value: "Has content"
-
-  # 27: Block removal test - agent starts with blocks, then all removed
-  - name: e2e-27-block-removal
-    description: Agent with blocks that will be removed
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent testing block removal.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: temp_block_a
-        description: Temporary block A
-        limit: 1000
-        value: "Will be removed"
-      - name: temp_block_b
-        description: Temporary block B
-        limit: 1000
-        value: "Also will be removed"
-
-  # 28: Special characters - tests escaping/handling of special chars
-  - name: e2e-28-special-chars
-    description: Special characters in prompts and blocks
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        Agent with special characters: "quotes", 'apostrophes', & ampersands.
-        Newlines and	tabs included.
-        Backslash: \ and forward slash: /
-        JSON-like: {"key": "value"}
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: special_data
-        description: Block with special characters
-        limit: 2000
-        value: |
-          Line 1: "quoted text"
-          Line 2: 'single quotes'
-          Line 3: key=value&other=data
-          Line 4: path/to/file.txt
-          Line 5: C:\Windows\System32
-
-  # 29: Unicode content - tests non-ASCII character handling
-  - name: e2e-29-unicode-content
-    description: Unicode and international characters
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: |
-        Multilingual agent: Hello, Bonjour, Hola, Guten Tag
-        Japanese: こんにちは
-        Chinese: 你好
-        Arabic: مرحبا
-        Russian: Привет
-        Greek: Γειά σου
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: unicode_notes
-        description: Notes with unicode
-        limit: 2000
-        value: |
-          Currency: € £ ¥ ₹
-          Math: ∑ ∏ √ ∞ ≠ ≤ ≥
-          Arrows: → ← ↑ ↓ ↔
-
-  # 30: Cleanup test helper - creates orphaned resources for cleanup testing
-  - name: e2e-30-cleanup-test
-    description: Agent for cleanup command testing
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: Agent used for cleanup tests.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: cleanup_block
-        description: Block that will become orphaned
-        limit: 1000
-        value: "Orphan me"
-    folders:
-      - name: e2e-cleanup-folder
-        files:
-          - folder-files/doc1.txt
-
-  # ============================================================================
-  # BLOCK ISOLATION - Cross-Agent Contamination Prevention (#128)
-  # ============================================================================
-
-  # 33a: First agent with brand_identity block
-  - name: e2e-33-block-isolation-a
-    description: Agent A for block isolation test
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are Agent A for Alpha Corp.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: brand_identity
-        description: Brand identity for this agent
-        limit: 2000
-        agent_owned: false
-        value: |
-          # Brand Identity: Alpha Corp
-          Company: Alpha Corp
-          Industry: Technology
-          Target: Enterprise customers
-
-  # 33b: Second agent with SAME block name but DIFFERENT value
-  - name: e2e-33-block-isolation-b
-    description: Agent B for block isolation test
-    embedding: openai/text-embedding-3-small
-    system_prompt:
-      value: You are Agent B for Beta Inc.
-    llm_config:
-      model: google_ai/gemini-2.5-pro
-      context_window: 32000
-    memory_blocks:
-      - name: brand_identity
-        description: Brand identity for this agent
-        limit: 2000
-        agent_owned: false
-        value: |
-          # Brand Identity: Beta Inc
-          Company: Beta Inc
-          Industry: Healthcare
-          Target: Small businesses
+      '

--- a/tests/unit/lib/fleet-parser.test.ts
+++ b/tests/unit/lib/fleet-parser.test.ts
@@ -49,6 +49,7 @@ shared_blocks:
     description: "Shared memory"
     limit: 5000
     value: "Shared content"
+    agent_owned: true
 
 agents:
   - name: test-agent


### PR DESCRIPTION
## Summary
- Makes `agent_owned` a required field on memory blocks (no more silent defaults)
- Forces explicit decision on every block
- Prevents accidental nuking of agent learnings

Breaking change - existing configs without `agent_owned` will fail validation.

Closes #193