### PR TITLE
feat: add tags support to YAML and get filtering

### DIFF
--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -266,7 +266,8 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
             files: folder.files,
             fileContentHashes: folderContentHashes.get(folder.name) || {}
           })),
-          sharedBlocks: agent.shared_blocks || []
+          sharedBlocks: agent.shared_blocks || [],
+          tags: agent.tags || []
         };
 
         // Check if agent exists

--- a/src/commands/apply/template.ts
+++ b/src/commands/apply/template.ts
@@ -142,7 +142,7 @@ export async function applyTemplateMode(
         id: existingAgent.id,
         name: existingAgent.name,
         baseName: existingAgent.name,
-        configHashes: { overall: '', systemPrompt: '', tools: '', model: '', memoryBlocks: '', folders: '', sharedBlocks: '', archives: '' },
+        configHashes: { overall: '', systemPrompt: '', tools: '', model: '', memoryBlocks: '', folders: '', sharedBlocks: '', archives: '', tags: '' },
         version: 'latest',
         lastUpdated: existingAgent.updated_at || new Date().toISOString()
       };

--- a/src/commands/get/agents.ts
+++ b/src/commands/get/agents.ts
@@ -25,7 +25,12 @@ export async function getAgents(
   try {
     spinner.text = 'Fetching agent details...';
 
-    const agents = await fetcher.fetchAllAgents(detailLevel);
+    // Parse tags filter
+    const tagFilter = options?.tags
+      ? options.tags.split(',').map(t => t.trim()).filter(Boolean)
+      : undefined;
+
+    const agents = await fetcher.fetchAllAgents(detailLevel, tagFilter ? { tags: tagFilter } : undefined);
 
     spinner.stop();
 

--- a/src/commands/get/types.ts
+++ b/src/commands/get/types.ts
@@ -8,4 +8,5 @@ export interface GetOptions {
   short?: boolean;
   full?: boolean;
   query?: string;
+  tags?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ program
   .option('--short', 'truncate block values to 300 characters (use with: get blocks <agent>)')
   .option('--full', 'show full archival entry text (use with: get archival <agent>)')
   .option('--query <text>', 'search archival memory by semantic similarity')
+  .option('--tags <tags>', 'filter agents by tags (comma-separated)')
   .action(getCommand);
 
 // Describe command - detailed agent info

--- a/src/lib/apply/apply-helpers.ts
+++ b/src/lib/apply/apply-helpers.ts
@@ -376,6 +376,10 @@ export async function createNewAgent(
       reasoning: agent.reasoning ?? DEFAULT_REASONING
     };
 
+    if (agent.tags && agent.tags.length > 0) {
+      createPayload.tags = agent.tags;
+    }
+
     // Handle embedding vs embedding_config (mutually exclusive)
     if (agent.embedding_config) {
       createPayload.embedding_config = agent.embedding_config;

--- a/src/lib/apply/diff-applier.ts
+++ b/src/lib/apply/diff-applier.ts
@@ -63,6 +63,9 @@ export class DiffApplier {
       if (fields.reasoning !== undefined) {
         apiFields.reasoning = fields.reasoning.to;
       }
+      if (fields.tags !== undefined) {
+        apiFields.tags = fields.tags.to;
+      }
 
       await this.client.updateAgent(agentId, apiFields);
     }

--- a/src/lib/apply/diff-engine.ts
+++ b/src/lib/apply/diff-engine.ts
@@ -50,6 +50,7 @@ export class DiffEngine {
       folders?: Array<{name: string; files: string[]; fileContentHashes?: Record<string, string>}>;
       archives?: Array<{name: string; description?: string; embedding?: string; embedding_config?: Record<string, any>}>;
       sharedBlocks?: string[];
+      tags?: string[];
     },
     toolRegistry: Map<string, string>,
     folderRegistry: Map<string, string>,
@@ -147,6 +148,13 @@ export class DiffEngine {
     const currentReasoning = (currentAgent as any).reasoning ?? DEFAULT_REASONING;
     if (currentReasoning !== desiredReasoning) {
       fieldUpdates.reasoning = { from: currentReasoning, to: desiredReasoning };
+      operations.operationCount++;
+    }
+
+    const currentTags = [...((currentAgent as any).tags || [])].sort();
+    const desiredTags = [...(desiredConfig.tags || [])].sort();
+    if (JSON.stringify(currentTags) !== JSON.stringify(desiredTags)) {
+      fieldUpdates.tags = { from: currentTags, to: desiredTags };
       operations.operationCount++;
     }
 

--- a/src/lib/client/agent-data-fetcher.ts
+++ b/src/lib/client/agent-data-fetcher.ts
@@ -38,8 +38,8 @@ export class AgentDataFetcher {
   /**
    * Fetch all agents with specified detail level
    */
-  async fetchAllAgents(detailLevel: DetailLevel = 'standard'): Promise<AgentDisplayData[]> {
-    const agents = await this.client.listAgents();
+  async fetchAllAgents(detailLevel: DetailLevel = 'standard', options?: { tags?: string[] }): Promise<AgentDisplayData[]> {
+    const agents = await this.client.listAgents(options);
     const agentList = normalizeResponse(agents);
 
     if (detailLevel === 'minimal') {

--- a/src/lib/client/letta-client.ts
+++ b/src/lib/client/letta-client.ts
@@ -18,8 +18,13 @@ export class LettaClientWrapper {
     this.client = new LettaClient(config);
   }
 
-  async listAgents() {
-    return await this.client.agents.list();
+  async listAgents(options?: { tags?: string[] }) {
+    const params: any = {};
+    if (options?.tags && options.tags.length > 0) {
+      params.tags = options.tags;
+      params.match_all_tags = true;
+    }
+    return await this.client.agents.list(params);
   }
 
   async getAgent(agentId: string) {

--- a/src/lib/managers/agent-manager.ts
+++ b/src/lib/managers/agent-manager.ts
@@ -45,11 +45,12 @@ export class AgentManager {
           overall: '',              // Will be populated during comparison
           systemPrompt: generateContentHash(agent.system),
           tools: '',
-          model: '', 
+          model: '',
           memoryBlocks: '',
           folders: '',
           sharedBlocks: '',
-          archives: ''
+          archives: '',
+          tags: ''
         };
         const { baseName, version } = this.parseVersionFromName(agent.name);
 
@@ -87,6 +88,7 @@ export class AgentManager {
     folders?: Array<{name: string; files: string[]; fileContentHashes?: Record<string, string>}>;
     archives?: Array<{name: string; description?: string; embedding?: string}>;
     sharedBlocks?: string[];
+    tags?: string[];
   }): AgentConfigHashes {
     
     // System prompt hash
@@ -145,6 +147,9 @@ export class AgentManager {
       .sort((a, b) => a.name.localeCompare(b.name));
     const archivesHash = generateContentHash(JSON.stringify(normalizedArchives));
     
+    // Tags hash
+    const tagsHash = generateContentHash(JSON.stringify([...(config.tags || [])].sort()));
+
     // Overall hash combining all components
     const overallHash = generateContentHash(JSON.stringify({
       systemPrompt: systemPromptHash,
@@ -153,7 +158,8 @@ export class AgentManager {
       memoryBlocks: memoryBlocksHash,
       folders: foldersHash,
       sharedBlocks: sharedBlocksHash,
-      archives: archivesHash
+      archives: archivesHash,
+      tags: tagsHash
     }));
     
     return {
@@ -164,7 +170,8 @@ export class AgentManager {
       memoryBlocks: memoryBlocksHash,
       folders: foldersHash,
       sharedBlocks: sharedBlocksHash,
-      archives: archivesHash
+      archives: archivesHash,
+      tags: tagsHash
     };
   }
 
@@ -172,7 +179,7 @@ export class AgentManager {
    * Determines if an agent needs to be created/updated based on complete configuration
    */
   async getOrCreateAgentName(
-    baseName: string, 
+    baseName: string,
     agentConfig: {
       systemPrompt: string;
       tools: string[];
@@ -186,6 +193,7 @@ export class AgentManager {
       folders?: Array<{name: string; files: string[]}>;
       archives?: Array<{name: string; description?: string; embedding?: string}>;
       sharedBlocks?: string[];
+      tags?: string[];
     },
     verbose: boolean = false
   ): Promise<{ agentName: string; shouldCreate: boolean; existingAgent?: AgentVersion }> {
@@ -231,6 +239,7 @@ export class AgentManager {
     folders?: Array<{name: string; files: string[]}>;
     archives?: Array<{name: string; description?: string; embedding?: string}>;
     sharedBlocks?: string[];
+    tags?: string[];
   }): {
     hasChanges: boolean;
     changedComponents: string[];
@@ -261,6 +270,9 @@ export class AgentManager {
     if (existing.configHashes.archives !== newHashes.archives) {
       changedComponents.push('archives');
     }
+    if (existing.configHashes.tags !== newHashes.tags) {
+      changedComponents.push('tags');
+    }
 
     return {
       hasChanges: changedComponents.length > 0,
@@ -283,6 +295,7 @@ export class AgentManager {
     folders?: Array<{name: string; files: string[]}>;
     archives?: Array<{name: string; description?: string; embedding?: string}>;
     sharedBlocks?: string[];
+    tags?: string[];
   }, agentId: string): void {
     const configHashes = this.generateAgentConfigHashes(agentConfig);
     const { baseName, version } = this.parseVersionFromName(agentName);

--- a/src/lib/validation/config-validators.ts
+++ b/src/lib/validation/config-validators.ts
@@ -153,6 +153,10 @@ export class AgentValidator {
     if (agent.shared_folders) {
       this.validateSharedFolderReferences(agent.shared_folders);
     }
+
+    if (agent.tags) {
+      this.validateTags(agent.tags);
+    }
   }
   
   private static validateStructure(agent: any): void {
@@ -201,7 +205,7 @@ export class AgentValidator {
       'name', 'description', 'system_prompt', 'llm_config',
       'tools', 'mcp_tools', 'memory_blocks', 'archives', 'folders',
       'embedding', 'embedding_config', 'shared_blocks', 'shared_folders',
-      'first_message', 'reasoning'
+      'first_message', 'reasoning', 'tags'
     ];
     
     const unknownFields = Object.keys(agent).filter(field => !allowedFields.includes(field));
@@ -247,6 +251,21 @@ export class AgentValidator {
     sharedFolders.forEach((folderName, index) => {
       if (!folderName || typeof folderName !== 'string' || folderName.trim() === '') {
         throw new Error(`Shared folder reference ${index + 1} must be a non-empty string (folder name).`);
+      }
+    });
+  }
+
+  private static validateTags(tags: any): void {
+    if (!Array.isArray(tags)) {
+      throw new Error('Agent tags must be an array of strings.');
+    }
+
+    tags.forEach((tag, index) => {
+      if (!tag || typeof tag !== 'string' || tag.trim() === '') {
+        throw new Error(`Tag ${index + 1} must be a non-empty string.`);
+      }
+      if (tag.includes(',')) {
+        throw new Error(`Tag "${tag}" must not contain commas (commas are used as delimiters in CLI filters).`);
       }
     });
   }

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -7,6 +7,7 @@ export interface AgentConfigHashes {
   folders: string;           // Folders hash
   sharedBlocks: string;      // Shared blocks hash
   archives: string;          // Archives hash
+  tags: string;              // Tags hash
 }
 
 export interface AgentVersion {

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -48,6 +48,7 @@ export interface AgentUpdateOperations {
     embeddingConfig?: FieldChange<Record<string, any> | null>;
     contextWindow?: FieldChange<number>;
     reasoning?: FieldChange<boolean>;
+    tags?: FieldChange<string[]>;
   };
 
   // Resource management operations

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -46,6 +46,7 @@ export interface AgentConfig {
   embedding_config?: Record<string, any>;
   first_message?: string; // Message sent to agent on first creation for auto-calibration
   reasoning?: boolean; // Enable reasoning for models that support it (default: true)
+  tags?: string[]; // Tags for filtering and multi-tenancy (e.g., ["tenant:user-123", "role:support"])
 }
 
 export interface McpToolConfig {

--- a/tests/e2e/fixtures/fleet-tags-test.yml
+++ b/tests/e2e/fixtures/fleet-tags-test.yml
@@ -1,0 +1,27 @@
+agents:
+- name: e2e-49-tags-a
+  description: Tagged agent A
+  tags: ["tenant:acme", "role:support"]
+  embedding: openai/text-embedding-3-small
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  system_prompt:
+    value: "You are a support agent for Acme Corp."
+- name: e2e-49-tags-b
+  description: Tagged agent B
+  tags: ["tenant:acme", "role:research"]
+  embedding: openai/text-embedding-3-small
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  system_prompt:
+    value: "You are a research agent for Acme Corp."
+- name: e2e-49-tags-c
+  description: Untagged agent C
+  embedding: openai/text-embedding-3-small
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  system_prompt:
+    value: "You are an untagged agent."

--- a/tests/e2e/tests/49-tags.sh
+++ b/tests/e2e/tests/49-tags.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Test: Agent tags - set via YAML, filter via get
+# Issue: #212
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT_A="e2e-49-tags-a"
+AGENT_B="e2e-49-tags-b"
+AGENT_C="e2e-49-tags-c"
+
+section "Test: Agent Tags (#212)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+# Cleanup
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+delete_agent_if_exists "$AGENT_C"
+
+# Deploy agents with tags
+$CLI apply -f "$FIXTURES/fleet-tags-test.yml" --root "$FIXTURES" > $OUT 2>&1
+output_contains "created" && pass "Tagged agents deployed" || fail "Deploy failed"
+
+# Verify agents exist
+agent_exists "$AGENT_A" && pass "Agent A exists" || fail "Agent A missing"
+agent_exists "$AGENT_B" && pass "Agent B exists" || fail "Agent B missing"
+agent_exists "$AGENT_C" && pass "Agent C exists" || fail "Agent C missing"
+
+# Filter by tenant tag
+$CLI get agents --tags "tenant:acme" -o json > $OUT 2>&1
+output_contains "$AGENT_A" && pass "Tag filter includes agent A" || fail "Tag filter missing agent A"
+output_contains "$AGENT_B" && pass "Tag filter includes agent B" || fail "Tag filter missing agent B"
+output_not_contains "$AGENT_C" && pass "Tag filter excludes untagged agent C" || fail "Tag filter should exclude agent C"
+
+# Filter by role tag
+$CLI get agents --tags "role:support" -o json > $OUT 2>&1
+output_contains "$AGENT_A" && pass "Role filter includes support agent" || fail "Role filter missing support agent"
+output_not_contains "$AGENT_B" && pass "Role filter excludes research agent" || fail "Role filter should exclude research agent"
+
+# Filter by nonexistent tag
+$CLI get agents --tags "tenant:nonexistent" -o json > $OUT 2>&1
+output_not_contains "$AGENT_A" && pass "Nonexistent tag returns no matches" || fail "Should return no matches"
+
+# Cleanup
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+delete_agent_if_exists "$AGENT_C"
+
+print_summary

--- a/tests/unit/lib/config-validators.test.ts
+++ b/tests/unit/lib/config-validators.test.ts
@@ -77,6 +77,46 @@ describe('FleetConfigValidator - duplicate folder names', () => {
   });
 });
 
+describe('AgentValidator - tags', () => {
+  const baseAgent = (name: string, tags?: any) => ({
+    name,
+    description: 'd',
+    llm_config: { model: 'm', context_window: 1000 },
+    system_prompt: { value: 'p' },
+    tags
+  });
+
+  it('accepts valid tags', () => {
+    expect(() => FleetConfigValidator.validate({
+      agents: [baseAgent('agent-a', ['tenant:user-123', 'role:support'])]
+    })).not.toThrow();
+  });
+
+  it('accepts agents without tags', () => {
+    expect(() => FleetConfigValidator.validate({
+      agents: [baseAgent('agent-a')]
+    })).not.toThrow();
+  });
+
+  it('rejects non-array tags', () => {
+    expect(() => FleetConfigValidator.validate({
+      agents: [baseAgent('agent-a', 'not-array')]
+    })).toThrow('tags must be an array');
+  });
+
+  it('rejects empty string tags', () => {
+    expect(() => FleetConfigValidator.validate({
+      agents: [baseAgent('agent-a', ['valid', ''])]
+    })).toThrow('Tag 2 must be a non-empty string');
+  });
+
+  it('rejects tags containing commas', () => {
+    expect(() => FleetConfigValidator.validate({
+      agents: [baseAgent('agent-a', ['valid:tag', 'bad,tag'])]
+    })).toThrow('must not contain commas');
+  });
+});
+
 describe('McpToolsValidator', () => {
   it('accepts tools: all', () => {
     expect(() => McpToolsValidator.validate([

--- a/tests/unit/sdk.test.ts
+++ b/tests/unit/sdk.test.ts
@@ -26,6 +26,20 @@ describe('FleetConfigBuilder', () => {
     expect(config.agents[0].shared_folders).toContain('docs');
   });
 
+  it('builds config with agent tags', () => {
+    const config = new FleetConfigBuilder()
+      .addAgent({
+        name: 'agent',
+        description: 'd',
+        llm_config: { model: 'm', context_window: 1000 },
+        system_prompt: { value: 'p' },
+        tags: ['tenant:user-123', 'role:support']
+      })
+      .build();
+
+    expect(config.agents[0].tags).toEqual(['tenant:user-123', 'role:support']);
+  });
+
   it('starts with empty config', () => {
     const config = new FleetConfigBuilder().build();
     expect(config.agents).toEqual([]);


### PR DESCRIPTION
## Summary
- Add `tags` field to agent YAML config for multi-tenancy filtering
- Add `--tags` flag to `get agents` for AND-based tag filtering (`match_all_tags: true`)
- Wire tags through full apply pipeline: create, update, diff detection
- Validate tags (no commas, non-empty strings)
- Add multi-tenancy guide to README (B2B and B2B2C patterns)

Closes #212