### PR TITLE
fix: prevent tool cross-contamination in multi-agent apply

### DIFF
--- a/src/lib/apply/fleet-parser.ts
+++ b/src/lib/apply/fleet-parser.ts
@@ -275,6 +275,18 @@ export class FleetParser {
             }
           } else if (typeof tool === 'object' && tool.name) {
             // Tool configuration object with bucket source
+            // Check for conflicting tool configs with same name but different source
+            const existing = this.toolConfigs.get(tool.name);
+            if (existing) {
+              const existingSource = existing.from_file || existing.from_bucket?.path || existing.source_code || '';
+              const newSource = tool.from_file || tool.from_bucket?.path || tool.source_code || '';
+              if (existingSource !== newSource) {
+                throw new Error(
+                  `Tool name collision: "${tool.name}" is defined with different sources. ` +
+                  `Rename one of the tools to avoid ambiguity.`
+                );
+              }
+            }
             // Store the full config for later retrieval in registerRequiredTools
             this.toolConfigs.set(tool.name, tool);
             expandedTools.push(tool.name);

--- a/tests/e2e/tests/61-tool-isolation.sh
+++ b/tests/e2e/tests/61-tool-isolation.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Test: Tools declared on one agent must NOT leak to another agent (#242)
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT_A="e2e-61-agent-a"
+AGENT_B="e2e-61-agent-b"
+section "Test: Tool isolation across multi-agent fleet (#242)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+
+# Fleet with two agents, each with distinct tools
+cat > "$LOG_DIR/fleet-tool-isolation.yml" <<'YAML'
+agents:
+- name: e2e-61-agent-a
+  description: Agent A - has look_around and wave_at
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent A for tool isolation test.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+    - look_around
+    - wave_at
+
+- name: e2e-61-agent-b
+  description: Agent B - has wander and start_conversation
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent B for tool isolation test.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  tools:
+    - wander
+    - start_conversation
+YAML
+
+$CLI apply -f "$LOG_DIR/fleet-tool-isolation.yml" --root "$FIXTURES" > $OUT 2>&1
+agent_exists "$AGENT_A" && pass "Agent A created" || fail "Agent A not created"
+agent_exists "$AGENT_B" && pass "Agent B created" || fail "Agent B not created"
+
+# Check Agent A has its own tools
+$CLI get tools --agent "$AGENT_A" > $OUT 2>&1
+output_contains "look_around"  && pass "Agent A has look_around"  || fail "Agent A missing look_around"
+output_contains "wave_at"      && pass "Agent A has wave_at"      || fail "Agent A missing wave_at"
+
+# Check Agent A does NOT have Agent B's tools
+output_not_contains "wander"             && pass "Agent A does NOT have wander"             || fail "Agent A has wander (leaked)"
+output_not_contains "start_conversation" && pass "Agent A does NOT have start_conversation" || fail "Agent A has start_conversation (leaked)"
+
+# Check Agent B has its own tools
+$CLI get tools --agent "$AGENT_B" > $OUT 2>&1
+output_contains "wander"             && pass "Agent B has wander"             || fail "Agent B missing wander"
+output_contains "start_conversation" && pass "Agent B has start_conversation" || fail "Agent B missing start_conversation"
+
+# Check Agent B does NOT have Agent A's tools
+output_not_contains "look_around" && pass "Agent B does NOT have look_around" || fail "Agent B has look_around (leaked)"
+output_not_contains "wave_at"     && pass "Agent B does NOT have wave_at"     || fail "Agent B has wave_at (leaked)"
+
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+print_summary


### PR DESCRIPTION
Closes #242

## Problem

When running `lettactl apply` with a multi-agent fleet YAML, tools declared under one agent leak to other agents. Two root causes:

1. `createNewAgent` creates the agent first, then attaches tools in a separate loop — the server auto-attaches default/MCP tools during creation, and these are never cleaned up.
2. `toolConfigs` is a flat global map that silently overwrites if two agents define `from_file` tools with the same name but different source files.

## Fix

- **Pass `tool_ids` in the create payload** so the agent is created with exactly the right tools from the start. Removed the post-creation `attachToolToAgent` loop.
- **Detect tool name collisions** in `expandToolReferences` — throw a clear error if two agents define a tool config with the same name but different sources.

## Test plan

- [x] `pnpm test` — 128 unit tests pass (includes 2 new collision detection tests)
- [x] `pnpm run build` — compiles cleanly
- [x] `pnpm test:e2e` — all 59 e2e tests pass (458 checks, 0 failures)
- [x] New e2e test `61-tool-isolation.sh` — verifies two agents get only their declared tools (12/12 checks pass)