### PR TITLE
fix: paginate agent tools, blocks, and folders listings (#246)

### DIFF
--- a/src/lib/client/agent-resolver.ts
+++ b/src/lib/client/agent-resolver.ts
@@ -34,7 +34,7 @@ export class AgentResolver {
     // Fetch attached tools
     try {
       const tools = await this.client.listAgentTools(agentId);
-      agentWithDetails.tools = Array.isArray(tools) ? tools : (tools?.items || []);
+      agentWithDetails.tools = tools;
     } catch (error) {
       warn(`Warning: Could not fetch tools for agent ${agentId}`);
       agentWithDetails.tools = [];
@@ -43,7 +43,7 @@ export class AgentResolver {
     // Fetch attached memory blocks
     try {
       const blocks = await this.client.listAgentBlocks(agentId);
-      agentWithDetails.blocks = Array.isArray(blocks) ? blocks : (blocks?.items || []);
+      agentWithDetails.blocks = blocks;
     } catch (error) {
       warn(`Warning: Could not fetch blocks for agent ${agentId}`);
       agentWithDetails.blocks = [];
@@ -52,7 +52,7 @@ export class AgentResolver {
     // Fetch attached folders
     try {
       const folders = await this.client.listAgentFolders(agentId);
-      agentWithDetails.folders = Array.isArray(folders) ? folders : (folders?.items || []);
+      agentWithDetails.folders = folders;
     } catch (error) {
       warn(`Warning: Could not fetch folders for agent ${agentId}`);
       agentWithDetails.folders = [];

--- a/src/lib/client/letta-client.ts
+++ b/src/lib/client/letta-client.ts
@@ -348,7 +348,11 @@ export class LettaClientWrapper {
   }
 
   async listAgentTools(agentId: string) {
-    return await this.client.agents.tools.list(agentId);
+    const allTools: any[] = [];
+    for await (const tool of this.client.agents.tools.list(agentId)) {
+      allTools.push(tool);
+    }
+    return allTools;
   }
 
   async updateToolApproval(agentId: string, toolName: string, requiresApproval: boolean) {
@@ -375,7 +379,11 @@ export class LettaClientWrapper {
   }
 
   async listAgentBlocks(agentId: string) {
-    return await this.client.agents.blocks.list(agentId);
+    const allBlocks: any[] = [];
+    for await (const block of this.client.agents.blocks.list(agentId)) {
+      allBlocks.push(block);
+    }
+    return allBlocks;
   }
 
   // Folder Management
@@ -384,7 +392,11 @@ export class LettaClientWrapper {
   }
 
   async listAgentFolders(agentId: string) {
-    return await this.client.agents.folders.list(agentId);
+    const allFolders: any[] = [];
+    for await (const folder of this.client.agents.folders.list(agentId)) {
+      allFolders.push(folder);
+    }
+    return allFolders;
   }
 
   async closeAllAgentFiles(agentId: string) {


### PR DESCRIPTION
## Summary
- Fix `listAgentTools`, `listAgentBlocks`, and `listAgentFolders` in `letta-client.ts` to use `for await` pagination instead of returning only the first page
- Simplify `agent-resolver.ts` normalization wrappers that were now typed as `never`

Fixes #246 (Bugs 2 & 3: describe truncation and phantom drift)

## Test plan
- [x] `pnpm run build` compiles cleanly
- [x] `pnpm test` — 128 unit tests pass
- [ ] `pnpm test:e2e` — full e2e suite