### PR TITLE
fix: describe duplicates, missing tools, and phantom drift (#248)

### DIFF
--- a/src/commands/export/export.ts
+++ b/src/commands/export/export.ts
@@ -158,13 +158,13 @@ async function buildAgentYamlConfig(
   // Fetch full agent details
   const fullAgent = await client.getAgent(agent.id);
 
-  // Fetch attached resources
-  const [tools, blocks, folders, archives] = await Promise.all([
-    client.listAgentTools(agent.id).then(normalizeResponse),
-    client.listAgentBlocks(agent.id).then(normalizeResponse),
+  // Use embedded tools/blocks from agent object; fetch folders/archives separately
+  const [folders, archives] = await Promise.all([
     client.listAgentFolders(agent.id).then(normalizeResponse),
     client.listAgentArchives(agent.id).then(normalizeResponse),
   ]);
+  const tools = normalizeResponse((fullAgent as any).tools || []);
+  const blocks = normalizeResponse((fullAgent as any).blocks || []);
 
   // Build YAML-compatible config
   const agentConfig: any = {

--- a/src/lib/apply/diff-engine.ts
+++ b/src/lib/apply/diff-engine.ts
@@ -72,14 +72,12 @@ export class DiffEngine {
 
     // Get current agent state from server
     const currentAgent = await this.client.getAgent(existingAgent.id);
-    const currentToolsResponse = await this.client.listAgentTools(existingAgent.id);
-    const currentBlocksResponse = await this.client.listAgentBlocks(existingAgent.id);
     const currentFoldersResponse = await this.client.listAgentFolders(existingAgent.id);
     const currentArchivesResponse = await this.client.listAgentArchives(existingAgent.id);
-    
-    // Normalize responses to arrays
-    const currentTools = normalizeResponse(currentToolsResponse);
-    const currentBlocks = normalizeResponse(currentBlocksResponse);
+
+    // Use embedded tools/blocks from agent object (more reliable than paginated list endpoints)
+    const currentTools = normalizeResponse((currentAgent as any).tools || []);
+    const currentBlocks = normalizeResponse((currentAgent as any).blocks || []);
     const currentFolders = normalizeResponse(currentFoldersResponse);
     const currentArchives = normalizeResponse(currentArchivesResponse);
 

--- a/src/lib/client/agent-data-fetcher.ts
+++ b/src/lib/client/agent-data-fetcher.ts
@@ -65,11 +65,9 @@ export class AgentDataFetcher {
       return this.transformMinimal(agent);
     }
 
-    // Fetch tools and blocks in parallel
-    const [tools, blocks] = await Promise.all([
-      this.safeListAgentTools(agentId),
-      this.safeListAgentBlocks(agentId),
-    ]);
+    // Use embedded tools/blocks from agent object (more reliable than paginated list endpoints)
+    const tools = normalizeResponse((agent as any).tools || []);
+    const blocks = normalizeResponse((agent as any).blocks || []);
 
     let folders: any[] = [];
     let fileCount = 0;

--- a/src/lib/client/agent-resolver.ts
+++ b/src/lib/client/agent-resolver.ts
@@ -31,24 +31,10 @@ export class AgentResolver {
     const agent = await this.client.getAgent(agentId);
     const agentWithDetails = agent as any;
     
-    // Fetch attached tools
-    try {
-      const tools = await this.client.listAgentTools(agentId);
-      agentWithDetails.tools = tools;
-    } catch (error) {
-      warn(`Warning: Could not fetch tools for agent ${agentId}`);
-      agentWithDetails.tools = [];
-    }
-    
-    // Fetch attached memory blocks
-    try {
-      const blocks = await this.client.listAgentBlocks(agentId);
-      agentWithDetails.blocks = blocks;
-    } catch (error) {
-      warn(`Warning: Could not fetch blocks for agent ${agentId}`);
-      agentWithDetails.blocks = [];
-    }
-    
+    // Use embedded tools/blocks from agent object (more reliable than paginated list endpoints)
+    agentWithDetails.tools = agentWithDetails.tools || [];
+    agentWithDetails.blocks = agentWithDetails.blocks || [];
+
     // Fetch attached folders
     try {
       const folders = await this.client.listAgentFolders(agentId);

--- a/src/lib/client/letta-client.ts
+++ b/src/lib/client/letta-client.ts
@@ -67,7 +67,8 @@ export class LettaClientWrapper {
       const response = await fetch(`${baseUrl}/v1/agents/${agentId}/`, { headers: this.getAuthHeaders() });
       if (response.ok) {
         const raw: any = await response.json();
-        if (raw.tags) (agent as any).tags = raw.tags;
+        if (raw.tags !== undefined) (agent as any).tags = raw.tags;
+        if (raw.description !== undefined) (agent as any).description = raw.description;
       }
     } catch {
       // Fall back to SDK response

--- a/tests/unit/lib/agent-resolver.test.ts
+++ b/tests/unit/lib/agent-resolver.test.ts
@@ -79,25 +79,37 @@ describe('AgentResolver', () => {
   });
 
   describe('getAgentWithDetails', () => {
-    it('should get agent details by ID', async () => {
+    it('should get agent details by ID using embedded tools/blocks', async () => {
+      const mockTools = [
+        { id: 'tool-1', name: 'my_tool' },
+        { id: 'tool-2', name: 'other_tool' },
+      ];
+      const mockBlocks = [
+        { id: 'block-1', label: 'persona', value: 'test' },
+      ];
       const mockAgent = {
         id: 'agent-123',
         name: 'test-agent',
         system: 'You are a test agent',
         memory: { blocks: [] },
-        tools: ['archival_memory_insert']
+        tools: mockTools,
+        blocks: mockBlocks,
       };
 
       mockClient.getAgent.mockResolvedValue(mockAgent as any);
+      mockClient.listAgentFolders.mockResolvedValue([] as any);
       mockClient.listAgentArchives.mockResolvedValue([] as any);
 
       const result = await agentResolver.getAgentWithDetails('agent-123');
 
-      expect(result).toMatchObject({
-        ...mockAgent,
-        archives: [],
-      });
+      expect(result.tools).toEqual(mockTools);
+      expect(result.blocks).toEqual(mockBlocks);
+      expect(result.folders).toEqual([]);
+      expect(result.archives).toEqual([]);
       expect(mockClient.getAgent).toHaveBeenCalledWith('agent-123');
+      // Should NOT call listAgentTools or listAgentBlocks
+      expect(mockClient.listAgentTools).not.toHaveBeenCalled();
+      expect(mockClient.listAgentBlocks).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Use embedded `.tools`/`.blocks` from `agents.retrieve()` instead of separate paginated list endpoints that return incomplete/duplicate results
- Patch `description` alongside `tags` in the raw-fetch workaround to prevent phantom drift
- Harden `tags` guard to use `!== undefined`

Fixes #248

## Changes

- **letta-client.ts**: Patch `description` from raw response; harden `tags` guard
- **agent-resolver.ts**: Use embedded `tools`/`blocks` instead of `listAgentTools()`/`listAgentBlocks()`
- **diff-engine.ts**: Use embedded `tools`/`blocks` from `currentAgent` for diffing
- **export.ts**: Use embedded `tools`/`blocks` from `fullAgent` for export
- **agent-data-fetcher.ts**: Use embedded `tools`/`blocks` from agent for display
- **agent-resolver.test.ts**: Update mocks to use embedded data, assert list methods not called