### PR TITLE
fix: paginate agent listing, normalize model drift (#252)

### DIFF
--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -324,6 +324,12 @@ function formatUpdateDetails(ops: AgentUpdateOperations, verbose: boolean, fancy
     if (ops.updateFields.maxTokens) {
       output(`    ${dim('max_tokens:')} ${ops.updateFields.maxTokens.from} ${dim('->')} ${ops.updateFields.maxTokens.to}`);
     }
+    if (ops.updateFields.reasoning !== undefined) {
+      output(`    ${dim('reasoning:')} ${ops.updateFields.reasoning.from} ${dim('->')} ${ops.updateFields.reasoning.to}`);
+    }
+    if (ops.updateFields.embeddingConfig) {
+      output(`    ${dim('embedding_config:')} ${JSON.stringify(ops.updateFields.embeddingConfig.from)} ${dim('->')} ${JSON.stringify(ops.updateFields.embeddingConfig.to)}`);
+    }
     if (ops.updateFields.tags) {
       output(`    ${dim('tags:')} [${ops.updateFields.tags.from}] ${dim('->')} [${ops.updateFields.tags.to}]`);
     }

--- a/src/lib/managers/agent-manager.ts
+++ b/src/lib/managers/agent-manager.ts
@@ -38,12 +38,12 @@ export class AgentManager {
     const agentList = normalizeResponse(agents);
 
     for (const agent of agentList) {
-      if (agent.name && agent.system) {
+      if (agent.name) {
         // For existing agents, store basic info for lookup
         // Full configuration hashing will be done during comparison
         const configHashes: AgentConfigHashes = {
           overall: '',              // Will be populated during comparison
-          systemPrompt: generateContentHash(agent.system),
+          systemPrompt: generateContentHash(agent.system || ''),
           tools: '',
           model: '',
           memoryBlocks: '',

--- a/src/lib/tools/mcp-tools.ts
+++ b/src/lib/tools/mcp-tools.ts
@@ -9,9 +9,11 @@ export async function buildMcpServerRegistry(client: LettaClientWrapper): Promis
   const serverList = Array.isArray(servers) ? servers : (servers as any).items || [];
   const registry = new Map<string, string>();
   for (const server of serverList) {
-    const name = (server as any).server_name || (server as any).name;
-    if (name && (server as any).id) {
-      registry.set(name, (server as any).id);
+    const s = server as any;
+    const name = s.server_name || s.name;
+    const id = s.id || s.server_id;
+    if (name && id) {
+      registry.set(name, id);
     }
   }
   return registry;

--- a/tests/e2e/fixtures/fleet-model-drift-test.yml
+++ b/tests/e2e/fixtures/fleet-model-drift-test.yml
@@ -1,0 +1,9 @@
+agents:
+- name: e2e-62-model-drift
+  description: Tests model provider prefix normalization
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: Agent for model drift test.
+  llm_config:
+    model: anthropic/claude-haiku-4-5-20251001
+    context_window: 32000

--- a/tests/e2e/tests/62-model-drift.sh
+++ b/tests/e2e/tests/62-model-drift.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Test: Model/embedding provider prefix normalization (#252)
+# Letta strips provider prefixes (e.g. "anthropic/claude-..." → "claude-...")
+# Re-apply should detect no drift after normalization
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT="e2e-62-model-drift"
+section "Test: Model Drift Normalization (#252)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+delete_agent_if_exists "$AGENT"
+
+# Create agent with provider-prefixed model
+info "Creating agent with anthropic/claude-haiku model..."
+$CLI apply -f "$FIXTURES/fleet-model-drift-test.yml" > $OUT 2>&1
+agent_exists "$AGENT" && pass "Agent created" || fail "Agent not created"
+
+# Re-apply same config — should be idempotent (0 changes)
+info "Re-applying same config..."
+$CLI apply -f "$FIXTURES/fleet-model-drift-test.yml" --dry-run > $OUT 2>&1
+cat $OUT
+output_contains "0 changes" && pass "No phantom drift on re-apply" || fail "Phantom drift detected on re-apply"
+output_not_contains "model:" && pass "No model field change" || fail "Model field flagged as changed"
+output_not_contains "embedding_config:" && pass "No embedding_config drift" || fail "embedding_config flagged as changed"
+
+delete_agent_if_exists "$AGENT"
+print_summary


### PR DESCRIPTION
Fixes #252

## Changes

- **`listAgents()` → raw API with cursor pagination**: SDK `agents.list()` only returned the first page (10 agents). Replaced with raw `/v1/agents/` API call with manual `after` cursor pagination to fetch all agents regardless of server page size.

- **Model name normalization**: Letta strips provider prefixes, cloud vendor prefixes, and version suffixes from model names (e.g. `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0` → `claude-haiku-4-5-20251001`). Added `normalizeModelName()` to strip these before comparison, eliminating phantom model drift.

- **Embedding name normalization**: Same `normalizeModelName()` applied to embedding field comparison.

- **Skip `embedding_config` when unset in YAML**: When YAML only specifies the `embedding` shorthand (no explicit `embedding_config`), the server auto-expands it into a full config object. Skip comparison to avoid phantom drift.

- **Agent registry filter relaxed**: Changed `if (agent.name && agent.system)` to `if (agent.name)` — SDK list response may not include `system` field.

- **MCP server ID fallback**: `s.id || s.server_id` for defensive MCP server lookup.

- **Dry-run output**: Added `reasoning` and `embedding_config` to verbose dry-run output so phantom drift is visible.

## E2E Test

Added `62-model-drift.sh` — creates agent with provider-prefixed model, re-applies same config, asserts 0 changes (no phantom drift).