### PR TITLE
fix: add FolderManager for idempotent folder creation (#259)

### DIFF
--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -2,6 +2,7 @@ import { FleetParser } from '../../lib/apply/fleet-parser';
 import { LettaClientWrapper } from '../../lib/client/letta-client';
 import { BlockManager } from '../../lib/managers/block-manager';
 import { ArchiveManager } from '../../lib/managers/archive-manager';
+import { FolderManager } from '../../lib/managers/folder-manager';
 import { AgentManager } from '../../lib/managers/agent-manager';
 import { DiffEngine } from '../../lib/apply/diff-engine';
 import { FileContentTracker } from '../../lib/apply/file-content-tracker';
@@ -136,6 +137,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
     const blockManager = new BlockManager(client);
     const agentManager = new AgentManager(client);
     const archiveManager = new ArchiveManager(client);
+    const folderManager = new FolderManager(client);
     const diffEngine = new DiffEngine(client, blockManager, archiveManager, parser.basePath);
     const fileTracker = new FileContentTracker(parser.basePath, parser.storageBackend);
 
@@ -147,6 +149,9 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
     if (verbose) log('Loading existing archives...');
     await archiveManager.loadExistingArchives();
 
+    if (verbose) log('Loading existing folders...');
+    await folderManager.loadExistingFolders();
+
     if (verbose) log('Loading existing agents...');
     await agentManager.loadExistingAgents();
     loadSpinner.succeed('Loaded existing resources');
@@ -157,6 +162,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
         client,
         blockManager,
         archiveManager,
+        folderManager,
         agentManager,
         diffEngine,
         fileTracker,
@@ -222,7 +228,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
 
     // Process folders
     const folderSpinner = createSpinner('Processing folders...', spinnerEnabled).start();
-    const createdFolders = await processFolders(config, client, parser, options, verbose);
+    const createdFolders = await processFolders(config, folderManager, client, parser, options, verbose);
     folderSpinner.succeed(`Processed ${createdFolders.size} folders`);
 
     // Process agents

--- a/src/lib/managers/folder-manager.ts
+++ b/src/lib/managers/folder-manager.ts
@@ -1,0 +1,66 @@
+import { LettaClientWrapper } from '../client/letta-client';
+import { log } from '../shared/logger';
+
+export interface FolderInfo {
+  id: string;
+  name: string;
+  embedding?: string | null;
+}
+
+export class FolderManager {
+  private client: LettaClientWrapper;
+  private folderRegistry = new Map<string, FolderInfo>();
+
+  constructor(client: LettaClientWrapper) {
+    this.client = client;
+  }
+
+  async loadExistingFolders(): Promise<void> {
+    const folders = await this.client.listFolders();
+    const folderList = Array.isArray(folders) ? folders : (folders as any).items || [];
+
+    for (const folder of folderList) {
+      if (!folder.name || !folder.id) {
+        continue;
+      }
+      this.folderRegistry.set(folder.name, {
+        id: folder.id,
+        name: folder.name,
+        embedding: folder.embedding,
+      });
+    }
+  }
+
+  getFolderId(name: string): string | null {
+    const existing = this.folderRegistry.get(name);
+    return existing ? existing.id : null;
+  }
+
+  async getOrCreateFolder(config: {
+    name: string;
+    embedding?: string;
+  }): Promise<string> {
+    const existing = this.folderRegistry.get(config.name);
+    if (existing) {
+      return existing.id;
+    }
+
+    log(`Creating folder: ${config.name}`);
+    const newFolder = await this.client.createFolder({
+      name: config.name,
+      embedding: config.embedding,
+    });
+
+    this.folderRegistry.set(config.name, {
+      id: newFolder.id,
+      name: newFolder.name,
+      embedding: config.embedding || null,
+    });
+
+    return newFolder.id;
+  }
+
+  getFolderRegistry(): Map<string, FolderInfo> {
+    return new Map(this.folderRegistry);
+  }
+}

--- a/src/lib/managers/index.ts
+++ b/src/lib/managers/index.ts
@@ -1,3 +1,4 @@
 export * from './agent-manager';
 export * from './block-manager';
 export * from './archive-manager';
+export * from './folder-manager';

--- a/tests/e2e/fixtures/fleet-shared-folder-idempotent.yml
+++ b/tests/e2e/fixtures/fleet-shared-folder-idempotent.yml
@@ -1,0 +1,27 @@
+shared_folders:
+- name: e2e-65-shared-idem-docs
+  files:
+  - folder-files/doc1.txt
+
+agents:
+- name: e2e-65-shared-idem-a
+  description: First agent sharing a folder for idempotency test
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant with access to shared documents.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  shared_folders:
+  - e2e-65-shared-idem-docs
+
+- name: e2e-65-shared-idem-b
+  description: Second agent sharing the same folder for idempotency test
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a helpful assistant with access to shared documents.
+  llm_config:
+    model: google_ai/gemini-2.0-flash-lite
+    context_window: 32000
+  shared_folders:
+  - e2e-65-shared-idem-docs

--- a/tests/e2e/tests/65-shared-folder-idempotent.sh
+++ b/tests/e2e/tests/65-shared-folder-idempotent.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Test: Shared folder idempotency — repeated deploys must not hit duplicate constraint
+# Issue: #259
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT_A="e2e-65-shared-idem-a"
+AGENT_B="e2e-65-shared-idem-b"
+
+section "Test: Shared Folder Idempotent Deploy (#259)"
+
+# Setup
+preflight_check
+mkdir -p "$LOG_DIR"
+
+# Cleanup before test
+info "Cleaning up test agents if they exist..."
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+
+# First apply — should create both agents and the shared folder
+section "First Apply"
+if $CLI apply -f "$FIXTURES/fleet-shared-folder-idempotent.yml" --root "$FIXTURES" > $OUT 2>&1; then
+    pass "First apply succeeded"
+else
+    fail "First apply failed"
+    cat $OUT
+    exit 1
+fi
+
+# Verify both agents created
+if agent_exists "$AGENT_A"; then
+    pass "Agent A exists: $AGENT_A"
+else
+    fail "Agent A not created: $AGENT_A"
+fi
+
+if agent_exists "$AGENT_B"; then
+    pass "Agent B exists: $AGENT_B"
+else
+    fail "Agent B not created: $AGENT_B"
+fi
+
+# Second apply — must NOT fail with duplicate constraint error
+section "Second Apply (idempotency)"
+if $CLI apply -f "$FIXTURES/fleet-shared-folder-idempotent.yml" --root "$FIXTURES" > $OUT 2>&1; then
+    pass "Second apply succeeded (no duplicate constraint error)"
+else
+    fail "Second apply failed — possible duplicate folder constraint"
+    cat $OUT
+    exit 1
+fi
+
+# Verify agents still exist after second apply
+if agent_exists "$AGENT_A"; then
+    pass "Agent A still exists after re-apply"
+else
+    fail "Agent A missing after re-apply"
+fi
+
+if agent_exists "$AGENT_B"; then
+    pass "Agent B still exists after re-apply"
+else
+    fail "Agent B missing after re-apply"
+fi
+
+# Cleanup
+section "Cleanup"
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+pass "Cleaned up test agents"
+
+# Summary
+print_summary

--- a/tests/unit/lib/folder-manager.test.ts
+++ b/tests/unit/lib/folder-manager.test.ts
@@ -1,0 +1,101 @@
+import { FolderManager } from '../../../src/lib/managers/folder-manager';
+import { LettaClientWrapper } from '../../../src/lib/client/letta-client';
+
+jest.mock('../../../src/lib/client/letta-client');
+
+describe('FolderManager', () => {
+  let manager: FolderManager;
+  let mockClient: jest.Mocked<LettaClientWrapper>;
+
+  beforeEach(() => {
+    mockClient = new (LettaClientWrapper as any)();
+    manager = new FolderManager(mockClient);
+  });
+
+  describe('loadExistingFolders', () => {
+    it('loads folders into registry', async () => {
+      mockClient.listFolders.mockResolvedValue([
+        { id: 'f1', name: 'docs', embedding: 'openai/text-embedding-3-small' },
+        { id: 'f2', name: 'notes', embedding: null },
+      ] as any);
+
+      await manager.loadExistingFolders();
+
+      expect(manager.getFolderId('docs')).toBe('f1');
+      expect(manager.getFolderId('notes')).toBe('f2');
+    });
+
+    it('skips entries without name or id', async () => {
+      mockClient.listFolders.mockResolvedValue([
+        { id: 'f1', name: 'valid' },
+        { id: null, name: 'no-id' },
+        { id: 'f3', name: null },
+        { id: null, name: null },
+      ] as any);
+
+      await manager.loadExistingFolders();
+
+      expect(manager.getFolderId('valid')).toBe('f1');
+      expect(manager.getFolderId('no-id')).toBeNull();
+    });
+  });
+
+  describe('getOrCreateFolder', () => {
+    it('creates folder when not in registry', async () => {
+      mockClient.listFolders.mockResolvedValue([] as any);
+      mockClient.createFolder.mockResolvedValue({ id: 'new-1', name: 'docs' } as any);
+      await manager.loadExistingFolders();
+
+      const id = await manager.getOrCreateFolder({ name: 'docs', embedding: 'openai/text-embedding-3-small' });
+
+      expect(id).toBe('new-1');
+      expect(mockClient.createFolder).toHaveBeenCalledWith({
+        name: 'docs',
+        embedding: 'openai/text-embedding-3-small',
+      });
+    });
+
+    it('returns existing folder without API call', async () => {
+      mockClient.listFolders.mockResolvedValue([
+        { id: 'existing-1', name: 'docs', embedding: 'openai/text-embedding-3-small' },
+      ] as any);
+      await manager.loadExistingFolders();
+
+      const id = await manager.getOrCreateFolder({ name: 'docs', embedding: 'openai/text-embedding-3-small' });
+
+      expect(id).toBe('existing-1');
+      expect(mockClient.createFolder).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — second call reuses first (1 API call total)', async () => {
+      mockClient.listFolders.mockResolvedValue([] as any);
+      mockClient.createFolder.mockResolvedValue({ id: 'new-1', name: 'docs' } as any);
+      await manager.loadExistingFolders();
+
+      const id1 = await manager.getOrCreateFolder({ name: 'docs', embedding: 'openai/text-embedding-3-small' });
+      const id2 = await manager.getOrCreateFolder({ name: 'docs', embedding: 'openai/text-embedding-3-small' });
+
+      expect(id1).toBe('new-1');
+      expect(id2).toBe('new-1');
+      expect(mockClient.createFolder).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getFolderRegistry', () => {
+    it('returns a copy of the registry', async () => {
+      mockClient.listFolders.mockResolvedValue([
+        { id: 'f1', name: 'docs', embedding: 'openai/text-embedding-3-small' },
+      ] as any);
+      await manager.loadExistingFolders();
+
+      const registry = manager.getFolderRegistry();
+
+      expect(registry.size).toBe(1);
+      expect(registry.get('docs')?.id).toBe('f1');
+
+      // Verify it's a copy — mutating it doesn't affect the manager
+      registry.delete('docs');
+      expect(manager.getFolderId('docs')).toBe('f1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `FolderManager` class (`src/lib/managers/folder-manager.ts`) following the `ArchiveManager` pattern — loads existing folders upfront, provides `getOrCreateFolder()` for idempotent creation
- Refactors `processFolders()` in `apply-helpers.ts` to use `FolderManager` instead of inline `listFolders()`/`createFolder()` calls
- Wires `FolderManager` into `apply.ts` and `dry-run.ts`, removing the standalone `buildFolderRegistry()` function
- Adds unit tests and e2e test (65-shared-folder-idempotent) verifying repeated deploys with shared folders succeed

Fixes #259