### PR TITLE
fix: scope resource registries to current fleet config (#267)

### DIFF
--- a/src/commands/apply/template.ts
+++ b/src/commands/apply/template.ts
@@ -11,6 +11,7 @@ import { readLastApplied, applyThreeWayMerge, hashCurrentTools, hashCurrentBlock
 import { normalizeResponse } from '../../lib/shared/response-normalizer';
 import { log, output } from '../../lib/shared/logger';
 import { buildMcpServerRegistry, expandMcpToolsForAgents } from '../../lib/tools/mcp-tools';
+import { collectDesiredResourceNames } from '../../lib/apply/apply-helpers';
 
 /**
  * Template mode: apply a template config to all existing agents matching a glob pattern.
@@ -75,8 +76,9 @@ export async function applyTemplateMode(
   const fileTracker = new FileContentTracker(parser.basePath, parser.storageBackend);
   const createdFolders = new Map<string, string>();
 
-  await blockManager.loadExistingBlocks();
-  await archiveManager.loadExistingArchives();
+  const { blockNames, archiveNames } = collectDesiredResourceNames(config);
+  await blockManager.loadExistingBlocks(blockNames);
+  await archiveManager.loadExistingArchives(archiveNames);
 
   // Register MCP servers (if configured) and expand MCP tool selections
   if (config.mcp_servers && config.mcp_servers.length > 0) {

--- a/tests/e2e/fixtures/fleet-tenant-a.yml
+++ b/tests/e2e/fixtures/fleet-tenant-a.yml
@@ -1,0 +1,27 @@
+shared_blocks:
+- name: tenant_a_policies
+  description: Tenant A policies
+  limit: 2000
+  value: "Tenant A policy content"
+  agent_owned: true
+
+agents:
+- name: e2e-66-tenant-a
+  description: Tenant A agent
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a tenant A assistant.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: tenant_a_context
+    description: Tenant A context
+    limit: 2000
+    value: "Tenant A context data"
+    agent_owned: true
+  shared_blocks:
+  - tenant_a_policies
+  tools:
+  - send_message
+  - conversation_search

--- a/tests/e2e/fixtures/fleet-tenant-b.yml
+++ b/tests/e2e/fixtures/fleet-tenant-b.yml
@@ -1,0 +1,27 @@
+shared_blocks:
+- name: tenant_b_policies
+  description: Tenant B policies
+  limit: 2000
+  value: "Tenant B policy content"
+  agent_owned: true
+
+agents:
+- name: e2e-66-tenant-b
+  description: Tenant B agent
+  embedding: openai/text-embedding-3-small
+  system_prompt:
+    value: You are a tenant B assistant.
+  llm_config:
+    model: google_ai/gemini-2.5-pro
+    context_window: 32000
+  memory_blocks:
+  - name: tenant_b_context
+    description: Tenant B context
+    limit: 2000
+    value: "Tenant B context data"
+    agent_owned: true
+  shared_blocks:
+  - tenant_b_policies
+  tools:
+  - send_message
+  - conversation_search

--- a/tests/e2e/tests/66-cross-tenant-isolation.sh
+++ b/tests/e2e/tests/66-cross-tenant-isolation.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Test: Cross-tenant resource isolation (#267)
+# Verifies that applying fleet configs for separate tenants in sequence
+# does not leak blocks/resources across tenant boundaries.
+#
+# Scenario:
+#   1. Deploy tenant A fleet (creates tenant_a_* blocks)
+#   2. Deploy tenant B fleet (creates tenant_b_* blocks)
+#   3. Re-deploy tenant A — should NOT show tenant B resources as drift
+#   4. Dry-run tenant A — output must not mention tenant_b_*
+#   5. Verify each agent only has its own blocks
+#   6. Apply tenant A with --force — must not detach its own blocks
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+AGENT_A="e2e-66-tenant-a"
+AGENT_B="e2e-66-tenant-b"
+
+section "Test: Cross-Tenant Resource Isolation (#267)"
+preflight_check
+mkdir -p "$LOG_DIR"
+
+# ============================================================================
+# Cleanup
+# ============================================================================
+info "Cleaning up test agents..."
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+
+# ============================================================================
+# Step 1: Deploy tenant A
+# ============================================================================
+section "Step 1: Deploy tenant A"
+$CLI apply -f "$FIXTURES/fleet-tenant-a.yml" --skip-first-message > $OUT 2>&1
+agent_exists "$AGENT_A" && pass "Tenant A agent created" || fail "Tenant A agent not created"
+
+# Verify tenant A blocks
+$CLI get blocks --agent "$AGENT_A" > $OUT 2>&1
+output_contains "tenant_a_context" && pass "Tenant A has tenant_a_context block" || fail "Missing tenant_a_context"
+output_contains "tenant_a_policies" && pass "Tenant A has tenant_a_policies block" || fail "Missing tenant_a_policies"
+
+# ============================================================================
+# Step 2: Deploy tenant B (separate fleet config, same server)
+# ============================================================================
+section "Step 2: Deploy tenant B"
+$CLI apply -f "$FIXTURES/fleet-tenant-b.yml" --skip-first-message > $OUT 2>&1
+agent_exists "$AGENT_B" && pass "Tenant B agent created" || fail "Tenant B agent not created"
+
+# Verify tenant B blocks
+$CLI get blocks --agent "$AGENT_B" > $OUT 2>&1
+output_contains "tenant_b_context" && pass "Tenant B has tenant_b_context block" || fail "Missing tenant_b_context"
+output_contains "tenant_b_policies" && pass "Tenant B has tenant_b_policies block" || fail "Missing tenant_b_policies"
+
+# ============================================================================
+# Step 3: Re-apply tenant A — must be clean, no drift from tenant B
+# ============================================================================
+section "Step 3: Re-apply tenant A (no changes expected)"
+$CLI apply -f "$FIXTURES/fleet-tenant-a.yml" --skip-first-message > $OUT 2>&1
+output_not_contains "tenant_b" && pass "Re-apply output has no tenant_b references" || fail "Tenant B resources leaked into tenant A apply"
+output_not_contains "Removed" && pass "No removal drift detected" || fail "Unexpected removal drift on re-apply"
+
+# ============================================================================
+# Step 4: Dry-run tenant A — must not show tenant B blocks as drift
+# ============================================================================
+section "Step 4: Dry-run tenant A"
+$CLI apply -f "$FIXTURES/fleet-tenant-a.yml" --dry-run --skip-first-message > $OUT 2>&1
+output_not_contains "tenant_b" && pass "Dry-run has no tenant_b references" || fail "Tenant B resources in tenant A dry-run"
+output_not_contains "requires --force" && pass "No --force removal lines in dry-run" || fail "Unexpected --force removal lines in dry-run"
+
+# ============================================================================
+# Step 5: Verify agent blocks are isolated
+# ============================================================================
+section "Step 5: Verify block isolation"
+
+$CLI get blocks --agent "$AGENT_A" > $OUT 2>&1
+output_not_contains "tenant_b" && pass "Tenant A agent has no tenant_b blocks" || fail "CONTAMINATION: tenant_b blocks on tenant A agent"
+
+$CLI get blocks --agent "$AGENT_B" > $OUT 2>&1
+output_not_contains "tenant_a" && pass "Tenant B agent has no tenant_a blocks" || fail "CONTAMINATION: tenant_a blocks on tenant B agent"
+
+# ============================================================================
+# Step 6: --force apply tenant A should not detach its own blocks
+# ============================================================================
+section "Step 6: Force apply tenant A (should keep its own blocks)"
+$CLI apply -f "$FIXTURES/fleet-tenant-a.yml" --force --skip-first-message > $OUT 2>&1
+
+$CLI get blocks --agent "$AGENT_A" > $OUT 2>&1
+output_contains "tenant_a_context" && pass "tenant_a_context survives --force" || fail "tenant_a_context lost after --force"
+output_contains "tenant_a_policies" && pass "tenant_a_policies survives --force" || fail "tenant_a_policies lost after --force"
+
+# ============================================================================
+# Step 7: Dry-run tenant B unaffected by tenant A operations
+# ============================================================================
+section "Step 7: Dry-run tenant B (unaffected)"
+$CLI apply -f "$FIXTURES/fleet-tenant-b.yml" --dry-run --skip-first-message > $OUT 2>&1
+output_not_contains "tenant_a" && pass "Tenant B dry-run has no tenant_a references" || fail "Tenant A resources in tenant B dry-run"
+
+# ============================================================================
+# Cleanup
+# ============================================================================
+section "Cleanup"
+delete_agent_if_exists "$AGENT_A"
+delete_agent_if_exists "$AGENT_B"
+pass "Cleaned up test agents"
+
+print_summary

--- a/tests/unit/lib/block-manager.test.ts
+++ b/tests/unit/lib/block-manager.test.ts
@@ -114,6 +114,32 @@ describe('BlockManager', () => {
     });
   });
 
+  describe('loadExistingBlocks scoping', () => {
+    it('excludes blocks not in desiredNames', async () => {
+      mockClient.listBlocks.mockResolvedValue([
+        { id: 'b1', label: 'tenant_a_block', value: 'a', description: '', limit: 1000 },
+        { id: 'b2', label: 'tenant_b_block', value: 'b', description: '', limit: 1000 },
+      ] as any);
+
+      await manager.loadExistingBlocks(new Set(['tenant_a_block']));
+
+      expect(manager.getSharedBlockId('tenant_a_block')).toBe('b1');
+      expect(manager.getSharedBlockId('tenant_b_block')).toBeNull();
+    });
+
+    it('loads all blocks when desiredNames is omitted', async () => {
+      mockClient.listBlocks.mockResolvedValue([
+        { id: 'b1', label: 'block_a', value: 'a', description: '', limit: 1000 },
+        { id: 'b2', label: 'block_b', value: 'b', description: '', limit: 1000 },
+      ] as any);
+
+      await manager.loadExistingBlocks();
+
+      expect(manager.getSharedBlockId('block_a')).toBe('b1');
+      expect(manager.getSharedBlockId('block_b')).toBe('b2');
+    });
+  });
+
   describe('getSharedBlockId', () => {
     it('returns null when block only exists under plain label', async () => {
       // Manually register a block under plain label only (no shared: prefix)

--- a/tests/unit/lib/collect-desired-resource-names.test.ts
+++ b/tests/unit/lib/collect-desired-resource-names.test.ts
@@ -1,0 +1,57 @@
+import { collectDesiredResourceNames } from '../../../src/lib/apply/apply-helpers';
+
+describe('collectDesiredResourceNames', () => {
+  it('collects block names from shared_blocks and agent memory_blocks/shared_blocks', () => {
+    const config = {
+      shared_blocks: [{ name: 'global_context' }],
+      agents: [
+        {
+          memory_blocks: [{ name: 'persona' }, { name: 'policies' }],
+          shared_blocks: ['global_context'],
+        },
+        {
+          memory_blocks: [{ name: 'brand_identity' }],
+        },
+      ],
+    };
+
+    const { blockNames } = collectDesiredResourceNames(config);
+
+    expect(blockNames).toEqual(new Set(['global_context', 'persona', 'policies', 'brand_identity']));
+  });
+
+  it('collects folder names from agents and shared_folders', () => {
+    const config = {
+      shared_folders: [{ name: 'shared_docs' }],
+      agents: [
+        { folders: [{ name: 'research' }] },
+        { folders: [{ name: 'shared_docs' }, { name: 'notes' }] },
+      ],
+    };
+
+    const { folderNames } = collectDesiredResourceNames(config);
+
+    expect(folderNames).toEqual(new Set(['shared_docs', 'research', 'notes']));
+  });
+
+  it('collects archive names from agents', () => {
+    const config = {
+      agents: [
+        { archives: [{ name: 'search_index' }] },
+        { archives: [{ name: 'metrics' }] },
+      ],
+    };
+
+    const { archiveNames } = collectDesiredResourceNames(config);
+
+    expect(archiveNames).toEqual(new Set(['search_index', 'metrics']));
+  });
+
+  it('returns empty sets for minimal config', () => {
+    const { blockNames, folderNames, archiveNames } = collectDesiredResourceNames({ agents: [] });
+
+    expect(blockNames.size).toBe(0);
+    expect(folderNames.size).toBe(0);
+    expect(archiveNames.size).toBe(0);
+  });
+});

--- a/tests/unit/lib/folder-manager.test.ts
+++ b/tests/unit/lib/folder-manager.test.ts
@@ -40,6 +40,32 @@ describe('FolderManager', () => {
     });
   });
 
+  describe('loadExistingFolders scoping', () => {
+    it('excludes folders not in desiredNames', async () => {
+      mockClient.listFolders.mockResolvedValue([
+        { id: 'f1', name: 'tenant_a_docs', embedding: null },
+        { id: 'f2', name: 'tenant_b_docs', embedding: null },
+      ] as any);
+
+      await manager.loadExistingFolders(new Set(['tenant_a_docs']));
+
+      expect(manager.getFolderId('tenant_a_docs')).toBe('f1');
+      expect(manager.getFolderId('tenant_b_docs')).toBeNull();
+    });
+
+    it('loads all folders when desiredNames is omitted', async () => {
+      mockClient.listFolders.mockResolvedValue([
+        { id: 'f1', name: 'folder_a', embedding: null },
+        { id: 'f2', name: 'folder_b', embedding: null },
+      ] as any);
+
+      await manager.loadExistingFolders();
+
+      expect(manager.getFolderId('folder_a')).toBe('f1');
+      expect(manager.getFolderId('folder_b')).toBe('f2');
+    });
+  });
+
   describe('getOrCreateFolder', () => {
     it('creates folder when not in registry', async () => {
       mockClient.listFolders.mockResolvedValue([] as any);


### PR DESCRIPTION
## Summary

- Add `desiredNames` filter to `BlockManager.loadExistingBlocks()`, `FolderManager.loadExistingFolders()`, and `ArchiveManager.loadExistingArchives()` so only resources declared in the current fleet YAML are registered
- Add `collectDesiredResourceNames()` helper to collect all block/folder/archive names from config
- Pass scoped names at both call sites (`apply.ts` and `template.ts`)
- Prevents cross-tenant contamination where blocks/folders/archives from one fleet config leak into another via unscoped global registries

Closes #267

## Test plan

- [x] Unit tests: scoping excludes foreign resources, backward-compatible when filter omitted
- [x] Unit tests: `collectDesiredResourceNames` covers shared_blocks, memory_blocks, shared_folders, folders, archives
- [x] E2E test `66-cross-tenant-isolation`: deploy two tenants sequentially, verify no cross-contamination on re-apply, dry-run, --force, and block isolation (18 checks)
- [x] Full E2E suite: 65 tests, 514 checks, 0 failures