### PR TITLE
fix: skip folder/archive calls when config declares none

### DIFF
--- a/src/lib/apply/diff-engine.ts
+++ b/src/lib/apply/diff-engine.ts
@@ -72,10 +72,20 @@ export class DiffEngine {
 
     if (verbose) log(`  Analyzing configuration changes for agent: ${existingAgent.name}`);
 
-    // Get current agent state from server
+    // Get current agent state from server. Only fetch folders/archives when
+    // the desired config declares them — this preserves reconciliation for
+    // managed resources while skipping an unnecessary API call (and an
+    // endpoint that some deployments have deprecated, e.g. Letta Cloud's
+    // `GET /v1/agents/{id}/folders`) for agents that don't use them.
     const currentAgent = await this.client.getAgent(existingAgent.id);
-    const currentFoldersResponse = await this.client.listAgentFolders(existingAgent.id);
-    const currentArchivesResponse = await this.client.listAgentArchives(existingAgent.id);
+    const hasDesiredFolders = (desiredConfig.folders || []).length > 0;
+    const hasDesiredArchives = (desiredConfig.archives || []).length > 0;
+    const currentFoldersResponse = hasDesiredFolders
+      ? await this.client.listAgentFolders(existingAgent.id)
+      : [];
+    const currentArchivesResponse = hasDesiredArchives
+      ? await this.client.listAgentArchives(existingAgent.id)
+      : [];
 
     // Use embedded tools/blocks from agent object (more reliable than paginated list endpoints)
     const currentTools = normalizeResponse((currentAgent as any).tools || []);

--- a/src/lib/managers/archive-manager.ts
+++ b/src/lib/managers/archive-manager.ts
@@ -22,8 +22,15 @@ export class ArchiveManager {
    * Loads existing archives from the server and builds the registry.
    * When desiredNames is provided, only archives matching those names are registered,
    * preventing cross-tenant contamination via unscoped global lookups.
+   *
+   * If the caller explicitly declared an empty desired set, skip the API
+   * call entirely — the resulting registry would be empty after filtering
+   * anyway, and it avoids an unnecessary round trip.
    */
   async loadExistingArchives(desiredNames?: Set<string>): Promise<void> {
+    if (desiredNames !== undefined && desiredNames.size === 0) {
+      return;
+    }
     const archives = await this.client.listArchives();
     const archiveList = normalizeResponse(archives);
 

--- a/src/lib/managers/folder-manager.ts
+++ b/src/lib/managers/folder-manager.ts
@@ -19,8 +19,16 @@ export class FolderManager {
    * Loads existing folders from the server and builds the registry.
    * When desiredNames is provided, only folders matching those names are registered,
    * preventing cross-tenant contamination via unscoped global lookups.
+   *
+   * If the caller explicitly declared an empty desired set, skip the API
+   * call entirely — the resulting registry would be empty after filtering
+   * anyway, and it spares us hitting a server endpoint that some deployments
+   * have deprecated (e.g. Letta Cloud's `GET /v1/folders`).
    */
   async loadExistingFolders(desiredNames?: Set<string>): Promise<void> {
+    if (desiredNames !== undefined && desiredNames.size === 0) {
+      return;
+    }
     const folders = await this.client.listFolders();
     const folderList = Array.isArray(folders) ? folders : (folders as any).items || [];
 


### PR DESCRIPTION
## What

Skip unnecessary folder and archive API calls during `lettactl apply` when the fleet config doesn't declare either.

## Why

Two `lettactl apply` code paths unconditionally list folders/archives on the server, even when the config references neither:

1. The "Loading existing resources" phase calls `FolderManager.loadExistingFolders` and `ArchiveManager.loadExistingArchives` once per apply, regardless of what the config asks for.
2. The per-agent diff (`DiffEngine.generateUpdateOperations`) calls `listAgentFolders(agentId)` / `listAgentArchives(agentId)` for every agent being diffed, regardless of whether that agent manages folders or archives.

Letta Cloud has deprecated the `GET /v1/folders` and `GET /v1/agents/{id}/folders` endpoints — both now return HTTP 400. So **every `lettactl apply` against Letta Cloud currently fails**, even for the simplest config of an agent with a couple of memory blocks.

```
$ lettactl apply -f agents.yml --agent my-bot --dry-run
- Loading existing resources...
Apply failed: 400 {"error":"This API route is deprecated and no longer supported on the Letta API..."}
```

## Fix

Three targeted guards. Each is a cheap early-return that both skips the wasted round trip and avoids the deprecated endpoint:

- **`FolderManager.loadExistingFolders`**: early-return when `desiredNames` is an explicit empty `Set`. `undefined` still loads everything, preserving the existing "load all folders" semantics used by `get`, `cleanup`, `describe`, etc.
- **`ArchiveManager.loadExistingArchives`**: same guard for symmetry and to avoid an equivalent unnecessary round trip.
- **`DiffEngine.generateUpdateOperations`**: only call `listAgentFolders` / `listAgentArchives` when the agent's desired config declares folders / archives. Agents that don't manage those resource types no longer touch the server for them at all.

## Behavior change

Scoped to configs that omit folder/archive sections entirely. In that case, lettactl now stops managing those aspects (does not attempt to detach orphaned folders/archives on the server) instead of aborting with a 400. Configs that declare folders or archives reconcile exactly as before. `--force` semantics are unchanged.

## Testing

Verified against Letta Cloud with an `agents.yml` containing two agents, each with `system_prompt` (from_file) + a couple of memory blocks and no folders/archives:

- Before: `lettactl apply --dry-run` 400s during "Loading existing resources".
- After: `lettactl apply --dry-run` completes, prints diff, and exits 0. The underlying deprecated endpoint is no longer hit.

Verbose tracing confirmed the failure previously originated from the unconditional `listAgentFolders(agentId)` call in `DiffEngine`, not from any other call in the dry-run path.
