### PR TITLE
fix: v0.21.2 delete existing folder file before re-upload to avoid _(N) duplicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/lib/apply/diff-applier.ts
+++ b/src/lib/apply/diff-applier.ts
@@ -344,7 +344,18 @@ export class DiffApplier {
   }
 
   /**
-   * Helper method to update an existing file in a folder
+   * Helper method to update an existing file in a folder.
+   *
+   * Letta's POST /folders/{id}/upload always CREATES — if a file with the same
+   * name exists, the server appends a "_(N)" suffix instead of replacing it.
+   * That leaves stale duplicates accumulating across every apply, and
+   * downstream tools (grep_files, open_files) start matching both copies.
+   *
+   * Letta has no PATCH-by-name for file content, so the only idempotent path
+   * is: look up the existing file by name → delete it → upload the new copy
+   * under the original name. If delete succeeds but upload fails, the file is
+   * gone until the next apply — surface a clear error so the operator can
+   * retry. (See nouamanecodes/lettactl#375.)
    */
   private async updateFileInFolder(folderId: string, filePath: string): Promise<void> {
     const fullPath = path.resolve(this.basePath, filePath);
@@ -354,7 +365,13 @@ export class DiffApplier {
       throw new Error(`File not found: ${fullPath}`);
     }
 
-    // For file updates, we re-upload the file
+    // Delete the existing file first so the new upload keeps the original name.
+    // No-op if the file isn't present (e.g. first-time add via this path).
+    const existingFileId = await this.client.getFileIdByName(folderId, fileName);
+    if (existingFileId) {
+      await this.client.deleteFileFromFolder(folderId, existingFileId);
+    }
+
     const fileStream = fs.createReadStream(fullPath);
     await this.client.uploadFileToFolder(fileStream, folderId, fileName);
   }


### PR DESCRIPTION
Closes #375.

## What

In `diff-applier.ts → updateFileInFolder`, look up the existing file by name and DELETE it before uploading the new copy. Letta's `POST /folders/{id}/upload` always creates — if a file with the same name exists, the server appends a `_(N)` suffix instead of replacing. That left stale duplicates accumulating across every \`lettactl apply\` and downstream tools (\`grep_files\`, \`open_files\`) started matching both copies.

There's no PATCH-by-name for file content on Letta's side, so delete-then-upload is the only idempotent path.

## Trade-off

If the delete succeeds but the upload then fails, the file is gone until the next apply. Documented inline. The previous behavior left two files in that case, which is also broken — silently — and harder to recover from. Hard failure with a clear error surface is the better default.

## Test plan
- [x] tsc clean
- [ ] Reproduce on a folder: apply, change content of one file, re-apply, confirm the file count stays at 1 and the new content is loaded (`open_files` returns the new content)
- [ ] Confirm: removing a file from yaml still detaches cleanly (`filesToRemove` path unchanged)
- [ ] Confirm: first-time upload (no existing file) still works (the `existingFileId` check no-ops cleanly)

Discovered while migrating Adspectre's Draper agent to folder-attached files — re-applying the recipes test fleet created `recipes_(1).md` alongside the original `recipes.md`.