### PR TITLE
fix: v0.21.6 attach letta_builtin tools instead of silently skipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/lib/apply/diff-analyzers.ts
+++ b/src/lib/apply/diff-analyzers.ts
@@ -4,7 +4,7 @@ import { normalizeResponse } from '../shared/response-normalizer';
 import { ToolDiff, BlockDiff, FolderDiff, ArchiveDiff } from './diff-engine';
 import { FolderFileConfig } from '../../types/fleet-config';
 import { warn } from '../shared/logger';
-import { PROTECTED_MEMORY_TOOLS, isBuiltinTool } from '../tools/builtin-tools';
+import { PROTECTED_MEMORY_TOOLS, isImplicitBuiltin } from '../tools/builtin-tools';
 import { ArchiveManager } from '../managers/archive-manager';
 
 // Helper to extract file name from FolderFileConfig (string or from_bucket object)
@@ -56,9 +56,12 @@ export async function analyzeToolChanges(
     if (!currentToolNames.has(toolName)) {
       const toolId = toolRegistry.get(toolName);
       if (toolId) {
-        // Builtin tools are implicitly available — the API may not
-        // include them in listAgentTools, so skip re-attachment
-        if (isBuiltinTool(toolName)) {
+        // Server auto-attaches some builtins (core memory, file search,
+        // open_files) when prerequisites are met, and they show up in
+        // listAgentTools inconsistently — skip re-attachment for those.
+        // Explicit builtins (web_search, fetch_webpage, run_code) require
+        // attachToolToAgent and must go through toAdd.
+        if (isImplicitBuiltin(toolName)) {
           unchanged.push({ name: toolName, id: toolId });
           continue;
         }

--- a/src/lib/tools/builtin-tools.ts
+++ b/src/lib/tools/builtin-tools.ts
@@ -99,6 +99,25 @@ export function isBuiltinTool(toolName: string): boolean {
 }
 
 /**
+ * Builtins the server auto-attaches when prerequisites are met (folders
+ * attached, persona block set). These show up in listAgentTools inconsistently,
+ * so the diff analyzer should treat them as `unchanged` rather than `toAdd`.
+ *
+ * Counterpart: BUILTIN_TOOLS (web_search, fetch_webpage, run_code) require
+ * explicit attach via attachToolToAgent and must go through the toAdd path.
+ * @see https://github.com/nouamanecodes/lettactl/issues/381
+ */
+const IMPLICIT_BUILTIN_TOOLS = new Set<string>([
+  ...CORE_MEMORY_TOOLS,
+  ...FILE_SEARCH_TOOLS,
+  'open_files',
+]);
+
+export function isImplicitBuiltin(toolName: string): boolean {
+  return IMPLICIT_BUILTIN_TOOLS.has(toolName);
+}
+
+/**
  * Get info about a built-in tool if it exists
  */
 export function getBuiltinToolInfo(toolName: string): BuiltinToolInfo | null {


### PR DESCRIPTION
Closes #381

## Summary
- diff-analyzers.ts pushed every `isBuiltinTool()` name into `unchanged` instead of `toAdd` when the agent didn't already have it. The comment claimed builtins are 'implicitly available' but only CORE_MEMORY_TOOLS / FILE_SEARCH_TOOLS / open_files are server-auto-attached. Explicit builtins like web_search, fetch_webpage, and run_code DO require attachToolToAgent.
- Added isImplicitBuiltin() helper in builtin-tools.ts that excludes the BUILTIN_TOOLS registry entries.
- diff-analyzers.ts now skips re-attachment only for implicit builtins; explicit ones go through the normal toAdd path.

## Test plan
- [x] Verified bug repros on Adspectre prod (5 agents missing web_search/fetch_webpage despite YAML + 'Registered 8 builtin tools' message)
- [x] Patched local dist apply on twidx → 'Tool [+]: web_search' shown, agent now has 24 tools, web_search confirmed via /v1/agents/<id>