### PR TITLE
fix: v0.21.7 update analyzeToolChanges test to reflect explicit-vs-implicit builtin split

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/tests/unit/lib/diff-engine.test.ts
+++ b/tests/unit/lib/diff-engine.test.ts
@@ -55,16 +55,19 @@ describe('DiffEngine', () => {
       expect(result.toUpdate).toEqual([]);
     });
 
-    it('treats missing builtin tools as unchanged', async () => {
+    it('skips re-attachment for implicit builtins but adds explicit builtins (see #381)', async () => {
       const result = await analyzeToolChanges(
         [],
         ['archival_memory_insert', 'web_search'],
         new Map([['archival_memory_insert', 'builtin-id-1'], ['web_search', 'builtin-id-2']])
       );
-      expect(result.toAdd).toEqual([]);
-      expect(result.unchanged).toEqual([
-        { name: 'archival_memory_insert', id: 'builtin-id-1' },
+      // archival_memory_insert is server-auto-attached → unchanged
+      // web_search is letta_builtin → requires explicit attachToolToAgent → toAdd
+      expect(result.toAdd).toEqual([
         { name: 'web_search', id: 'builtin-id-2' }
+      ]);
+      expect(result.unchanged).toEqual([
+        { name: 'archival_memory_insert', id: 'builtin-id-1' }
       ]);
     });
   });


### PR DESCRIPTION
Follow-up to #381 / PR #382.

The diff-engine.test.ts case `treats missing builtin tools as unchanged` was encoding the bug — asserting that web_search lands in `unchanged` instead of `toAdd`. With the fix in v0.21.6 that's no longer correct: archival_memory_insert (implicit, server-auto-attached) is `unchanged`, web_search (explicit letta_builtin, requires attach) is `toAdd`.

Test renamed and rewritten to match the new contract.