### PR TITLE
fix: v0.21.9 canary isolates shared folders so folder-file changes are canary-validatable (closes #386)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -24,7 +24,7 @@ import { buildMcpServerRegistry, expandMcpToolsForAgents } from '../../lib/tools
 import { buildAgentManifest, getDefaultManifestPath, writeAgentManifest } from '../../lib/apply/agent-manifest';
 import { ApplyOptions, DeployResult } from './types';
 import { batchProcess } from '../../lib/shared/batch';
-import { DEFAULT_CANARY_PREFIX, rewriteAgentNamesForCanary, cleanupCanaryAgents, buildCanaryMetadata } from '../../lib/apply/canary';
+import { DEFAULT_CANARY_PREFIX, rewriteAgentNamesForCanary, rewriteFolderNamesForCanary, cleanupCanaryAgents, buildCanaryMetadata } from '../../lib/apply/canary';
 import { bulkSendMessage } from '../../lib/messaging/bulk-messenger';
 import { waitForAgentIdle, defaultWaitLogger, RequiresApprovalError } from '../../lib/messaging/wait-for-idle';
 import { retryOn409 } from '../../lib/shared/retry';
@@ -152,9 +152,13 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
     }
 
     if (options.canary && !options.promote) {
-      // Canary deploy: prefix all agent names
+      // Canary deploy: prefix all agent names, and isolate folders so the canary
+      // gets fresh CANARY-<folder> copies with the desired files (fidelity) without
+      // mutating the shared production folders (isolation). Must run before folder
+      // resolution below.
       const { rewrittenAgents } = rewriteAgentNamesForCanary(config.agents, canaryPrefix);
       config.agents = rewrittenAgents;
+      rewriteFolderNamesForCanary(config, canaryPrefix);
       canaryMode = true;
       log(`Canary mode: deploying with prefix "${canaryPrefix}"`);
     }

--- a/src/lib/apply/canary.ts
+++ b/src/lib/apply/canary.ts
@@ -47,6 +47,33 @@ export function rewriteAgentNamesForCanary(
   return { rewrittenAgents, nameMap };
 }
 
+/**
+ * Isolate folders for a canary deploy by prefixing every folder name.
+ *
+ * Folders are shared across agents (one source object referenced by name). A
+ * canary that introduces a new folder file would otherwise either attach the
+ * production folder as-is (missing the new file — a fidelity gap) or mutate the
+ * shared production folder (leaking the change before promotion). Prefixing the
+ * names makes `processFolders` create fresh `CANARY-<folder>` copies with the
+ * desired file set; `cleanupCanaryAgents` deletes them on promote/cleanup.
+ *
+ * Must run AFTER the agent-name rewrite and BEFORE folder resolution (collect +
+ * processFolders). Promote does not call this, so it operates on real folders.
+ *
+ * Note: `open_files` resolves files by basename within attached folders, so the
+ * folder-name change is invisible to the agent's runtime.
+ */
+export function rewriteFolderNamesForCanary(config: any, prefix: string): void {
+  if (Array.isArray(config.shared_folders)) {
+    config.shared_folders = config.shared_folders.map((f: any) => ({ ...f, name: `${prefix}${f.name}` }));
+  }
+  for (const agent of config.agents || []) {
+    if (Array.isArray(agent.folders)) {
+      agent.folders = agent.folders.map((f: any) => ({ ...f, name: `${prefix}${f.name}` }));
+    }
+  }
+}
+
 export async function cleanupCanaryAgents(
   config: any,
   prefix: string,
@@ -88,6 +115,27 @@ export async function cleanupCanaryAgents(
     } catch (err: any) {
       failed.push(agent.name);
       warn(`Failed to delete canary ${agent.name}: ${err.message}`);
+    }
+  }
+
+  // Delete the isolated CANARY-<folder> copies created by rewriteFolderNamesForCanary.
+  // Skip when an --agent filter is active: canary folders are shared across the
+  // canary run, so a targeted cleanup must not yank a folder a sibling canary uses.
+  // A full cleanup (no --agent) sweeps them.
+  if (!options.agent) {
+    try {
+      const allFolders = await client.listFolders();
+      const canaryFolders = (allFolders || []).filter((f: any) => isCanaryName(f.name, prefix));
+      for (const f of canaryFolders) {
+        try {
+          await client.deleteFolder(f.id);
+          output(`Deleted canary folder: ${f.name}`);
+        } catch (err: any) {
+          warn(`Failed to delete canary folder ${f.name}: ${err.message}`);
+        }
+      }
+    } catch (err: any) {
+      warn(`Failed to list folders for canary cleanup: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
Canary deploys attached shared folders as-is, so a config that adds a folder file wasn't reflected on the canary (validated a canary missing the change; file only landed on promote).

Fix: `rewriteFolderNamesForCanary` prefixes folder names on canary deploy → `processFolders` creates isolated `CANARY-<folder>` copies with the desired files; `cleanupCanaryAgents` deletes them on promote/cleanup. Promote is unprefixed (real folders). `open_files` resolves by basename so the rename is invisible to the agent.

Verified live: canary built `CANARY-creative-guidance` (5 files incl. the new compose_video.md); production `creative-guidance` untouched.

closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)