### PR TITLE
feat: v1.0.1 default memfs tools clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,52 +101,47 @@ lettactl apply -f fleet.yml --dry-run    # Preview changes (drift detection)
 lettactl apply -f fleet.yml --agent one  # Deploy specific agent
 ```
 
-### Cloud MemFS Skills and Secrets
+### Letta Code Agents
 
-Provision Letta Code agent-owned skills and secrets for Cloud agents without committing secret values:
+Deploy Cloud agents that use git-backed MemFS, agent-owned skills, and Letta Code secrets:
 
 ```yaml
-global-secrets:
-  ADSPECTRE_API_BASE:
-    value: https://app.adspectre.ai
-
 agents:
-  - name: draper-cloud
-    description: "Cloud Draper agent"
+  - name: code-agent
     llm_config:
       model: "letta/glm"
       context_window: 32000
     system_prompt:
       value: "You are helpful."
+    include_base_tools: false
+    include_base_tool_rules: false
     memory:
       mode: memfs
       bare_repo: auto
-      template_dir: agents/draper/memfs
+      template_dir: agents/code-agent/memfs
       skills:
-        - name: dashboard-api
-          from_dir: agents/skills/dashboard-api
+        - name: app-api
+          from_dir: agents/skills/app-api
     secrets:
-      ADSPECTRE_AGENT_TOKEN:
-        from_env: ADSPECTRE_AGENT_TOKEN
+      APP_AGENT_TOKEN:
+        from_env: APP_AGENT_TOKEN
         preserve_existing: true
 ```
-
-`memory.template_dir` copies a full MemFS skeleton such as `system/*.md`.
-`memory.skills[].from_dir` copies a directory containing `SKILL.md` into
-`skills/<name>` in the agent's git-backed memory filesystem. This lets agents
-own executable skill instructions without registering Letta custom tools.
-
-`global-secrets` are attached to every agent. `agents[].secrets` are per-agent
-and override globals. Secret values are synced to Letta agent API state and
-redacted from output; YAML should generally use `from_env` for sensitive values.
-Use `preserve_existing: true` when a deploy should keep the remote secret value
-if the local environment variable is intentionally absent. Agent-scoped identity
-secrets such as `ADSPECTRE_AGENT_TOKEN` must be configured per-agent, not globally.
 
 ```bash
 lettactl apply -f fleet.yml --dry-run     # Shows MemFS and secret drift
 lettactl apply -f fleet.yml --root .      # Resolves template_dir/from_dir paths from repo root
 ```
+
+Use `memory.template_dir` for system MemFS files, `memory.skills[].from_dir` for
+directories containing `SKILL.md`, and `agents[].secrets` or `global-secrets` for
+Letta Code secret sync. See the full docs for schema details.
+
+MemFS agents default to `include_base_tools: false` and
+`include_base_tool_rules: false` so Letta Code skills start from a clean server
+tool allowlist. Classic block agents keep base tools enabled by default. Set
+`include_base_tools: true` and list tools explicitly when a MemFS agent should
+use server tools such as `conversation_search`.
 
 ### Inspection & Debugging ([full guide](https://lettactl.dev/commands/inspection))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -23,7 +23,7 @@ import * as nodePath from 'path';
 import { formatLettaError } from '../../lib/shared/error-handler';
 import { computeDryRunDiffs, displayDryRunResults } from '../../lib/apply/dry-run';
 import { log, warn, output, isQuietMode } from '../../lib/shared/logger';
-import { DEFAULT_AGENT_TOOLS, FILE_SEARCH_TOOLS } from '../../lib/tools/builtin-tools';
+import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules } from '../../lib/tools/builtin-tools';
 import { displayApplySummary } from '../../lib/ux/display';
 import { buildMcpServerRegistry, expandMcpToolsForAgents } from '../../lib/tools/mcp-tools';
 import { buildAgentManifest, getDefaultManifestPath, writeAgentManifest } from '../../lib/apply/agent-manifest';
@@ -253,16 +253,10 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
     await expandMcpToolsForAgents(config, client, mcpServerNameToId, verbose);
 
     // Generate tool source hashes and register tools
-    const allToolNames = new Set<string>(DEFAULT_AGENT_TOOLS);
+    const allToolNames = new Set<string>();
     for (const agent of config.agents) {
-      for (const toolName of agent.tools || []) {
+      for (const toolName of resolveAgentToolNames(agent)) {
         allToolNames.add(toolName);
-      }
-      // Include file search tools for agents with folders
-      if ((agent.folders || []).length > 0) {
-        for (const fileTool of FILE_SEARCH_TOOLS) {
-          allToolNames.add(fileTool);
-        }
       }
     }
     const globalToolSourceHashes = fileTracker.generateToolSourceHashes(Array.from(allToolNames), parser.toolConfigs);
@@ -330,33 +324,15 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
         const toolSourceHashes = fileTracker.generateToolSourceHashes(agent.tools || [], parser.toolConfigs);
         const memoryBlockFileHashes = await fileTracker.generateMemoryBlockFileHashes(agent.memory_blocks || []);
 
-        // Build agent config - auto-add default tools and file search tools
-        let tools = agent.tools || [];
-        const toolSet = new Set(tools);
-        for (const defaultTool of DEFAULT_AGENT_TOOLS) {
-          if (!toolSet.has(defaultTool)) {
-            tools = [...tools, defaultTool];
-          }
-        }
-        const hasFolders = (agent.folders || []).length > 0;
-
-        if (hasFolders) {
-          // Add file search tools if not already present
-          const toolSet = new Set(tools);
-          for (const fileTool of FILE_SEARCH_TOOLS) {
-            if (!toolSet.has(fileTool)) {
-              tools = [...tools, fileTool];
-            }
-          }
-        } else {
-          // Remove auto-added file search tools if no folders
-          tools = tools.filter((t: string) => !FILE_SEARCH_TOOLS.includes(t));
-        }
+        // Build agent config - resolve base tools and file search tools by mode.
+        const tools = resolveAgentToolNames(agent);
 
         const agentConfig = {
           systemPrompt: agent.system_prompt.value || '',
           description: agent.description || '',
           tools,
+          includeBaseTools: shouldIncludeBaseTools(agent),
+          includeBaseToolRules: shouldIncludeBaseToolRules(agent),
           toolSourceHashes,
           model: agent.llm_config?.model,
           embedding: agent.embedding,

--- a/src/commands/apply/template.ts
+++ b/src/commands/apply/template.ts
@@ -145,7 +145,7 @@ export async function applyTemplateMode(
         id: existingAgent.id,
         name: existingAgent.name,
         baseName: existingAgent.name,
-        configHashes: { overall: '', systemPrompt: '', tools: '', model: '', memoryBlocks: '', folders: '', sharedBlocks: '', archives: '', tags: '', lettabotConfig: '', compactionSettings: '', conversations: '' },
+        configHashes: { overall: '', systemPrompt: '', tools: '', baseTools: '', model: '', memoryBlocks: '', folders: '', sharedBlocks: '', archives: '', tags: '', lettabotConfig: '', compactionSettings: '', conversations: '' },
         version: 'latest',
         lastUpdated: existingAgent.updated_at || new Date().toISOString()
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,8 @@ Example:
 
   agents:
     - name: agent-migrate
+      include_base_tools: false        # default for memory.mode: memfs
+      include_base_tool_rules: false   # default for memory.mode: memfs
       memory:
         mode: memfs
         bare_repo: auto
@@ -172,6 +174,8 @@ Example:
 
 Notes:
   - skill directories must be repo-relative and include SKILL.md
+  - memory.mode: memfs defaults to include_base_tools: false
+  - classic/block agents default to include_base_tools: true
   - secret values are redacted from output
   - agent-scoped identity secrets should be declared under agents[].secrets
 `)

--- a/src/lib/apply/agent-manifest.ts
+++ b/src/lib/apply/agent-manifest.ts
@@ -5,7 +5,7 @@ import type { FleetConfig, AgentConfig } from '../../types/fleet-config';
 import { BlockManager } from '../managers/block-manager';
 import { ArchiveManager } from '../managers/archive-manager';
 import { AgentManager } from '../managers/agent-manager';
-import { DEFAULT_AGENT_TOOLS, FILE_SEARCH_TOOLS } from '../tools/builtin-tools';
+import { resolveAgentToolNames } from '../tools/builtin-tools';
 
 export interface ManifestItem {
   name: string;
@@ -61,24 +61,7 @@ function sortByName<T extends { name: string }>(items: T[]): T[] {
 }
 
 function resolveAgentTools(agent: AgentConfig): string[] {
-  let tools = agent.tools ? [...agent.tools] : [];
-
-  // Always add default tools
-  for (const tool of DEFAULT_AGENT_TOOLS) {
-    tools.push(tool);
-  }
-
-  // Add/remove file search tools based on folder presence
-  const hasFolders = (agent.folders || []).length > 0;
-  if (hasFolders) {
-    for (const tool of FILE_SEARCH_TOOLS) {
-      tools.push(tool);
-    }
-  } else {
-    tools = tools.filter((tool) => !FILE_SEARCH_TOOLS.includes(tool));
-  }
-
-  return Array.from(new Set(tools)).sort((a, b) => a.localeCompare(b));
+  return resolveAgentToolNames(agent).sort((a, b) => a.localeCompare(b));
 }
 
 function addResource<T extends ManifestItem>(

--- a/src/lib/apply/apply-helpers.ts
+++ b/src/lib/apply/apply-helpers.ts
@@ -18,6 +18,7 @@ import { log, error } from '../shared/logger';
 import { DEFAULT_CONTEXT_WINDOW, DEFAULT_MODEL, DEFAULT_EMBEDDING, DEFAULT_REASONING } from '../shared/constants';
 import { isRunTerminal, getEffectiveRunStatus } from '../messaging/run-utils';
 import { Run } from '../../types/run';
+import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules } from '../tools/builtin-tools';
 
 /**
  * Collects all resource names declared in the fleet config.
@@ -429,6 +430,8 @@ export async function createNewAgent(
       system: agent.system_prompt.value || '',
       block_ids: blockIds,
       tool_ids: toolIds,
+      include_base_tools: shouldIncludeBaseTools(agent),
+      include_base_tool_rules: shouldIncludeBaseToolRules(agent),
       context_window_limit: agent.llm_config?.context_window || DEFAULT_CONTEXT_WINDOW,
       reasoning: agent.reasoning ?? DEFAULT_REASONING,
       ...(agent.llm_config?.max_tokens !== undefined && { max_tokens: agent.llm_config.max_tokens }),
@@ -460,7 +463,9 @@ export async function createNewAgent(
     // Update registry
     agentManager.updateRegistry(agentName, {
       systemPrompt: agent.system_prompt.value || '',
-      tools: agent.tools || [],
+      tools: resolveAgentToolNames(agent),
+      includeBaseTools: shouldIncludeBaseTools(agent),
+      includeBaseToolRules: shouldIncludeBaseToolRules(agent),
       model: agent.llm_config?.model,
       embedding: agent.embedding,
       embeddingConfig: agent.embedding_config,
@@ -499,6 +504,8 @@ export async function createNewAgent(
     // Store raw model/embedding strings for provider change detection (#255)
     metadata['lettactl.model'] = agent.llm_config?.model || 'google_ai/gemini-2.5-pro';
     metadata['lettactl.embedding'] = agent.embedding || 'openai/text-embedding-3-small';
+    metadata['lettactl.includeBaseTools'] = shouldIncludeBaseTools(agent);
+    metadata['lettactl.includeBaseToolRules'] = shouldIncludeBaseToolRules(agent);
     if (folderContentHashes && folderContentHashes.size > 0) {
       const newFolderFileHashes: Record<string, Record<string, string>> = {};
       for (const [folderName, hashes] of folderContentHashes) {

--- a/src/lib/apply/diff-analyzers.ts
+++ b/src/lib/apply/diff-analyzers.ts
@@ -41,7 +41,8 @@ export async function analyzeToolChanges(
   desiredToolNames: string[],
   toolRegistry: Map<string, string>,
   _toolSourceHashes?: Record<string, string>,
-  updatedTools?: Set<string>
+  updatedTools?: Set<string>,
+  protectMemoryTools: boolean = true
 ): Promise<ToolDiff> {
   const currentToolNames = new Set(currentTools.map(t => t.name));
   const desiredToolSet = new Set(desiredToolNames);
@@ -90,7 +91,7 @@ export async function analyzeToolChanges(
     } else {
       // Never remove protected memory tools - they're critical for agent operation
       // See: https://github.com/nouamanecodes/lettactl/issues/130
-      if (PROTECTED_MEMORY_TOOLS.has(tool.name)) {
+      if (protectMemoryTools && PROTECTED_MEMORY_TOOLS.has(tool.name)) {
         unchanged.push({ name: tool.name, id: tool.id });
       } else {
         toRemove.push({ name: tool.name, id: tool.id });

--- a/src/lib/apply/diff-applier.ts
+++ b/src/lib/apply/diff-applier.ts
@@ -75,6 +75,12 @@ export class DiffApplier {
       if (fields.reasoning !== undefined) {
         apiFields.reasoning = fields.reasoning.to;
       }
+      if (fields.includeBaseTools !== undefined) {
+        apiFields.include_base_tools = fields.includeBaseTools.to;
+      }
+      if (fields.includeBaseToolRules !== undefined) {
+        apiFields.include_base_tool_rules = fields.includeBaseToolRules.to;
+      }
       if (fields.tags !== undefined) {
         // Preserve memfs-owned tag if currently set — the memfs reconciler is its sole owner,
         // operators never write it in YAML, and a bare PATCH would silently strip it (rolling
@@ -87,7 +93,7 @@ export class DiffApplier {
       await this.client.updateAgent(agentId, apiFields);
 
       // Update metadata for fields that need raw value tracking
-      const needsMetadataUpdate = fields.model !== undefined || fields.embedding !== undefined || fields.lettabotConfig !== undefined;
+      const needsMetadataUpdate = fields.model !== undefined || fields.embedding !== undefined || fields.lettabotConfig !== undefined || fields.includeBaseTools !== undefined || fields.includeBaseToolRules !== undefined;
       if (needsMetadataUpdate) {
         const agent = await this.client.getAgent(agentId);
         const metadata = { ...(agent as any).metadata };
@@ -103,6 +109,12 @@ export class DiffApplier {
           } else {
             delete metadata['lettactl.lettabotConfig'];
           }
+        }
+        if (fields.includeBaseTools !== undefined) {
+          metadata['lettactl.includeBaseTools'] = fields.includeBaseTools.to;
+        }
+        if (fields.includeBaseToolRules !== undefined) {
+          metadata['lettactl.includeBaseToolRules'] = fields.includeBaseToolRules.to;
         }
         await this.client.updateAgent(agentId, { metadata });
       }

--- a/src/lib/apply/diff-engine.ts
+++ b/src/lib/apply/diff-engine.ts
@@ -39,6 +39,8 @@ export class DiffEngine {
       systemPrompt: string;
       description?: string;
       tools: string[];
+      includeBaseTools?: boolean;
+      includeBaseToolRules?: boolean;
       toolSourceHashes?: Record<string, string>;
       model?: string;
       embedding?: string;
@@ -209,6 +211,18 @@ export class DiffEngine {
       operations.operationCount++;
     }
 
+    const currentIncludeBaseTools = (currentAgent as any).metadata?.['lettactl.includeBaseTools'];
+    if (currentIncludeBaseTools !== desiredConfig.includeBaseTools) {
+      fieldUpdates.includeBaseTools = { from: currentIncludeBaseTools, to: desiredConfig.includeBaseTools };
+      operations.operationCount++;
+    }
+
+    const currentIncludeBaseToolRules = (currentAgent as any).metadata?.['lettactl.includeBaseToolRules'];
+    if (currentIncludeBaseToolRules !== desiredConfig.includeBaseToolRules) {
+      fieldUpdates.includeBaseToolRules = { from: currentIncludeBaseToolRules, to: desiredConfig.includeBaseToolRules };
+      operations.operationCount++;
+    }
+
     // Exclude memfs-owned tag from the general diff — the memfs reconciler is the
     // sole owner of `git-memory-enabled` (adds on migrate, removes on rollback).
     // Otherwise every re-apply against a memfs-mode agent would silently flag it
@@ -239,7 +253,8 @@ export class DiffEngine {
       desiredConfig.tools || [],
       toolRegistry,
       desiredConfig.toolSourceHashes || {},
-      updatedTools
+      updatedTools,
+      desiredConfig.includeBaseTools !== false
     );
     operations.operationCount += operations.tools.toAdd.length + operations.tools.toRemove.length + operations.tools.toUpdate.length;
 

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -23,6 +23,7 @@ import {
   type SecretApplyResult,
   type SecretPlan,
 } from '../secrets-reconciler';
+import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules } from '../tools/builtin-tools';
 
 export interface DryRunResult {
   name: string;
@@ -207,7 +208,9 @@ async function computeAgentDiff(
   const agentConfig = {
     systemPrompt: agent.system_prompt?.value || '',
     description: agent.description || '',
-    tools: agent.tools || [],
+    tools: resolveAgentToolNames(agent),
+    includeBaseTools: shouldIncludeBaseTools(agent),
+    includeBaseToolRules: shouldIncludeBaseToolRules(agent),
     toolSourceHashes,
     model: agent.llm_config?.model,
     embedding: agent.embedding,

--- a/src/lib/managers/agent-manager.ts
+++ b/src/lib/managers/agent-manager.ts
@@ -45,6 +45,7 @@ export class AgentManager {
           overall: '',              // Will be populated during comparison
           systemPrompt: generateContentHash(agent.system || ''),
           tools: '',
+          baseTools: '',
           model: '',
           memoryBlocks: '',
           folders: '',
@@ -81,6 +82,8 @@ export class AgentManager {
   private generateAgentConfigHashes(config: {
     systemPrompt: string;
     tools: string[];
+    includeBaseTools?: boolean;
+    includeBaseToolRules?: boolean;
     toolSourceHashes?: Record<string, string>;
     model?: string;
     embedding?: string;
@@ -107,6 +110,11 @@ export class AgentManager {
       sourceHash: config.toolSourceHashes?.[toolName] || ''
     })).sort((a, b) => a.name.localeCompare(b.name));
     const toolsHash = generateContentHash(JSON.stringify(toolsWithContent));
+
+    const baseToolsHash = generateContentHash(JSON.stringify({
+      includeBaseTools: config.includeBaseTools ?? null,
+      includeBaseToolRules: config.includeBaseToolRules ?? null
+    }));
     
     // Model configuration hash (model + embedding + context window)
     const modelConfig = {
@@ -173,6 +181,7 @@ export class AgentManager {
     const overallHash = generateContentHash(JSON.stringify({
       systemPrompt: systemPromptHash,
       tools: toolsHash,
+      baseTools: baseToolsHash,
       model: modelHash,
       memoryBlocks: memoryBlocksHash,
       folders: foldersHash,
@@ -188,6 +197,7 @@ export class AgentManager {
       overall: overallHash,
       systemPrompt: systemPromptHash,
       tools: toolsHash,
+      baseTools: baseToolsHash,
       model: modelHash,
       memoryBlocks: memoryBlocksHash,
       folders: foldersHash,
@@ -208,6 +218,8 @@ export class AgentManager {
     agentConfig: {
       systemPrompt: string;
       tools: string[];
+      includeBaseTools?: boolean;
+      includeBaseToolRules?: boolean;
       toolSourceHashes?: Record<string, string>;
       model?: string;
       embedding?: string;
@@ -257,6 +269,8 @@ export class AgentManager {
   getConfigChanges(existing: AgentVersion, newConfig: {
     systemPrompt: string;
     tools: string[];
+    includeBaseTools?: boolean;
+    includeBaseToolRules?: boolean;
     toolSourceHashes?: Record<string, string>;
     model?: string;
     embedding?: string;
@@ -286,6 +300,9 @@ export class AgentManager {
     }
     if (existing.configHashes.tools !== newHashes.tools) {
       changedComponents.push('tools');
+    }
+    if (existing.configHashes.baseTools !== newHashes.baseTools) {
+      changedComponents.push('baseTools');
     }
     if (existing.configHashes.model !== newHashes.model) {
       changedComponents.push('model');
@@ -328,6 +345,8 @@ export class AgentManager {
   updateRegistry(agentName: string, agentConfig: {
     systemPrompt: string;
     tools: string[];
+    includeBaseTools?: boolean;
+    includeBaseToolRules?: boolean;
     model?: string;
     embedding?: string;
     embeddingConfig?: Record<string, any>;

--- a/src/lib/tools/builtin-tools.ts
+++ b/src/lib/tools/builtin-tools.ts
@@ -80,6 +80,60 @@ export const DEFAULT_AGENT_TOOLS = ['conversation_search'];
  */
 export const FILE_SEARCH_TOOLS = ['grep_files', 'semantic_search_files'];
 
+export function shouldIncludeBaseTools(agent: {
+  include_base_tools?: boolean;
+  memory?: { mode?: string };
+}): boolean {
+  if (typeof agent.include_base_tools === 'boolean') {
+    return agent.include_base_tools;
+  }
+  return agent.memory?.mode !== 'memfs';
+}
+
+export function shouldIncludeBaseToolRules(agent: {
+  include_base_tool_rules?: boolean;
+  memory?: { mode?: string };
+}): boolean {
+  if (typeof agent.include_base_tool_rules === 'boolean') {
+    return agent.include_base_tool_rules;
+  }
+  return agent.memory?.mode !== 'memfs';
+}
+
+export function resolveAgentToolNames(agent: {
+  tools?: string[];
+  folders?: unknown[];
+  include_base_tools?: boolean;
+  memory?: { mode?: string };
+}): string[] {
+  let tools = agent.tools ? [...agent.tools] : [];
+
+  if (shouldIncludeBaseTools(agent)) {
+    const toolSet = new Set(tools);
+    for (const defaultTool of DEFAULT_AGENT_TOOLS) {
+      if (!toolSet.has(defaultTool)) {
+        tools = [...tools, defaultTool];
+        toolSet.add(defaultTool);
+      }
+    }
+  }
+
+  const hasFolders = (agent.folders || []).length > 0;
+  if (hasFolders) {
+    const toolSet = new Set(tools);
+    for (const fileTool of FILE_SEARCH_TOOLS) {
+      if (!toolSet.has(fileTool)) {
+        tools = [...tools, fileTool];
+        toolSet.add(fileTool);
+      }
+    }
+  } else {
+    tools = tools.filter((tool) => !FILE_SEARCH_TOOLS.includes(tool));
+  }
+
+  return Array.from(new Set(tools));
+}
+
 /**
  * Aggregated set of all builtin tool names for fast lookup
  * Add new builtin tools here

--- a/src/lib/validation/config-validators.ts
+++ b/src/lib/validation/config-validators.ts
@@ -131,6 +131,14 @@ export class AgentValidator {
       ToolsValidator.validate(agent.tools);
     }
 
+    if (agent.include_base_tools !== undefined && typeof agent.include_base_tools !== 'boolean') {
+      throw new Error('include_base_tools must be a boolean.');
+    }
+
+    if (agent.include_base_tool_rules !== undefined && typeof agent.include_base_tool_rules !== 'boolean') {
+      throw new Error('include_base_tool_rules must be a boolean.');
+    }
+
     if (agent.mcp_tools) {
       McpToolsValidator.validate(agent.mcp_tools);
     }
@@ -230,7 +238,7 @@ export class AgentValidator {
   private static validateUnknownFields(agent: any): void {
     const allowedFields = [
       'name', 'description', 'system_prompt', 'llm_config',
-      'tools', 'mcp_tools', 'memory_blocks', 'archives', 'folders',
+      'tools', 'include_base_tools', 'include_base_tool_rules', 'mcp_tools', 'memory_blocks', 'archives', 'folders',
       'embedding', 'embedding_config', 'shared_blocks', 'shared_folders',
       'first_message', 'reasoning', 'tags', 'lettabot', 'conversations',
       'compaction_settings', 'memory', 'secrets'

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -2,6 +2,7 @@ export interface AgentConfigHashes {
   overall: string;           // Combined hash for quick comparison
   systemPrompt: string;      // System prompt hash
   tools: string;             // Tools configuration hash
+  baseTools: string;         // include_base_tools / include_base_tool_rules hash
   model: string;             // Model + embedding + context window hash
   memoryBlocks: string;      // Memory blocks hash
   folders: string;           // Folders hash

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -55,6 +55,8 @@ export interface AgentUpdateOperations {
     contextWindow?: FieldChange<number>;
     maxTokens?: FieldChange<number>;
     reasoning?: FieldChange<boolean>;
+    includeBaseTools?: FieldChange<boolean>;
+    includeBaseToolRules?: FieldChange<boolean>;
     tags?: FieldChange<string[]>;
     lettabotConfig?: FieldChange<Record<string, any> | null>;
   };

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -41,6 +41,8 @@ export interface AgentConfig {
   system_prompt: PromptConfig;
   llm_config: LLMConfig;
   tools?: string[];
+  include_base_tools?: boolean; // Default: false for memory.mode=memfs, true otherwise.
+  include_base_tool_rules?: boolean; // Passed to Letta on create/update when supported.
   mcp_tools?: McpToolConfig[];
   shared_blocks?: string[];
   memory_blocks?: MemoryBlock[];


### PR DESCRIPTION
## Summary
- default MemFS agents to a clean base-tool policy
- add include_base_tools and include_base_tool_rules to fleet YAML
- preserve classic/block agent default base tools
- document the MemFS default in README and help

## Verification
- pnpm run build
- pnpm test
- pnpm audit
- dist/index.js --version => 1.0.1
- created disposable MemFS smoke agent with dist; raw API had tools: [] and includeBaseTools false

Closes #394