### PR TITLE
feat: v1.0.3 add memfs file entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ agents:
       mode: memfs
       bare_repo: auto
       template_dir: agents/code-agent/memfs
+      preserve_existing_paths:
+        - system/persona.md
+        - system/state.md
+      files:
+        - to: system/important_variables.md
+          value: |
+            # Important Variables
+            - COMPANY_ID: company-123
       skills:
         - name: app-api
           from_dir: agents/skills/app-api
@@ -135,7 +143,10 @@ lettactl apply -f fleet.yml --root .      # Resolves template_dir/from_dir paths
 
 Use `memory.template_dir` for system MemFS files, `memory.skills[].from_dir` for
 directories containing `SKILL.md`, and `agents[].secrets` or `global-secrets` for
-Letta Code secret sync. See the full docs for schema details.
+Letta Code secret sync. Add `memory.preserve_existing_paths` for mutable files
+that should be seeded on first deploy but preserved after the agent edits them.
+Use `memory.files[]` for explicit inline or `from_file` content, especially
+per-agent dynamic system files. See the full docs for schema details.
 
 MemFS agents default to `include_base_tools: false` and
 `include_base_tool_rules: false` so Letta Code skills start from a clean server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,8 @@ program
 MemFS skills and secrets:
   memory.mode: memfs              Sync agent state to the git-backed memory filesystem
   memory.template_dir             Copy a full MemFS template directory
+  memory.preserve_existing_paths  Seed listed paths, then preserve remote edits
+  memory.files[]                  Write explicit inline/from_file content to a MemFS path
   memory.skills[].from_dir        Copy a skill directory containing SKILL.md into skills/<name>
   global-secrets                  Sync secret values to every agent
   agents[].secrets                Sync per-agent secrets; overrides globals
@@ -164,6 +166,12 @@ Example:
         mode: memfs
         bare_repo: auto
         template_dir: migration-artifacts/agent-migrate/memfs
+        preserve_existing_paths:
+          - system/persona.md
+          - system/important_variables.md
+        files:
+          - to: system/important_variables.md
+            value: "# Important Variables\\n- COMPANY_ID: ..."
         skills:
           - name: media-generation
             from_dir: migration-artifacts/agent-migrate/memfs/skills/media-generation

--- a/src/lib/memfs-reconciler/plan.ts
+++ b/src/lib/memfs-reconciler/plan.ts
@@ -114,11 +114,17 @@ export function computeMemfsAction(
     };
   }
 
-  // Tag already set — diff targetFiles vs bareRepoFiles
+  // Tag already set — diff targetFiles vs bareRepoFiles. Paths listed in
+  // preserve_existing_paths are seed-only after their first remote write:
+  // if the file exists in the bare repo, do not overwrite agent-owned edits.
   const changedFiles = new Map<string, string>();
+  const preserveExistingPaths = new Set(memory.preserve_existing_paths ?? []);
   for (const [filePath, content] of targetFiles) {
-    const desiredSha = gitBlobSha(content);
     const currentSha = server.bareRepoFiles.get(filePath);
+    if (preserveExistingPaths.has(filePath) && currentSha) {
+      continue;
+    }
+    const desiredSha = gitBlobSha(content);
     if (desiredSha !== currentSha) {
       changedFiles.set(filePath, content);
     }
@@ -149,8 +155,9 @@ export function computeMemfsAction(
  *      excluding dotfiles (except .gitkeep/.keep), symlinks, and the root-level README.md.
  *      Hand-authored files like `system/identity.md` or `persona/learned-preferences.md`
  *      ship via this path without needing a `from_blocks` entry.
- *   3. `skills` — copies skill directories to `skills/<skill-name>/...`.
- *   4. `from_blocks` — last so it ALWAYS wins on collision. The YAML's explicit directive
+ *   3. `files` — explicit inline or from_file entries for dynamic per-agent content.
+ *   4. `skills` — copies skill directories to `skills/<skill-name>/...`.
+ *   5. `from_blocks` — last so it ALWAYS wins on collision. The YAML's explicit directive
  *      to derive a memfs file from a live block trumps any template skeleton at the same path.
  */
 export function buildTargetFiles(
@@ -189,6 +196,23 @@ export function buildTargetFiles(
     }
     for (const [filePath, content] of walkTemplateDir(absDir)) {
       out.set(filePath, content);
+    }
+  }
+
+  if (memory.files) {
+    for (const entry of memory.files) {
+      if (entry.value !== undefined) {
+        out.set(entry.to, renderTemplateVars(entry.value, entry.template_vars ?? {}));
+        continue;
+      }
+      const absFile = path.resolve(rootPath, entry.from_file!);
+      if (!fs.existsSync(absFile)) {
+        throw new Error(
+          `[memfs-plan] Agent ${agentName}: memory.files from_file does not exist at ${absFile}. ` +
+            `Check memory.files[].from_file in YAML (resolved against root_path).`,
+        );
+      }
+      out.set(entry.to, renderTemplateVars(fs.readFileSync(absFile, 'utf8'), entry.template_vars ?? {}));
     }
   }
 
@@ -355,4 +379,12 @@ export function gitBlobSha(content: string): string {
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function renderTemplateVars(content: string, vars: Record<string, string>): string {
+  let rendered = content;
+  for (const [key, value] of Object.entries(vars)) {
+    rendered = rendered.replace(new RegExp(`{{${escapeRegExp(key)}}}`, 'g'), value);
+  }
+  return rendered;
 }

--- a/src/lib/validation/config-validators.ts
+++ b/src/lib/validation/config-validators.ts
@@ -1048,6 +1048,88 @@ export class AgentMemoryConfigValidator {
       throw new Error('memory.template_dir must be a string (path relative to root_path).');
     }
 
+    if (memory.preserve_existing_paths !== undefined) {
+      if (!Array.isArray(memory.preserve_existing_paths)) {
+        throw new Error('memory.preserve_existing_paths must be an array of memfs paths.');
+      }
+      const seenPreservedPaths = new Set<string>();
+      memory.preserve_existing_paths.forEach((entry: any, i: number) => {
+        if (typeof entry !== 'string' || entry.length === 0) {
+          throw new Error(`memory.preserve_existing_paths[${i}] must be a non-empty string.`);
+        }
+        if (entry.startsWith('/') || entry.includes('..')) {
+          throw new Error(
+            `memory.preserve_existing_paths[${i}] must be a repo-relative path. ` +
+            `Got "${entry}" — no leading slash, no "..".`
+          );
+        }
+        if (seenPreservedPaths.has(entry)) {
+          throw new Error(`memory.preserve_existing_paths: duplicate path "${entry}".`);
+        }
+        seenPreservedPaths.add(entry);
+      });
+    }
+
+    if (memory.files !== undefined) {
+      if (!Array.isArray(memory.files)) {
+        throw new Error('memory.files must be an array.');
+      }
+      const seenFileTargets = new Set<string>();
+      memory.files.forEach((entry: any, i: number) => {
+        if (!entry || typeof entry !== 'object') {
+          throw new Error(`memory.files[${i}] must be an object.`);
+        }
+        if (typeof entry.to !== 'string' || entry.to.length === 0) {
+          throw new Error(`memory.files[${i}].to must be a non-empty string (memfs target path).`);
+        }
+        if (entry.to.startsWith('/') || entry.to.includes('..')) {
+          throw new Error(
+            `memory.files[${i}].to must be a repo-relative path. ` +
+            `Got "${entry.to}" — no leading slash, no "..".`
+          );
+        }
+        if (!entry.to.endsWith('.md')) {
+          throw new Error(`memory.files[${i}].to must end in ".md" (got "${entry.to}").`);
+        }
+        const hasValue = entry.value !== undefined;
+        const hasFromFile = entry.from_file !== undefined;
+        if (hasValue === hasFromFile) {
+          throw new Error(`memory.files[${i}] must set exactly one of value or from_file.`);
+        }
+        if (hasValue && typeof entry.value !== 'string') {
+          throw new Error(`memory.files[${i}].value must be a string.`);
+        }
+        if (hasFromFile) {
+          if (typeof entry.from_file !== 'string' || entry.from_file.length === 0) {
+            throw new Error(`memory.files[${i}].from_file must be a non-empty string.`);
+          }
+          if (entry.from_file.startsWith('/') || entry.from_file.includes('..')) {
+            throw new Error(
+              `memory.files[${i}].from_file must be a repo-relative path. ` +
+              `Got "${entry.from_file}" — no leading slash, no "..".`
+            );
+          }
+        }
+        if (entry.template_vars !== undefined) {
+          if (!entry.template_vars || typeof entry.template_vars !== 'object' || Array.isArray(entry.template_vars)) {
+            throw new Error(`memory.files[${i}].template_vars must be an object if set.`);
+          }
+          for (const [key, value] of Object.entries(entry.template_vars)) {
+            if (!/^[A-Z0-9_]+$/.test(key)) {
+              throw new Error(`memory.files[${i}].template_vars key "${key}" must use uppercase letters, numbers, and underscores.`);
+            }
+            if (typeof value !== 'string') {
+              throw new Error(`memory.files[${i}].template_vars.${key} must be a string.`);
+            }
+          }
+        }
+        if (seenFileTargets.has(entry.to)) {
+          throw new Error(`memory.files: duplicate target path "${entry.to}".`);
+        }
+        seenFileTargets.add(entry.to);
+      });
+    }
+
     if (memory.capability_index_file !== undefined && typeof memory.capability_index_file !== 'string') {
       throw new Error('memory.capability_index_file must be a string path.');
     }
@@ -1092,9 +1174,10 @@ export class AgentMemoryConfigValidator {
       const hasFromBlocks = Array.isArray(memory.from_blocks) && memory.from_blocks.length > 0;
       const hasTemplateDir = typeof memory.template_dir === 'string' && memory.template_dir.length > 0;
       const hasSkills = Array.isArray(memory.skills) && memory.skills.length > 0;
-      if (!hasFromBlocks && !hasTemplateDir && !hasSkills) {
+      const hasFiles = Array.isArray(memory.files) && memory.files.length > 0;
+      if (!hasFromBlocks && !hasTemplateDir && !hasSkills && !hasFiles) {
         throw new Error(
-          'memory.mode is "memfs" but none of from_blocks (non-empty array), template_dir, or skills is set. ' +
+          'memory.mode is "memfs" but none of from_blocks (non-empty array), template_dir, files, or skills is set. ' +
           'At least one is required so lettactl knows what to push to the bare repo.'
         );
       }

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -72,6 +72,13 @@ export interface AgentMemoryConfig {
   mode: 'blocks' | 'memfs';
   bare_repo?: 'auto';                        // 'auto' = resolve via Letta /v1/git/<id>/state.git
   template_dir?: string;                     // dir of skeleton .md files; relative to root_path
+  preserve_existing_paths?: string[];        // memfs paths to seed but not overwrite once present
+  files?: Array<{
+    to: string;                              // memfs target path
+    value?: string;                          // inline content
+    from_file?: string;                      // repo-relative source file
+    template_vars?: Record<string, string>;  // optional {{VAR}} replacements
+  }>;
   skills?: Array<{
     name?: string;                           // defaults to basename(from_dir)
     from_dir: string;                        // skill dir containing SKILL.md; relative to root_path

--- a/tests/unit/lib/config-validators.test.ts
+++ b/tests/unit/lib/config-validators.test.ts
@@ -382,12 +382,34 @@ describe('AgentMemoryConfigValidator', () => {
     })).not.toThrow();
   });
 
+  it('accepts preserve_existing_paths for memfs mode', () => {
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      template_dir: 'lib/fleet/memfs-templates/draper/',
+      preserve_existing_paths: [
+        'system/persona.md',
+        'system/important_variables.md',
+        'system/generation_state.md',
+      ],
+    })).not.toThrow();
+  });
+
   it('accepts a memfs-mode config with only skills', () => {
     expect(() => AgentMemoryConfigValidator.validate({
       mode: 'memfs',
       skills: [
         { from_dir: 'agents/skills/media-generation' },
         { name: 'reference-handling', from_dir: 'agents/skills/reference' },
+      ],
+    })).not.toThrow();
+  });
+
+  it('accepts a memfs-mode config with only files', () => {
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [
+        { to: 'system/important_variables.md', value: '# Important Variables' },
+        { to: 'system/persona.md', from_file: 'agents/draper/persona.md' },
       ],
     })).not.toThrow();
   });
@@ -426,6 +448,66 @@ describe('AgentMemoryConfigValidator', () => {
         { name: 'media-generation', from_dir: 'agents/skills/media-generation-copy' },
       ],
     })).toThrow('duplicate skill name');
+  });
+
+  it('rejects invalid preserve_existing_paths configs', () => {
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      template_dir: 'templates',
+      preserve_existing_paths: 'system/persona.md' as any,
+    })).toThrow('memory.preserve_existing_paths must be an array');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      template_dir: 'templates',
+      preserve_existing_paths: ['/system/persona.md'],
+    })).toThrow('repo-relative path');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      template_dir: 'templates',
+      preserve_existing_paths: ['system/persona.md', 'system/persona.md'],
+    })).toThrow('duplicate path');
+  });
+
+  it('rejects invalid memory.files configs', () => {
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: 'system/persona.md' as any,
+    })).toThrow('memory.files must be an array');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: '/system/persona.md', value: 'x' }],
+    })).toThrow('repo-relative path');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: 'system/persona.txt', value: 'x' }],
+    })).toThrow('must end in ".md"');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: 'system/persona.md', value: 'x', from_file: 'persona.md' }],
+    })).toThrow('exactly one of value or from_file');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: 'system/persona.md' }],
+    })).toThrow('exactly one of value or from_file');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: 'system/persona.md', from_file: '../persona.md' }],
+    })).toThrow('repo-relative path');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [
+        { to: 'system/persona.md', value: 'x' },
+        { to: 'system/persona.md', value: 'y' },
+      ],
+    })).toThrow('duplicate target path');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: 'system/persona.md', from_file: 'persona.md', template_vars: { 'bad-key': 'x' } }],
+    })).toThrow('uppercase letters');
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      files: [{ to: 'system/persona.md', from_file: 'persona.md', template_vars: { GOOD_KEY: 123 } }],
+    })).toThrow('must be a string');
   });
 
   it('rejects bare_repo value other than "auto"', () => {

--- a/tests/unit/lib/memfs-reconciler/plan.test.ts
+++ b/tests/unit/lib/memfs-reconciler/plan.test.ts
@@ -152,6 +152,74 @@ describe('computeMemfsAction', () => {
     }
   });
 
+  it('does not overwrite preserved paths that already exist in the bare repo', () => {
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        preserve_existing_paths: ['system/persona.md'],
+        from_blocks: [
+          { block: 'persona', to: 'system/persona.md' },
+          { block: 'routing', to: 'system/routing.md' },
+        ],
+      }),
+      mkServer({
+        tags: [GIT_MEMORY_ENABLED_TAG],
+        blocks: [
+          mkBlock('persona', 'TEMPLATE persona'),
+          mkBlock('routing', 'NEW routing'),
+        ],
+        files: {
+          'system/persona.md': gitBlobSha('AGENT EDITED persona'),
+          'system/routing.md': gitBlobSha('OLD routing'),
+        },
+      }),
+      '/tmp',
+    );
+    expect(action.kind).toBe('sync-files-only');
+    if (action.kind === 'sync-files-only') {
+      expect(action.changedFiles.has('system/persona.md')).toBe(false);
+      expect(action.changedFiles.get('system/routing.md')).toBe('NEW routing');
+    }
+  });
+
+  it('seeds preserved paths that do not exist in the bare repo yet', () => {
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        preserve_existing_paths: ['system/persona.md'],
+        from_blocks: [{ block: 'persona', to: 'system/persona.md' }],
+      }),
+      mkServer({
+        tags: [GIT_MEMORY_ENABLED_TAG],
+        blocks: [mkBlock('persona', 'TEMPLATE persona')],
+        files: {},
+      }),
+      '/tmp',
+    );
+    expect(action.kind).toBe('sync-files-only');
+    if (action.kind === 'sync-files-only') {
+      expect(action.changedFiles.get('system/persona.md')).toBe('TEMPLATE persona');
+    }
+  });
+
+  it('adds inline memory.files entries to target files', () => {
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        files: [{ to: 'system/important_variables.md', value: '# Important\n\nCOMPANY_ID=123\n' }],
+      }),
+      mkServer(),
+      '/tmp',
+    );
+    expect(action.kind).toBe('migrate-forward');
+    if (action.kind === 'migrate-forward') {
+      expect(action.targetFiles.get('system/important_variables.md')).toBe('# Important\n\nCOMPANY_ID=123\n');
+    }
+  });
+
   it('throws when a referenced block does not exist on the server', () => {
     expect(() =>
       computeMemfsAction(
@@ -336,6 +404,96 @@ describe('template_dir scan', () => {
     if (action.kind === 'migrate-forward') {
       expect(action.targetFiles.get('system/persona.md')).toBe('FROM_BLOCK');
     }
+  });
+
+  it('memory.files overwrites template_dir on path collision', () => {
+    writeFile('system/important_variables.md', 'TEMPLATE');
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        template_dir: 'templates',
+        files: [{ to: 'system/important_variables.md', value: 'INLINE' }],
+      }),
+      mkServer(),
+      tmpDir,
+    );
+    expect(action.kind).toBe('migrate-forward');
+    if (action.kind === 'migrate-forward') {
+      expect(action.targetFiles.get('system/important_variables.md')).toBe('INLINE');
+    }
+  });
+
+  it('memory.files reads from_file relative to root path', () => {
+    writeFile('system/template.md', 'FROM-FILE');
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        files: [{ to: 'system/copied.md', from_file: 'templates/system/template.md' }],
+      }),
+      mkServer(),
+      tmpDir,
+    );
+    expect(action.kind).toBe('migrate-forward');
+    if (action.kind === 'migrate-forward') {
+      expect(action.targetFiles.get('system/copied.md')).toBe('FROM-FILE');
+    }
+  });
+
+  it('memory.files renders template_vars for from_file content', () => {
+    writeFile('system/important_variables.md', '- COMPANY_ID: {{COMPANY_ID}}\n- USER_ID: {{USER_ID}}\n');
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        files: [{
+          to: 'system/important_variables.md',
+          from_file: 'templates/system/important_variables.md',
+          template_vars: {
+            COMPANY_ID: 'company-123',
+            USER_ID: 'user-456',
+          },
+        }],
+      }),
+      mkServer(),
+      tmpDir,
+    );
+    expect(action.kind).toBe('migrate-forward');
+    if (action.kind === 'migrate-forward') {
+      expect(action.targetFiles.get('system/important_variables.md')).toBe('- COMPANY_ID: company-123\n- USER_ID: user-456\n');
+    }
+  });
+
+  it('memory.files renders template_vars for inline value content', () => {
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        files: [{
+          to: 'system/important_variables.md',
+          value: '- COMPANY_ID: {{COMPANY_ID}}\n',
+          template_vars: { COMPANY_ID: 'company-123' },
+        }],
+      }),
+      mkServer(),
+      tmpDir,
+    );
+    expect(action.kind).toBe('migrate-forward');
+    if (action.kind === 'migrate-forward') {
+      expect(action.targetFiles.get('system/important_variables.md')).toBe('- COMPANY_ID: company-123\n');
+    }
+  });
+
+  it('throws when memory.files from_file is missing', () => {
+    expect(() =>
+      computeMemfsAction(
+        'test-agent',
+        mkAgent({ mode: 'memfs', files: [{ to: 'system/copied.md', from_file: 'templates/missing.md' }] }),
+        mkServer(),
+        tmpDir,
+      ),
+    ).toThrow('memory.files from_file does not exist');
   });
 
   it('preserves .gitkeep files as empty strings', () => {


### PR DESCRIPTION
## Summary
- add memory.files[] support for inline and from_file MemFS content
- add template_vars rendering for per-agent file values
- add preserve_existing_paths so mutable MemFS files seed once and keep remote edits

## Tests
- pnpm audit
- pnpm test
- pnpm run build

Closes #398