### PR TITLE
fix: v1.0.4 clarify unavailable resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/context/context.ts
+++ b/src/commands/context/context.ts
@@ -31,7 +31,9 @@ export async function contextCommand(agentName: string, options: { output?: stri
 
   // Fetch context
   const baseUrl = process.env.LETTA_BASE_URL;
-  const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/context`);
+  const headers: Record<string, string> = {};
+  if (process.env.LETTA_API_KEY) headers.Authorization = `Bearer ${process.env.LETTA_API_KEY}`;
+  const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/context`, { headers });
 
   if (!response.ok) {
     error(`Failed to fetch context: ${response.status}`);

--- a/src/commands/files/files.ts
+++ b/src/commands/files/files.ts
@@ -2,6 +2,7 @@ import { LettaClientWrapper } from '../../lib/client/letta-client';
 import { AgentResolver } from '../../lib/client/agent-resolver';
 import { OutputFormatter } from '../../lib/ux/output-formatter';
 import { output, error } from '../../lib/shared/logger';
+import { isAgentResourceSurfaceUnavailable, shouldPrintNotAvailableForAgent } from '../get/availability';
 
 interface AgentFile {
   id: string;
@@ -25,9 +26,19 @@ export async function filesCommand(agentName: string, options: { output?: string
     process.exit(1);
   }
 
+  if (await isAgentResourceSurfaceUnavailable(client, agent.id)) {
+    if (OutputFormatter.handleJsonOutput([], options.output)) return;
+    output(`Files for agent: ${agentName}`);
+    output('='.repeat(40));
+    output('\nnot available');
+    return;
+  }
+
   // Fetch files
   const baseUrl = process.env.LETTA_BASE_URL;
-  const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/files`);
+  const headers: Record<string, string> = {};
+  if (process.env.LETTA_API_KEY) headers.Authorization = `Bearer ${process.env.LETTA_API_KEY}`;
+  const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/files`, { headers });
 
   if (!response.ok) {
     error(`Failed to fetch files: ${response.status}`);
@@ -45,7 +56,11 @@ export async function filesCommand(agentName: string, options: { output?: string
   output('='.repeat(40));
 
   if (files.length === 0) {
-    output('\nNo files attached');
+    if (await shouldPrintNotAvailableForAgent(client, agent.id, files, options.output)) {
+      output('\nnot available');
+    } else {
+      output('\nNo files attached');
+    }
     return;
   }
 

--- a/src/commands/get/archival.ts
+++ b/src/commands/get/archival.ts
@@ -4,6 +4,7 @@ import { OutputFormatter } from '../../lib/ux/output-formatter';
 import { createSpinner } from '../../lib/ux/spinner';
 import { output } from '../../lib/shared/logger';
 import { GetOptions } from './types';
+import { shouldPrintNotAvailableForAgent } from './availability';
 
 export async function getArchival(
   client: LettaClientWrapper,
@@ -54,7 +55,9 @@ export async function getArchival(
     }
 
     if (entries.length === 0) {
-      if (isSearch) output(`No archival entries found for ${agentName}`);
+      if (await shouldPrintNotAvailableForAgent(client, agentId, entries, options?.output)) {
+        output('not available');
+      } else if (isSearch) output(`No archival entries found for ${agentName}`);
       else output(`No archival memory entries for ${agentName}`);
       return;
     }

--- a/src/commands/get/archives.ts
+++ b/src/commands/get/archives.ts
@@ -5,6 +5,7 @@ import { createSpinner } from '../../lib/ux/spinner';
 import { normalizeToArray, computeAgentCounts } from '../../lib/resources/resource-usage';
 import { output } from '../../lib/shared/logger';
 import { GetOptions } from './types';
+import { shouldPrintNotAvailableForAgent } from './availability';
 
 export async function getArchives(
   client: LettaClientWrapper,
@@ -48,7 +49,9 @@ export async function getArchives(
     }
 
     if (archiveList.length === 0) {
-      if (agentId) output('No archives attached to this agent');
+      if (agentId && await shouldPrintNotAvailableForAgent(client, agentId, archiveList, options?.output)) {
+        output('not available');
+      } else if (agentId) output('No archives attached to this agent');
       else if (options?.shared) output('No shared archives found (attached to 2+ agents)');
       else if (options?.orphaned) output('No orphaned archives found (attached to 0 agents)');
       else output('No archives found');

--- a/src/commands/get/availability.ts
+++ b/src/commands/get/availability.ts
@@ -1,0 +1,35 @@
+import { LettaClientWrapper } from '../../lib/client/letta-client';
+
+export async function shouldPrintNotAvailableForAgent(
+  client: LettaClientWrapper,
+  agentId: string,
+  resourceList: any[],
+  outputFormat?: string
+): Promise<boolean> {
+  if (resourceList.length > 0 || outputFormat === 'json') return false;
+
+  return await isAgentResourceSurfaceUnavailable(client, agentId);
+}
+
+export async function isAgentResourceSurfaceUnavailable(
+  client: LettaClientWrapper,
+  agentId: string
+): Promise<boolean> {
+  const agent: any = await client.getAgent(agentId);
+  const metadata = agent?.metadata || {};
+  const tags = Array.isArray(agent?.tags) ? agent.tags : [];
+  const blocks = normalizeList(agent?.blocks || agent?.memory?.blocks);
+  const tools = normalizeList(agent?.tools);
+
+  const memfsEnabled = metadata['lettactl.memfs.enabled'] === true || tags.includes('git-memory-enabled');
+  const isV1Agent = agent?.agent_type === 'letta_v1_agent' || agent?.agentType === 'letta_v1_agent';
+  const hasOldPrimitives = blocks.length > 0 || tools.length > 0;
+
+  return memfsEnabled || !isV1Agent || !hasOldPrimitives;
+}
+
+function normalizeList(value: any): any[] {
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.items)) return value.items;
+  return [];
+}

--- a/src/commands/get/blocks.ts
+++ b/src/commands/get/blocks.ts
@@ -5,6 +5,7 @@ import { createSpinner } from '../../lib/ux/spinner';
 import { normalizeToArray, computeAgentCounts } from '../../lib/resources/resource-usage';
 import { output } from '../../lib/shared/logger';
 import { GetOptions } from './types';
+import { shouldPrintNotAvailableForAgent } from './availability';
 
 export async function getBlocks(
   client: LettaClientWrapper,
@@ -48,7 +49,9 @@ export async function getBlocks(
     }
 
     if (blockList.length === 0) {
-      if (agentId) output('No blocks attached to this agent');
+      if (agentId && await shouldPrintNotAvailableForAgent(client, agentId, blockList, options?.output)) {
+        output('not available');
+      } else if (agentId) output('No blocks attached to this agent');
       else if (options?.shared) output('No shared blocks found (attached to 2+ agents)');
       else if (options?.orphaned) output('No orphaned blocks found (attached to 0 agents)');
       else output('No blocks found');

--- a/src/commands/get/files.ts
+++ b/src/commands/get/files.ts
@@ -5,6 +5,7 @@ import { createSpinner } from '../../lib/ux/spinner';
 import { normalizeToArray, computeAgentCounts } from '../../lib/resources/resource-usage';
 import { output } from '../../lib/shared/logger';
 import { GetOptions } from './types';
+import { isAgentResourceSurfaceUnavailable, shouldPrintNotAvailableForAgent } from './availability';
 
 export async function getFiles(
   client: LettaClientWrapper,
@@ -37,6 +38,12 @@ export async function getFiles(
     let agentCounts: Map<string, number> | undefined;
 
     if (agentId) {
+      if (await isAgentResourceSurfaceUnavailable(client, agentId)) {
+        spinner.stop();
+        if (OutputFormatter.handleJsonOutput([], options?.output)) return;
+        output('not available');
+        return;
+      }
       // For agent-specific files, get folders attached to agent then get their files
       const agentFolders = normalizeToArray(await client.listAgentFolders(agentId));
 
@@ -85,7 +92,9 @@ export async function getFiles(
     }
 
     if (fileList.length === 0) {
-      if (agentId) output('No files attached to this agent');
+      if (agentId && await shouldPrintNotAvailableForAgent(client, agentId, fileList, options?.output)) {
+        output('not available');
+      } else if (agentId) output('No files attached to this agent');
       else if (options?.shared) output('No shared files found (in folders attached to 2+ agents)');
       else if (options?.orphaned) output('No orphaned files found (in folders attached to 0 agents)');
       else output('No files found');

--- a/src/commands/get/folders.ts
+++ b/src/commands/get/folders.ts
@@ -5,6 +5,7 @@ import { createSpinner } from '../../lib/ux/spinner';
 import { normalizeToArray, computeAgentCounts } from '../../lib/resources/resource-usage';
 import { output } from '../../lib/shared/logger';
 import { GetOptions } from './types';
+import { isAgentResourceSurfaceUnavailable, shouldPrintNotAvailableForAgent } from './availability';
 
 export async function getFolders(
   client: LettaClientWrapper,
@@ -39,6 +40,12 @@ export async function getFolders(
     let fileCounts: Map<string, number> | undefined;
 
     if (agentId) {
+      if (await isAgentResourceSurfaceUnavailable(client, agentId)) {
+        spinner.stop();
+        if (OutputFormatter.handleJsonOutput([], options?.output)) return;
+        output('not available');
+        return;
+      }
       // For agent-specific folders, no need for agent counts
       folderList = normalizeToArray(await client.listAgentFolders(agentId));
     } else {
@@ -73,7 +80,9 @@ export async function getFolders(
     }
 
     if (folderList.length === 0) {
-      if (agentId) output('No folders attached to this agent');
+      if (agentId && await shouldPrintNotAvailableForAgent(client, agentId, folderList, options?.output)) {
+        output('not available');
+      } else if (agentId) output('No folders attached to this agent');
       else if (options?.shared) output('No shared folders found (attached to 2+ agents)');
       else if (options?.orphaned) output('No orphaned folders found (attached to 0 agents)');
       else output('No folders found');

--- a/src/commands/get/tools.ts
+++ b/src/commands/get/tools.ts
@@ -5,6 +5,7 @@ import { createSpinner } from '../../lib/ux/spinner';
 import { normalizeToArray, computeAgentCounts } from '../../lib/resources/resource-usage';
 import { output } from '../../lib/shared/logger';
 import { GetOptions } from './types';
+import { shouldPrintNotAvailableForAgent } from './availability';
 
 export async function getTools(
   client: LettaClientWrapper,
@@ -53,7 +54,9 @@ export async function getTools(
     }
 
     if (toolList.length === 0) {
-      if (agentId) output('No tools attached to this agent');
+      if (agentId && await shouldPrintNotAvailableForAgent(client, agentId, toolList, options?.output)) {
+        output('not available');
+      } else if (agentId) output('No tools attached to this agent');
       else if (options?.shared) output('No shared tools found (attached to 2+ agents)');
       else if (options?.orphaned) output('No orphaned tools found (attached to 0 agents)');
       else output('No tools found');

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,18 @@ Notes:
   .action(async (options, command) => { await applyCommand(options, command); });
 
 // Get command - parent with subcommands
-const getCmd = program.command('get').description('Display resources');
+const getCmd = program.command('get').description('Display resources')
+  .addHelpText('after', `
+
+Agent-scoped resource notes:
+  get blocks <agent>          Show attached memory blocks when available
+  get tools -a <agent>        Show attached tools when available
+  get folders -a <agent>      Show attached folders when available
+  get files -a <agent>        Show attached folder files when available
+  get archival <agent>        Show archival memory when available
+
+  Commands print "not available" when the agent does not expose that resource surface.
+`);
 
 getCmd
   .command('agents')
@@ -203,7 +214,7 @@ getCmd
 
 getCmd
   .command('blocks')
-  .description('List memory blocks')
+  .description('List attached memory blocks')
   .argument('[name]', 'specific block or agent name (optional)')
   .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
   .option('-a, --agent <name>', 'filter by agent name')
@@ -214,7 +225,7 @@ getCmd
 
 getCmd
   .command('archives')
-  .description('List archives')
+  .description('List attached archives')
   .argument('[name]', 'specific archive name (optional)')
   .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
   .option('-a, --agent <name>', 'filter by agent name')
@@ -222,7 +233,7 @@ getCmd
 
 getCmd
   .command('tools')
-  .description('List tools')
+  .description('List attached tools')
   .argument('[name]', 'specific tool name (optional)')
   .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
   .option('-a, --agent <name>', 'filter by agent name')
@@ -232,7 +243,7 @@ getCmd
 
 getCmd
   .command('folders')
-  .description('List folders')
+  .description('List attached folders')
   .argument('[name]', 'specific folder name (optional)')
   .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
   .option('-a, --agent <name>', 'filter by agent name')
@@ -242,7 +253,7 @@ getCmd
 
 getCmd
   .command('files')
-  .description('List files')
+  .description('List attached folder files')
   .argument('[name]', 'specific file name (optional)')
   .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
   .option('-a, --agent <name>', 'filter by agent name')
@@ -562,7 +573,7 @@ remoteCmd
 // Files - show agent file state
 program
   .command('files')
-  .description('Show attached files and their open/closed state')
+  .description('Show attached folder files and their open/closed state')
   .argument('<agent>', 'agent name')
   .option('-o, --output <format>', 'output format (table|json)', 'table')
   .action(filesCommand);

--- a/tests/unit/commands/get-availability.test.ts
+++ b/tests/unit/commands/get-availability.test.ts
@@ -1,0 +1,84 @@
+import { shouldPrintNotAvailableForAgent } from '../../../src/commands/get/availability';
+
+describe('get resource availability', () => {
+  const client = (agent: any) => ({
+    getAgent: jest.fn().mockResolvedValue(agent),
+  }) as any;
+
+  it('does not hide non-empty resource lists', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ agent_type: 'letta_v1_agent', blocks: [] }),
+      'agent-1',
+      [{ id: 'block-1' }],
+      'table'
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('keeps json output compatible', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ metadata: { 'lettactl.memfs.enabled': true } }),
+      'agent-1',
+      [],
+      'json'
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('prints not available for memfs-backed agents', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ agent_type: 'letta_v1_agent', metadata: { 'lettactl.memfs.enabled': true } }),
+      'agent-1',
+      [],
+      'table'
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('prints not available for non-v1 agents', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ agent_type: 'letta_code_agent', blocks: [{ id: 'block-1' }] }),
+      'agent-1',
+      [],
+      'table'
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('prints not available when no primitive bindings exist', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ agent_type: 'letta_v1_agent', blocks: [], tools: [] }),
+      'agent-1',
+      [],
+      'table'
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('keeps old-shape v1 agents with blocks available', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ agent_type: 'letta_v1_agent', blocks: [{ id: 'block-1' }], tools: [] }),
+      'agent-1',
+      [],
+      'table'
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('keeps old-shape v1 agents with tools available', async () => {
+    const result = await shouldPrintNotAvailableForAgent(
+      client({ agent_type: 'letta_v1_agent', blocks: [], tools: [{ id: 'tool-1' }] }),
+      'agent-1',
+      [],
+      'table'
+    );
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- print `not available` for unavailable agent-scoped resource surfaces
- avoid deprecated attached-folder/file endpoints for MemFS-backed agents
- add Cloud auth to context and attached-file fetches
- keep JSON empty-list output compatible

## Verification
- `pnpm audit`
- `pnpm test`
- `pnpm run build`
- live Cloud sweep against `CANARY-a3590f8d-adspectre-draper`

Closes #400