### PR TITLE
feat: v1.0.5 prune managed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ agents:
       preserve_existing_paths:
         - system/persona.md
         - system/state.md
+      prune_missing_skills: true
       files:
         - to: system/important_variables.md
           value: |
@@ -145,6 +146,9 @@ Use `memory.template_dir` for system MemFS files, `memory.skills[].from_dir` for
 directories containing `SKILL.md`, and `agents[].secrets` or `global-secrets` for
 Letta Code secret sync. Add `memory.preserve_existing_paths` for mutable files
 that should be seeded on first deploy but preserved after the agent edits them.
+Set `memory.prune_missing_skills: true` when `memory.skills` is the managed skill
+catalog and deploys should delete stale `skills/<name>` files missing from the
+template.
 Use `memory.files[]` for explicit inline or `from_file` content, especially
 per-agent dynamic system files. See the full docs for schema details.
 
@@ -261,7 +265,7 @@ await ctl.deleteAgent('my-agent');
 | **Lifecycle** | `duplicate`, `delete`, `delete-all`, `cleanup` |
 | **Export** | `export agent`, `export agents`, `export lettabot`, `import` |
 | **Runs** | `get runs`, `get run`, `track`, `run-delete` |
-| **Fleet** | `report memory`, `memory.mode=memfs`, `memory.skills`, `global-secrets`, `agents[].secrets`, `--canary`, `--fresh-context`, `--compact`, `--recalibrate`, `--skip-recompile`, `--match`, `--no-wait-for-idle` |
+| **Fleet** | `report memory`, `memory.mode=memfs`, `memory.skills`, `memory.prune_missing_skills`, `global-secrets`, `agents[].secrets`, `--canary`, `--fresh-context`, `--compact`, `--recalibrate`, `--skip-recompile`, `--match`, `--no-wait-for-idle` |
 | **Config** | `remote add/use/list/remove`, `completion` |
 
 Run `lettactl --help` or visit [lettactl.dev](https://lettactl.dev) for full documentation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -868,7 +868,8 @@ function logMemfsResult(result: MemfsExecutionResult, agentName: string): void {
       } else if (result.kind === 'rollback') {
         log(`${prefix} DRY-RUN rollback: remove git-memory-enabled tag`);
       } else if (result.kind === 'sync-files-only') {
-        log(`${prefix} DRY-RUN sync-files-only: ${result.filesChanged?.length ?? 0} files`);
+        const count = (result.filesChanged?.length ?? 0) + (result.filesDeleted?.length ?? 0);
+        log(`${prefix} DRY-RUN sync-files-only: ${count} files`);
       }
       break;
     case 'applied':
@@ -878,7 +879,8 @@ function logMemfsResult(result: MemfsExecutionResult, agentName: string): void {
       } else if (result.kind === 'rollback') {
         log(`${prefix} ✓ rolled back to block-mode (tag removed)`);
       } else if (result.kind === 'sync-files-only') {
-        log(`${prefix} ✓ synced ${result.filesChanged?.length} files (commit ${result.commitSha?.slice(0, 7)})`);
+        const count = (result.filesChanged?.length ?? 0) + (result.filesDeleted?.length ?? 0);
+        log(`${prefix} ✓ synced ${count} files (commit ${result.commitSha?.slice(0, 7)})`);
       }
       break;
     case 'failed':

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ MemFS skills and secrets:
   memory.mode: memfs              Sync agent state to the git-backed memory filesystem
   memory.template_dir             Copy a full MemFS template directory
   memory.preserve_existing_paths  Seed listed paths, then preserve remote edits
+  memory.prune_missing_skills     Delete managed skills/<name> files missing from memory.skills
   memory.files[]                  Write explicit inline/from_file content to a MemFS path
   memory.skills[].from_dir        Copy a skill directory containing SKILL.md into skills/<name>
   global-secrets                  Sync secret values to every agent
@@ -169,6 +170,7 @@ Example:
         preserve_existing_paths:
           - system/persona.md
           - system/important_variables.md
+        prune_missing_skills: true
         files:
           - to: system/important_variables.md
             value: "# Important Variables\\n- COMPANY_ID: ..."
@@ -182,6 +184,7 @@ Example:
 
 Notes:
   - skill directories must be repo-relative and include SKILL.md
+  - prune_missing_skills only prunes managed skills declared by memory.skills
   - memory.mode: memfs defaults to include_base_tools: false
   - classic/block agents default to include_base_tools: true
   - secret values are redacted from output

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -476,7 +476,7 @@ function formatMemfsDetails(result: DryRunResult, fancy: boolean): void {
       break;
     }
     case 'sync-files-only': {
-      const paths = Array.from(action.changedFiles.keys());
+      const paths = [...Array.from(action.changedFiles.keys()), ...action.deletedFiles];
       const detail = `sync-files-only (${formatMemfsFileList(paths.length, paths)})`;
       output(`${indent}${colorPurple('Memfs [~]:')} ${detail}`);
       break;

--- a/src/lib/memfs-reconciler/executor.ts
+++ b/src/lib/memfs-reconciler/executor.ts
@@ -35,6 +35,7 @@ export interface MemfsExecutionResult {
   commitSha?: string;
   newTags?: string[];
   filesChanged?: string[];
+  filesDeleted?: string[];
   error?: string;
 }
 
@@ -210,6 +211,7 @@ export class MemfsReconciler {
     action: Extract<MemfsAction, { kind: 'sync-files-only' }>,
   ): Promise<MemfsExecutionResult> {
     const filesChanged = Array.from(action.changedFiles.keys());
+    const filesDeleted = action.deletedFiles;
 
     if (this.opts.dryRun) {
       return {
@@ -217,15 +219,17 @@ export class MemfsReconciler {
         agentId: action.agentId,
         status: 'dry-run',
         filesChanged,
+        filesDeleted,
       };
     }
 
-    const commitMessage = `update: ${action.changedFiles.size} files changed (lettactl ${this.opts.lettactlVersion})`;
+    const changeCount = action.changedFiles.size + action.deletedFiles.length;
+    const commitMessage = `update: ${changeCount} memfs files changed (lettactl ${this.opts.lettactlVersion})`;
     let tempDir: string | null = null;
     let commitSha: string;
     try {
       tempDir = await this.git.cloneToTemp(action.agentId);
-      commitSha = await this.git.writeCommitPush(tempDir, action.changedFiles, commitMessage);
+      commitSha = await this.git.writeCommitPush(tempDir, action.changedFiles, commitMessage, action.deletedFiles);
     } finally {
       if (tempDir) {
         await this.git.cleanup(tempDir).catch((e) => {
@@ -235,7 +239,7 @@ export class MemfsReconciler {
       }
     }
 
-    const remoteVerify = await this.verifyRemoteFiles(action.agentId, action.changedFiles);
+    const remoteVerify = await this.verifyRemoteFiles(action.agentId, action.changedFiles, action.deletedFiles);
     if (!remoteVerify.ok) {
       return {
         kind: 'sync-files-only',
@@ -243,6 +247,7 @@ export class MemfsReconciler {
         status: 'failed',
         commitSha,
         filesChanged,
+        filesDeleted,
         error: `Remote MemFS verification failed after push: ${remoteVerify.error}.`,
       };
     }
@@ -253,6 +258,7 @@ export class MemfsReconciler {
       status: 'applied',
       commitSha,
       filesChanged,
+      filesDeleted,
     };
   }
 
@@ -304,6 +310,7 @@ export class MemfsReconciler {
   private async verifyRemoteFiles(
     agentId: string,
     expectedFiles: Map<string, string>,
+    deletedFiles: string[] = [],
   ): Promise<{ ok: true } | { ok: false; error: string }> {
     const expectedShas = mapContentToBlobShas(expectedFiles);
     let lastError = '';
@@ -312,6 +319,16 @@ export class MemfsReconciler {
       try {
         const remoteFiles = await this.git.listBareRepoFiles(agentId);
         const mismatches = findRemoteFileMismatches(expectedShas, remoteFiles);
+        for (const filePath of deletedFiles) {
+          if (remoteFiles.has(filePath)) {
+            mismatches.push({
+              path: filePath,
+              reason: 'not-deleted',
+              expected: '<absent>',
+              actual: remoteFiles.get(filePath),
+            });
+          }
+        }
         if (mismatches.length === 0) return { ok: true };
         lastError = summarizeMismatches(mismatches);
       } catch (err) {
@@ -338,8 +355,8 @@ export function mapContentToBlobShas(files: Map<string, string>): Map<string, st
 export function findRemoteFileMismatches(
   expectedShas: Map<string, string>,
   remoteShas: Map<string, string>,
-): Array<{ path: string; reason: 'missing' | 'sha-mismatch'; expected: string; actual?: string }> {
-  const out: Array<{ path: string; reason: 'missing' | 'sha-mismatch'; expected: string; actual?: string }> = [];
+): Array<{ path: string; reason: 'missing' | 'sha-mismatch' | 'not-deleted'; expected: string; actual?: string }> {
+  const out: Array<{ path: string; reason: 'missing' | 'sha-mismatch' | 'not-deleted'; expected: string; actual?: string }> = [];
   for (const [filePath, expected] of expectedShas) {
     const actual = remoteShas.get(filePath);
     if (!actual) {
@@ -352,7 +369,7 @@ export function findRemoteFileMismatches(
 }
 
 function summarizeMismatches(
-  mismatches: Array<{ path: string; reason: 'missing' | 'sha-mismatch'; expected: string; actual?: string }>,
+  mismatches: Array<{ path: string; reason: 'missing' | 'sha-mismatch' | 'not-deleted'; expected: string; actual?: string }>,
 ): string {
   const preview = mismatches
     .slice(0, 5)

--- a/src/lib/memfs-reconciler/git-client.ts
+++ b/src/lib/memfs-reconciler/git-client.ts
@@ -94,9 +94,15 @@ export class GitClient {
     workdir: string,
     files: Map<string, string>,
     commitMessage: string,
+    deletedFiles: string[] = [],
   ): Promise<string> {
-    if (files.size === 0) {
+    if (files.size === 0 && deletedFiles.length === 0) {
       throw new Error('[GitClient.writeCommitPush] files map is empty — nothing to commit');
+    }
+
+    for (const relPath of deletedFiles) {
+      const absPath = path.join(workdir, relPath);
+      await fs.rm(absPath, { recursive: true, force: true });
     }
 
     // Write all files
@@ -107,7 +113,7 @@ export class GitClient {
     }
 
     // Stage everything that changed (new + modified)
-    await this.runGit(['add', '.'], { cwd: workdir });
+    await this.runGit(['add', '-A'], { cwd: workdir });
 
     // Check whether anything is actually staged — git commit fails on empty diff.
     const { stdout: statusOut } = await this.runGit(['status', '--porcelain'], { cwd: workdir });

--- a/src/lib/memfs-reconciler/plan.ts
+++ b/src/lib/memfs-reconciler/plan.ts
@@ -60,6 +60,8 @@ export type MemfsAction =
       agentId: string;
       // Only files whose content differs from the bare repo (or are new).
       changedFiles: Map<string, string>;
+      // Managed remote files that should be removed.
+      deletedFiles: string[];
     };
 
 /**
@@ -129,8 +131,9 @@ export function computeMemfsAction(
       changedFiles.set(filePath, content);
     }
   }
+  const deletedFiles = computeManagedSkillDeletions(memory, targetFiles, server.bareRepoFiles);
 
-  if (changedFiles.size === 0) {
+  if (changedFiles.size === 0 && deletedFiles.length === 0) {
     return {
       kind: 'no-op',
       agentId: server.agentId,
@@ -142,7 +145,31 @@ export function computeMemfsAction(
     kind: 'sync-files-only',
     agentId: server.agentId,
     changedFiles,
+    deletedFiles,
   };
+}
+
+function computeManagedSkillDeletions(
+  memory: AgentMemoryConfig,
+  targetFiles: Map<string, string>,
+  bareRepoFiles: Map<string, string>,
+): string[] {
+  if (!memory.prune_missing_skills || !memory.skills) return [];
+
+  const desiredSkills = new Set(
+    memory.skills.map((skill) => skill.name || path.basename(skill.from_dir)),
+  );
+  const deleted = new Set<string>();
+
+  for (const filePath of bareRepoFiles.keys()) {
+    const match = filePath.match(/^skills\/([^/]+)\//);
+    if (!match) continue;
+    if (!desiredSkills.has(match[1]) || !targetFiles.has(filePath)) {
+      deleted.add(filePath);
+    }
+  }
+
+  return Array.from(deleted).sort();
 }
 
 /**

--- a/src/lib/validation/config-validators.ts
+++ b/src/lib/validation/config-validators.ts
@@ -1070,6 +1070,10 @@ export class AgentMemoryConfigValidator {
       });
     }
 
+    if (memory.prune_missing_skills !== undefined && typeof memory.prune_missing_skills !== 'boolean') {
+      throw new Error('memory.prune_missing_skills must be a boolean if set.');
+    }
+
     if (memory.files !== undefined) {
       if (!Array.isArray(memory.files)) {
         throw new Error('memory.files must be an array.');

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -73,6 +73,7 @@ export interface AgentMemoryConfig {
   bare_repo?: 'auto';                        // 'auto' = resolve via Letta /v1/git/<id>/state.git
   template_dir?: string;                     // dir of skeleton .md files; relative to root_path
   preserve_existing_paths?: string[];        // memfs paths to seed but not overwrite once present
+  prune_missing_skills?: boolean;            // when true, delete remote skills/<name> dirs absent from memory.skills
   files?: Array<{
     to: string;                              // memfs target path
     value?: string;                          // inline content

--- a/tests/unit/lib/apply/dry-run.test.ts
+++ b/tests/unit/lib/apply/dry-run.test.ts
@@ -54,10 +54,10 @@ describe('displayDryRunResults memfs rendering', () => {
     };
   }
 
-  function makeSyncOnly(paths: string[]): MemfsAction {
+  function makeSyncOnly(paths: string[], deletedFiles: string[] = []): MemfsAction {
     const changedFiles = new Map<string, string>();
     for (const p of paths) changedFiles.set(p, 'x');
-    return { kind: 'sync-files-only', agentId: 'agent-1', changedFiles };
+    return { kind: 'sync-files-only', agentId: 'agent-1', changedFiles, deletedFiles };
   }
 
   it('renders migrate-forward with file list and backup path', () => {
@@ -95,6 +95,19 @@ describe('displayDryRunResults memfs rendering', () => {
     expect(memfsLines.some((l) => l.includes('sync-files-only'))).toBe(true);
     expect(memfsLines.some((l) => l.includes('prompting.md'))).toBe(true);
     expect(memfsLines.some((l) => l.includes('identity.md'))).toBe(true);
+  });
+
+  it('renders sync-files-only deleted files', () => {
+    const result: DryRunResult = {
+      name: 'agent-b',
+      action: 'update',
+      operations: { operationCount: 1 } as any,
+      memfsAction: makeSyncOnly([], ['skills/old/SKILL.md']),
+    };
+    displayDryRunResults([result], false);
+    const memfsLines = lines.filter((l) => l.includes('Memfs'));
+    expect(memfsLines.some((l) => l.includes('sync-files-only'))).toBe(true);
+    expect(memfsLines.some((l) => l.includes('SKILL.md'))).toBe(true);
   });
 
   it('renders rollback', () => {

--- a/tests/unit/lib/config-validators.test.ts
+++ b/tests/unit/lib/config-validators.test.ts
@@ -394,6 +394,14 @@ describe('AgentMemoryConfigValidator', () => {
     })).not.toThrow();
   });
 
+  it('accepts prune_missing_skills for memfs mode', () => {
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      template_dir: 'lib/fleet/memfs-templates/draper/',
+      prune_missing_skills: true,
+    })).not.toThrow();
+  });
+
   it('accepts a memfs-mode config with only skills', () => {
     expect(() => AgentMemoryConfigValidator.validate({
       mode: 'memfs',
@@ -466,6 +474,14 @@ describe('AgentMemoryConfigValidator', () => {
       template_dir: 'templates',
       preserve_existing_paths: ['system/persona.md', 'system/persona.md'],
     })).toThrow('duplicate path');
+  });
+
+  it('rejects invalid prune_missing_skills configs', () => {
+    expect(() => AgentMemoryConfigValidator.validate({
+      mode: 'memfs',
+      template_dir: 'templates',
+      prune_missing_skills: 'yes' as any,
+    })).toThrow('memory.prune_missing_skills must be a boolean');
   });
 
   it('rejects invalid memory.files configs', () => {

--- a/tests/unit/lib/memfs-reconciler/plan.test.ts
+++ b/tests/unit/lib/memfs-reconciler/plan.test.ts
@@ -614,6 +614,68 @@ describe('template_dir scan', () => {
     }
   });
 
+  it('prunes remote skill files missing from memory.skills when enabled', () => {
+    const skillDir = path.join(tmpDir, 'skills-src', 'saved-memory');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'saved');
+    fs.writeFileSync(path.join(skillDir, 'current.md'), 'current');
+
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        prune_missing_skills: true,
+        skills: [{ name: 'saved-memory', from_dir: 'skills-src/saved-memory' }],
+      }),
+      mkServer({
+        tags: [GIT_MEMORY_ENABLED_TAG],
+        files: {
+          'skills/saved-memory/SKILL.md': gitBlobSha('saved'),
+          'skills/saved-memory/current.md': gitBlobSha('current'),
+          'skills/saved-memory/old-reference.md': gitBlobSha('old-reference'),
+          'skills/old-memory/SKILL.md': gitBlobSha('old'),
+          'skills/old-memory/scripts/call.sh': gitBlobSha('old-script'),
+          'system/persona.md': gitBlobSha('persona'),
+        },
+      }),
+      tmpDir,
+    );
+
+    expect(action.kind).toBe('sync-files-only');
+    if (action.kind === 'sync-files-only') {
+      expect(action.changedFiles.size).toBe(0);
+      expect(action.deletedFiles).toEqual([
+        'skills/old-memory/SKILL.md',
+        'skills/old-memory/scripts/call.sh',
+        'skills/saved-memory/old-reference.md',
+      ]);
+    }
+  });
+
+  it('preserves remote skill files missing from memory.skills when pruning is disabled', () => {
+    const skillDir = path.join(tmpDir, 'skills-src', 'saved-memory');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'saved');
+
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        skills: [{ name: 'saved-memory', from_dir: 'skills-src/saved-memory' }],
+      }),
+      mkServer({
+        tags: [GIT_MEMORY_ENABLED_TAG],
+        files: {
+          'skills/saved-memory/SKILL.md': gitBlobSha('saved'),
+          'skills/old-memory/SKILL.md': gitBlobSha('old'),
+        },
+      }),
+      tmpDir,
+    );
+
+    expect(action.kind).toBe('no-op');
+  });
+
   it('throws when memory.skills directory is missing SKILL.md', () => {
     fs.mkdirSync(path.join(tmpDir, 'bad-skill'), { recursive: true });
     expect(() =>


### PR DESCRIPTION
## Summary
- add opt-in memory.prune_missing_skills for MemFS agents
- prune stale managed skills/<name> files during MemFS reconciliation
- update CLI help and README for the new config key

## Verification
- pnpm audit
- pnpm test -- tests/unit/lib/memfs-reconciler/plan.test.ts tests/unit/lib/memfs-reconciler/executor.test.ts tests/unit/lib/apply/dry-run.test.ts tests/unit/lib/config-validators.test.ts
- pnpm run build
- node dist/index.js --version
- node dist/index.js apply --help | rg -n "prune_missing_skills|memory\.skills"

Closes #402