### PR TITLE
feat: v1.0.6 add project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,22 @@ Point it at your Letta server:
 ```bash
 # Named remotes (recommended)
 lettactl remote add local http://localhost:8283
-lettactl remote add cloud https://api.letta.com --api-key sk-xxx
+lettactl remote add cloud https://api.letta.com --api-key sk-xxx --project-id project-xxx
 lettactl remote use local
 
 # Or environment variables
 export LETTA_BASE_URL=http://localhost:8283
+```
+
+For Letta Cloud projects, list available projects and scope commands with the
+project id or slug:
+
+```bash
+lettactl get projects
+
+export LETTA_PROJECT_ID=project-xxx   # sends X-Project-Id
+# or
+export LETTA_PROJECT=my-project-slug  # sends X-Project
 ```
 
 ## Quick example
@@ -162,6 +173,7 @@ use server tools such as `conversation_search`.
 
 ```bash
 lettactl get agents                      # List agents
+lettactl get projects                    # List Letta Cloud projects
 lettactl get all                         # Server overview
 lettactl describe agent my-agent         # Full details + blocks/tools/messages
 lettactl get blocks --orphaned           # Find orphaned resources
@@ -221,7 +233,11 @@ pnpm add lettactl
 ```typescript
 import { LettaCtl } from 'lettactl';
 
-const ctl = new LettaCtl({ lettaBaseUrl: 'http://localhost:8283' });
+const ctl = new LettaCtl({
+  lettaBaseUrl: 'https://api.letta.com',
+  lettaApiKey: process.env.LETTA_API_KEY,
+  lettaProjectId: 'project-xxx',
+});
 
 // Deploy from YAML string
 await ctl.deployFromYamlString(`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/context/context.ts
+++ b/src/commands/context/context.ts
@@ -33,6 +33,8 @@ export async function contextCommand(agentName: string, options: { output?: stri
   const baseUrl = process.env.LETTA_BASE_URL;
   const headers: Record<string, string> = {};
   if (process.env.LETTA_API_KEY) headers.Authorization = `Bearer ${process.env.LETTA_API_KEY}`;
+  if (process.env.LETTA_PROJECT_ID) headers['X-Project-Id'] = process.env.LETTA_PROJECT_ID;
+  if (process.env.LETTA_PROJECT) headers['X-Project'] = process.env.LETTA_PROJECT;
   const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/context`, { headers });
 
   if (!response.ok) {

--- a/src/commands/files/files.ts
+++ b/src/commands/files/files.ts
@@ -38,6 +38,8 @@ export async function filesCommand(agentName: string, options: { output?: string
   const baseUrl = process.env.LETTA_BASE_URL;
   const headers: Record<string, string> = {};
   if (process.env.LETTA_API_KEY) headers.Authorization = `Bearer ${process.env.LETTA_API_KEY}`;
+  if (process.env.LETTA_PROJECT_ID) headers['X-Project-Id'] = process.env.LETTA_PROJECT_ID;
+  if (process.env.LETTA_PROJECT) headers['X-Project'] = process.env.LETTA_PROJECT;
   const response = await fetch(`${baseUrl}/v1/agents/${agent.id}/files`, { headers });
 
   if (!response.ok) {

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -15,6 +15,7 @@ import { getMcpServers } from './mcp-servers';
 import { getArchival } from './archival';
 import { getArchives } from './archives';
 import { getConversations } from './conversations';
+import { getProjects } from './projects';
 import { getAll } from './all';
 
 async function getCommandImpl(resource: string, name?: string, options?: GetOptions, command?: any) {
@@ -88,6 +89,9 @@ async function getCommandImpl(resource: string, name?: string, options?: GetOpti
       break;
     case 'mcp-servers':
       await getMcpServers(client, options, spinnerEnabled);
+      break;
+    case 'projects':
+      await getProjects(client, options, spinnerEnabled);
       break;
     case 'archival':
       await getArchival(client, resolver, options, spinnerEnabled, agentId, agentName);

--- a/src/commands/get/projects.ts
+++ b/src/commands/get/projects.ts
@@ -1,0 +1,50 @@
+import { LettaClientWrapper } from '../../lib/client/letta-client';
+import { OutputFormatter } from '../../lib/ux/output-formatter';
+import { createSpinner } from '../../lib/ux/spinner';
+import { output } from '../../lib/shared/logger';
+import { GetOptions } from './types';
+
+function formatProjectTable(projects: any[]): string {
+  const nameW = Math.max(...projects.map(p => String(p.name || '').length), 4) + 1;
+  const slugW = Math.max(...projects.map(p => String(p.slug || '').length), 4) + 1;
+  const idW = Math.max(...projects.map(p => String(p.id || '').length), 2) + 1;
+  const header = 'NAME'.padEnd(nameW) + '  ' + 'SLUG'.padEnd(slugW) + '  ' + 'ID'.padEnd(idW);
+  const lines = [header, '-'.repeat(header.length)];
+
+  for (const project of projects) {
+    lines.push(
+      String(project.name || '').padEnd(nameW) + '  ' +
+      String(project.slug || '').padEnd(slugW) + '  ' +
+      String(project.id || '').padEnd(idW),
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export async function getProjects(
+  client: LettaClientWrapper,
+  options?: GetOptions,
+  spinnerEnabled?: boolean,
+) {
+  const spinner = createSpinner('Loading projects...', spinnerEnabled).start();
+
+  try {
+    const projects = await client.listProjects();
+    spinner.stop();
+
+    if (OutputFormatter.handleJsonOutput(projects, options?.output)) {
+      return;
+    }
+
+    if (projects.length === 0) {
+      output('No projects found');
+      return;
+    }
+
+    output(formatProjectTable(projects));
+  } catch (error) {
+    spinner.fail('Failed to load projects');
+    throw error;
+  }
+}

--- a/src/commands/get/types.ts
+++ b/src/commands/get/types.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_RESOURCES = ['agents', 'blocks', 'archives', 'tools', 'folders', 'files', 'mcp-servers', 'archival', 'conversations', 'all'];
+export const SUPPORTED_RESOURCES = ['agents', 'blocks', 'archives', 'tools', 'folders', 'files', 'mcp-servers', 'projects', 'archival', 'conversations', 'all'];
 
 export interface GetOptions {
   output?: string;

--- a/src/commands/remote/remote.ts
+++ b/src/commands/remote/remote.ts
@@ -12,6 +12,8 @@ export interface RemoteConfig {
   name: string;
   base_url: string;
   api_key?: string;
+  project_id?: string;
+  project?: string;
 }
 
 interface RemoteStore {
@@ -50,7 +52,7 @@ function saveStore(store: RemoteStore): void {
 export async function remoteAddCommand(
   name: string,
   url: string,
-  options: { apiKey?: string },
+  options: { apiKey?: string; projectId?: string; project?: string },
   _command: any
 ): Promise<void> {
   const store = loadStore();
@@ -66,6 +68,12 @@ export async function remoteAddCommand(
   const remote: RemoteConfig = { name, base_url: baseUrl };
   if (options.apiKey) {
     remote.api_key = options.apiKey;
+  }
+  if (options.projectId) {
+    remote.project_id = options.projectId;
+  }
+  if (options.project) {
+    remote.project = options.project;
   }
 
   store.remotes.push(remote);
@@ -163,14 +171,16 @@ export async function remoteListCommand(): Promise<void> {
     const isActive = remote.name === store.active;
     const marker = isActive ? '*' : ' ';
     const hasKey = remote.api_key ? 'key: ✓' : 'key: -';
+    const project = remote.project_id || remote.project;
+    const projectLabel = project ? `project: ${project}` : 'project: -';
 
     if (fancy) {
       const nameStr = isActive
         ? chalk.green(`* ${remote.name}`)
         : `  ${remote.name}`;
-      output(`${nameStr}  ${chalk.dim(remote.base_url)}  ${chalk.dim(`(${hasKey})`)}`);
+      output(`${nameStr}  ${chalk.dim(remote.base_url)}  ${chalk.dim(`(${hasKey}, ${projectLabel})`)}`);
     } else {
-      output(`${marker} ${remote.name}\t${remote.base_url}\t(${hasKey})`);
+      output(`${marker} ${remote.name}\t${remote.base_url}\t(${hasKey}, ${projectLabel})`);
     }
   }
 }
@@ -197,6 +207,16 @@ export async function remoteEnvCommand(): Promise<void> {
   } else {
     console.log('unset LETTA_API_KEY');
   }
+  if (remote.project_id) {
+    console.log(`export LETTA_PROJECT_ID="${remote.project_id}"`);
+  } else {
+    console.log('unset LETTA_PROJECT_ID');
+  }
+  if (remote.project) {
+    console.log(`export LETTA_PROJECT="${remote.project}"`);
+  } else {
+    console.log('unset LETTA_PROJECT');
+  }
 }
 
 export async function remoteShowCommand(name: string): Promise<void> {
@@ -216,10 +236,12 @@ export async function remoteShowCommand(name: string): Promise<void> {
     output(purple('─'.repeat(20)));
     output(`${chalk.dim('URL:')}     ${remote.base_url}`);
     output(`${chalk.dim('API Key:')} ${remote.api_key ? chalk.dim(remote.api_key.substring(0, 8) + '...') : chalk.dim('-')}`);
+    output(`${chalk.dim('Project:')} ${remote.project_id || remote.project || chalk.dim('-')}`);
   } else {
     output(`Remote: ${remote.name}${isActive ? ' (active)' : ''}`);
     output(`URL:     ${remote.base_url}`);
     output(`API Key: ${remote.api_key ? remote.api_key.substring(0, 8) + '...' : '-'}`);
+    output(`Project: ${remote.project_id || remote.project || '-'}`);
   }
 }
 
@@ -239,5 +261,11 @@ export function loadActiveRemote(): void {
   process.env.LETTA_BASE_URL = remote.base_url;
   if (remote.api_key && !process.env.LETTA_API_KEY) {
     process.env.LETTA_API_KEY = remote.api_key;
+  }
+  if (remote.project_id && !process.env.LETTA_PROJECT_ID) {
+    process.env.LETTA_PROJECT_ID = remote.project_id;
+  }
+  if (remote.project && !process.env.LETTA_PROJECT) {
+    process.env.LETTA_PROJECT = remote.project;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ function validateEnvironment(thisCommand: any, actionCommand: any) {
     error('For Letta Cloud:');
     error('  export LETTA_BASE_URL=https://api.letta.com');
     error('  export LETTA_API_KEY=your_api_key');
+    error('  export LETTA_PROJECT_ID=project_xxx  # optional');
     process.exit(1);
   }
 
@@ -202,6 +203,7 @@ Agent-scoped resource notes:
   get folders -a <agent>      Show attached folders when available
   get files -a <agent>        Show attached folder files when available
   get archival <agent>        Show archival memory when available
+  get projects                Show Letta Cloud projects
 
   Commands print "not available" when the agent does not expose that resource surface.
 `);
@@ -267,6 +269,12 @@ getCmd
   .description('List MCP servers')
   .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
   .action((options, command) => getCommand('mcp-servers', undefined, options, command));
+
+getCmd
+  .command('projects')
+  .description('List Letta Cloud projects')
+  .option('-o, --output <format>', 'output format (table|json|yaml)', 'table')
+  .action((options, command) => getCommand('projects', undefined, options, command));
 
 getCmd
   .command('archival')
@@ -543,6 +551,8 @@ remoteCmd
   .argument('<name>', 'remote name (e.g., local, staging, production)')
   .argument('<url>', 'server URL (e.g., http://localhost:8283)')
   .option('--api-key <key>', 'API key for authentication')
+  .option('--project-id <id>', 'Letta Cloud project id (sets LETTA_PROJECT_ID)')
+  .option('--project <slug>', 'Letta Cloud project slug (sets LETTA_PROJECT)')
   .action(remoteAddCommand);
 
 remoteCmd

--- a/src/lib/client/letta-client.ts
+++ b/src/lib/client/letta-client.ts
@@ -16,8 +16,33 @@ export class LettaClientWrapper {
     if (process.env.LETTA_API_KEY) {
       config.apiKey = process.env.LETTA_API_KEY;
     }
+    if (process.env.LETTA_PROJECT_ID) {
+      config.projectID = process.env.LETTA_PROJECT_ID;
+    }
+    if (process.env.LETTA_PROJECT) {
+      config.project = process.env.LETTA_PROJECT;
+    }
     
     this.client = new LettaClient(config);
+  }
+
+  async listProjects() {
+    const baseUrl = process.env.LETTA_BASE_URL;
+    const response = await fetch(`${baseUrl}/v1/projects`, {
+      headers: this.getAuthHeaders(),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Failed to list projects (HTTP ${response.status}): ${body || response.statusText}`);
+    }
+    const body: any = await response.json();
+    return Array.isArray(body) ? body : body.projects || body.data || [];
+  }
+
+  private async getProjectSlugForId(projectId: string): Promise<string | null> {
+    const projects = await this.listProjects();
+    const project = projects.find((p: any) => p.id === projectId);
+    return project?.slug || null;
   }
 
   async listAgents(options?: { tags?: string[] }) {
@@ -27,12 +52,20 @@ export class LettaClientWrapper {
     const headers = this.getAuthHeaders();
     const allAgents: any[] = [];
     let after: string | null = null;
+    let projectId = process.env.LETTA_PROJECT_ID || null;
+    if (!projectId && process.env.LETTA_PROJECT) {
+      const projects = await this.listProjects();
+      projectId = projects.find((p: any) => p.slug === process.env.LETTA_PROJECT || p.name === process.env.LETTA_PROJECT)?.id || null;
+    }
 
     while (true) {
       const url = new URL('/v1/agents/', baseUrl!);
       url.searchParams.set('limit', '100');
       url.searchParams.append('include', 'agent.tags');
       if (after) url.searchParams.set('after', after);
+      if (projectId) {
+        url.searchParams.set('project_id', projectId);
+      }
       if (options?.tags && options.tags.length > 0) {
         for (const tag of options.tags) {
           url.searchParams.append('tags', tag);
@@ -125,12 +158,37 @@ export class LettaClientWrapper {
     return await response.json();
   }
 
-  async createAgent(agentData: any) {
-    return await this.client.agents.create(agentData);
+  async createAgent(agentData: any): Promise<any> {
+    const baseUrl = process.env.LETTA_BASE_URL;
+    const headers = this.getAuthHeaders();
+    if (!process.env.LETTA_PROJECT && process.env.LETTA_PROJECT_ID) {
+      const slug = await this.getProjectSlugForId(process.env.LETTA_PROJECT_ID);
+      if (slug) headers['X-Project'] = slug;
+    }
+
+    const response = await fetch(`${baseUrl}/v1/agents/`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(agentData),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Failed to create agent (HTTP ${response.status}): ${body || response.statusText}`);
+    }
+    return await response.json();
   }
 
-  async deleteAgent(agentId: string) {
-    return await this.client.agents.delete(agentId);
+  async deleteAgent(agentId: string): Promise<any> {
+    const baseUrl = process.env.LETTA_BASE_URL;
+    const response = await fetch(`${baseUrl}/v1/agents/${agentId}`, {
+      method: 'DELETE',
+      headers: this.getAuthHeaders(),
+    });
+    if (!response.ok && response.status !== 404) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Failed to delete agent (HTTP ${response.status}): ${body || response.statusText}`);
+    }
+    return null;
   }
 
   async getAgentMessages(agentId: string, limit?: number) {
@@ -396,6 +454,12 @@ export class LettaClientWrapper {
     };
     if (process.env.LETTA_API_KEY) {
       headers['Authorization'] = `Bearer ${process.env.LETTA_API_KEY}`;
+    }
+    if (process.env.LETTA_PROJECT_ID) {
+      headers['X-Project-Id'] = process.env.LETTA_PROJECT_ID;
+    }
+    if (process.env.LETTA_PROJECT) {
+      headers['X-Project'] = process.env.LETTA_PROJECT;
     }
     return headers;
   }

--- a/src/lib/ux/help-formatter.ts
+++ b/src/lib/ux/help-formatter.ts
@@ -31,8 +31,7 @@ const COMMAND_GROUPS: CommandGroup[] = [
       { key: 'create', value: 'Create a new agent' },
       { key: 'update', value: 'Update an agent' },
       { key: 'delete', value: 'Delete a resource' },
-      { key: 'delete-all', value: 'Delete multiple agents' },
-      { key: 'cleanup', value: 'Remove orphaned resources' },
+      { key: 'get projects', value: 'List Cloud projects' },
     ],
   },
   {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -19,6 +19,8 @@ import { setQuietMode } from './lib/shared/logger';
 export interface LettaCtlOptions {
   lettaBaseUrl?: string;
   lettaApiKey?: string;
+  lettaProjectId?: string;
+  lettaProject?: string;
   supabaseUrl?: string;
   supabaseAnonKey?: string;
   supabaseServiceRoleKey?: string;
@@ -32,6 +34,8 @@ export class LettaCtl {
   constructor(options: LettaCtlOptions = {}) {
     if (options.lettaBaseUrl) process.env.LETTA_BASE_URL = options.lettaBaseUrl;
     if (options.lettaApiKey) process.env.LETTA_API_KEY = options.lettaApiKey;
+    if (options.lettaProjectId) process.env.LETTA_PROJECT_ID = options.lettaProjectId;
+    if (options.lettaProject) process.env.LETTA_PROJECT = options.lettaProject;
     if (options.supabaseUrl) process.env.SUPABASE_URL = options.supabaseUrl;
     if (options.supabaseAnonKey) process.env.SUPABASE_ANON_KEY = options.supabaseAnonKey;
     if (options.supabaseServiceRoleKey) process.env.SUPABASE_SERVICE_ROLE_KEY = options.supabaseServiceRoleKey;


### PR DESCRIPTION
## Summary
- add Letta Cloud project discovery with `lettactl get projects`
- support project scoping via `LETTA_PROJECT_ID` / `LETTA_PROJECT` and named remotes
- route project-scoped agent create/list/delete through the documented API behavior

## Verification
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm audit`
- `node dist/index.js get projects --no-ux`
- project-scoped apply smoke test created and deleted `lettactl-project-smoke` in `project-qsLMzGWjVUK_mr174o4i`

Closes #197