### PR TITLE
fix: v1.0.7 clear first message metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -372,6 +372,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
           ).filter(Boolean),
           tags: agent.tags || [],
           lettabotConfig: agent.lettabot || null,
+          firstMessage: agent.first_message || null,
           compactionSettings: agent.compaction_settings || null,
           conversations: agent.conversations || undefined
         };

--- a/src/lib/apply/diff-applier.ts
+++ b/src/lib/apply/diff-applier.ts
@@ -93,7 +93,7 @@ export class DiffApplier {
       await this.client.updateAgent(agentId, apiFields);
 
       // Update metadata for fields that need raw value tracking
-      const needsMetadataUpdate = fields.model !== undefined || fields.embedding !== undefined || fields.lettabotConfig !== undefined || fields.includeBaseTools !== undefined || fields.includeBaseToolRules !== undefined;
+      const needsMetadataUpdate = fields.model !== undefined || fields.embedding !== undefined || fields.lettabotConfig !== undefined || fields.firstMessage !== undefined || fields.includeBaseTools !== undefined || fields.includeBaseToolRules !== undefined;
       if (needsMetadataUpdate) {
         const agent = await this.client.getAgent(agentId);
         const metadata = { ...(agent as any).metadata };
@@ -108,6 +108,13 @@ export class DiffApplier {
             metadata['lettactl.lettabotConfig'] = fields.lettabotConfig.to;
           } else {
             delete metadata['lettactl.lettabotConfig'];
+          }
+        }
+        if (fields.firstMessage !== undefined) {
+          if (fields.firstMessage.to) {
+            metadata['lettactl.firstMessage'] = fields.firstMessage.to;
+          } else {
+            delete metadata['lettactl.firstMessage'];
           }
         }
         if (fields.includeBaseTools !== undefined) {

--- a/src/lib/apply/diff-engine.ts
+++ b/src/lib/apply/diff-engine.ts
@@ -56,6 +56,7 @@ export class DiffEngine {
       sharedBlockConfigs?: Array<{name: string; description?: string; limit?: number; value?: string; agent_owned?: boolean}>;
       tags?: string[];
       lettabotConfig?: Record<string, any> | null;
+      firstMessage?: string | null;
       compactionSettings?: Record<string, any> | null;
       conversations?: Array<{ summary: string; isolated_blocks?: string[] }>;
     },
@@ -240,6 +241,13 @@ export class DiffEngine {
     const desiredLettabotConfig = desiredConfig.lettabotConfig || null;
     if (JSON.stringify(currentLettabotConfig) !== JSON.stringify(desiredLettabotConfig)) {
       fieldUpdates.lettabotConfig = { from: currentLettabotConfig, to: desiredLettabotConfig };
+      operations.operationCount++;
+    }
+
+    const currentFirstMessage = (currentAgent as any).metadata?.['lettactl.firstMessage'] || null;
+    const desiredFirstMessage = desiredConfig.firstMessage || null;
+    if (currentFirstMessage !== desiredFirstMessage) {
+      fieldUpdates.firstMessage = { from: currentFirstMessage, to: desiredFirstMessage };
       operations.operationCount++;
     }
 

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -59,6 +59,7 @@ export interface AgentUpdateOperations {
     includeBaseToolRules?: FieldChange<boolean>;
     tags?: FieldChange<string[]>;
     lettabotConfig?: FieldChange<Record<string, any> | null>;
+    firstMessage?: FieldChange<string | null>;
   };
 
   // Resource management operations


### PR DESCRIPTION
Closes #405

## Summary
- track firstMessage in apply diffs
- clear stale lettactl.firstMessage metadata when first_message is removed
- bump package to 1.0.7

## Verification
- pnpm run typecheck
- pnpm run build
- pnpm audit