### PR TITLE
fix: v1.0.10 omit cloud embedding default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/lib/apply/apply-helpers.ts
+++ b/src/lib/apply/apply-helpers.ts
@@ -441,11 +441,13 @@ export async function createNewAgent(
       createPayload.tags = agent.tags;
     }
 
-    // Handle embedding vs embedding_config (mutually exclusive)
+    // Handle embedding vs embedding_config (mutually exclusive). Cloud-hosted
+    // Letta can omit embedding entirely; self-hosted validation rejects missing
+    // embedding before this path.
     if (agent.embedding_config) {
       createPayload.embedding_config = agent.embedding_config;
-    } else {
-      createPayload.embedding = agent.embedding || DEFAULT_EMBEDDING;
+    } else if (agent.embedding) {
+      createPayload.embedding = agent.embedding;
     }
 
     if (agent.compaction_settings) {
@@ -503,7 +505,9 @@ export async function createNewAgent(
     const metadata: Record<string, any> = {};
     // Store raw model/embedding strings for provider change detection (#255)
     metadata['lettactl.model'] = agent.llm_config?.model || 'google_ai/gemini-2.5-pro';
-    metadata['lettactl.embedding'] = agent.embedding || 'openai/text-embedding-3-small';
+    if (agent.embedding) {
+      metadata['lettactl.embedding'] = agent.embedding;
+    }
     metadata['lettactl.includeBaseTools'] = shouldIncludeBaseTools(agent);
     metadata['lettactl.includeBaseToolRules'] = shouldIncludeBaseToolRules(agent);
     if (folderContentHashes && folderContentHashes.size > 0) {

--- a/src/lib/apply/diff-applier.ts
+++ b/src/lib/apply/diff-applier.ts
@@ -57,7 +57,7 @@ export class DiffApplier {
       if (fields.model !== undefined) {
         apiFields.model = fields.model.to;
       }
-      if (fields.embedding !== undefined) {
+      if (fields.embedding !== undefined && fields.embedding.to !== null) {
         apiFields.embedding = fields.embedding.to;
       }
       if (fields.embeddingConfig !== undefined) {
@@ -101,7 +101,11 @@ export class DiffApplier {
           metadata['lettactl.model'] = fields.model.to;
         }
         if (fields.embedding !== undefined) {
-          metadata['lettactl.embedding'] = fields.embedding.to;
+          if (fields.embedding.to === null) {
+            delete metadata['lettactl.embedding'];
+          } else {
+            metadata['lettactl.embedding'] = fields.embedding.to;
+          }
         }
         if (fields.lettabotConfig !== undefined) {
           if (fields.lettabotConfig.to) {

--- a/src/lib/apply/diff-engine.ts
+++ b/src/lib/apply/diff-engine.ts
@@ -7,7 +7,7 @@ import { DiffApplier } from './diff-applier';
 import { analyzeToolChanges, analyzeBlockChanges, analyzeFolderChanges, analyzeArchiveChanges } from './diff-analyzers';
 import type { AgentUpdateOperations } from '../../types/diff';
 import { log } from '../shared/logger';
-import { DEFAULT_CONTEXT_WINDOW, DEFAULT_REASONING, DEFAULT_EMBEDDING } from '../shared/constants';
+import { DEFAULT_CONTEXT_WINDOW, DEFAULT_REASONING } from '../shared/constants';
 
 // Re-export types for backwards compatibility
 export type { ToolDiff, BlockDiff, FolderDiff, ArchiveDiff, FieldChange, AgentUpdateOperations } from '../../types/diff';
@@ -146,15 +146,17 @@ export class DiffEngine {
       operations.operationCount++;
     }
 
-    const desiredEmbedding = desiredConfig.embedding || DEFAULT_EMBEDDING;
+    const desiredEmbedding = desiredConfig.embedding ?? null;
     const storedEmbedding = (currentAgent as any).metadata?.['lettactl.embedding'];
     const handleEmbedding = (currentAgent as any).embedding_config?.handle;
     const currentEmbeddingRef = storedEmbedding || handleEmbedding;
-    const embeddingChanged = currentEmbeddingRef
-      ? currentEmbeddingRef !== desiredEmbedding
-      : normalizeModelName(currentAgent.embedding || '') !== normalizeModelName(desiredEmbedding);
+    const embeddingChanged = desiredEmbedding === null
+      ? currentEmbeddingRef !== undefined
+      : currentEmbeddingRef
+        ? currentEmbeddingRef !== desiredEmbedding
+        : normalizeModelName(currentAgent.embedding || '') !== normalizeModelName(desiredEmbedding);
     if (embeddingChanged) {
-      fieldUpdates.embedding = { from: currentEmbeddingRef || currentAgent.embedding, to: desiredEmbedding };
+      fieldUpdates.embedding = { from: currentEmbeddingRef || currentAgent.embedding || null, to: desiredEmbedding };
       operations.operationCount++;
     }
 

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -49,7 +49,7 @@ export interface AgentUpdateOperations {
     system?: FieldChange<string>;
     description?: FieldChange<string>;
     model?: FieldChange<string>;
-    embedding?: FieldChange<string>;
+    embedding?: FieldChange<string | null>;
     embeddingConfig?: FieldChange<Record<string, any> | null>;
     compactionSettings?: FieldChange<Record<string, any> | null>;
     contextWindow?: FieldChange<number>;

--- a/tests/unit/lib/diff-engine.test.ts
+++ b/tests/unit/lib/diff-engine.test.ts
@@ -1,6 +1,7 @@
 import { BlockManager } from '../../../src/lib/managers/block-manager';
 import { ArchiveManager } from '../../../src/lib/managers/archive-manager';
 import { LettaClientWrapper } from '../../../src/lib/client/letta-client';
+import { DiffEngine } from '../../../src/lib/apply/diff-engine';
 import { analyzeToolChanges, analyzeBlockChanges, analyzeFolderChanges, analyzeArchiveChanges } from '../../../src/lib/apply/diff-analyzers';
 
 jest.mock('../../../src/lib/client/letta-client');
@@ -190,6 +191,53 @@ describe('DiffEngine', () => {
       const result = await analyzeArchiveChanges(currentArchives, [], mockArchiveManager, false, agentTools);
       expect(result.toDetach).toEqual([{ name: 'old-archive', id: 'archive-1' }]);
       expect(result.unchanged).toEqual([]);
+    });
+  });
+
+  describe('generateUpdateOperations', () => {
+    it('removes stale lettactl embedding metadata when YAML omits embedding', async () => {
+      mockClient.getAgent.mockResolvedValue({
+        id: 'agent-1',
+        name: 'agent-1',
+        system: 'system',
+        description: 'description',
+        model: 'glm-4.7',
+        llm_config: {
+          handle: 'lc-zai/glm-4.7',
+          context_window: 64000,
+        },
+        metadata: {
+          'lettactl.model': 'lc-zai/glm-4.7',
+          'lettactl.embedding': 'openai/text-embedding-3-small',
+          'lettactl.includeBaseTools': false,
+          'lettactl.includeBaseToolRules': false,
+        },
+        tools: [],
+        blocks: [],
+        tags: [],
+      } as any);
+
+      const engine = new DiffEngine(mockClient, mockBlockManager, mockArchiveManager);
+      const operations = await engine.generateUpdateOperations(
+        { id: 'agent-1', name: 'agent-1' } as any,
+        {
+          systemPrompt: 'system',
+          description: 'description',
+          tools: [],
+          includeBaseTools: false,
+          includeBaseToolRules: false,
+          model: 'lc-zai/glm-4.7',
+          contextWindow: 64000,
+          tags: [],
+        },
+        new Map(),
+        new Map()
+      );
+
+      expect(operations.updateFields?.embedding).toEqual({
+        from: 'openai/text-embedding-3-small',
+        to: null,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Stop defaulting agent embedding in create payloads when fleet YAML omits embedding
- Stop writing synthetic lettactl.embedding metadata for omitted cloud embedding
- Remove stale lettactl.embedding metadata on re-apply without sending an embedding PATCH

## Verification
- pnpm test -- tests/unit/lib/diff-engine.test.ts --runInBand
- pnpm run typecheck

## Notes
- Self-hosted validation still requires embedding or embedding_config before apply