### PR TITLE
feat: v1.0.15 --reproject-skills renders skill changes on running memfs agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,12 @@ agents:
 ```
 
 ```bash
-lettactl apply -f fleet.yml --dry-run     # Shows MemFS and secret drift
-lettactl apply -f fleet.yml --root .      # Resolves template_dir/from_dir paths from repo root
+lettactl apply -f fleet.yml --dry-run          # Shows MemFS and secret drift
+lettactl apply -f fleet.yml --root .           # Resolves template_dir/from_dir paths from repo root
+lettactl apply -f fleet.yml --reproject-skills # Force skills/*/SKILL.md to re-render on running agents
 ```
+
+> **`--reproject-skills`** — Letta Cloud re-renders `system/*` MemFS files on a normal apply, but a `skills/*/SKILL.md` **content change does not render on a running agent** — only agent recreation or a detach + re-attach does. This flag detaches + re-adds each skill's current content (two pushes) then agent-recompiles, so skill edits take effect without recreation. Content- and conversation-preserving; runs even when the memfs diff is a no-op (fixes already-stale agents).
 
 Use `memory.template_dir` for system MemFS files, `memory.skills[].from_dir` for
 directories containing `SKILL.md`, and `agents[].secrets` or `global-secrets` for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -446,6 +446,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
             if (memfsResultRequiresRecompile(currentMemfsResult) && !options.skipRecompile) {
               await recompileConversationsForAgent(existingAgent.id, existingAgent.name, client, options.waitForIdle !== false);
             }
+            await maybeReprojectSkills(existingAgent.id, existingAgent.name, agent.memory?.mode, memfsReconciler, client, options);
 
             if (sidecarChanged) {
               succeeded.push(agent.name);
@@ -527,6 +528,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
             if (memfsResultRequiresRecompile(result) && !options.skipRecompile) {
               await recompileConversationsForAgent(existingAgent.id, existingAgent.name, client, options.waitForIdle !== false);
             }
+            await maybeReprojectSkills(existingAgent.id, existingAgent.name, agent.memory?.mode, memfsReconciler, client, options);
           }
           const secretResult = await reconcileSecretsForAgent(config, agent, existingAgent.id, client, false);
           if (secretResult) {
@@ -849,6 +851,41 @@ async function recompileConversationsForAgent(
     (conversation: any) => retryOn409(() => client.recompileConversation(conversation.id)),
   );
   log(`  Recompiled ${succeeded}/${list.length} conversation(s) after MemFS sync`);
+}
+
+/**
+ * `--reproject-skills`: force Letta to re-render skill blocks on a running
+ * git-memory agent. Letta Cloud re-renders `system/*` on recompile but never
+ * re-projects a `skills/*​/SKILL.md` content update on a running agent — only
+ * recreation or a detach+re-attach does. This runs regardless of the memfs diff
+ * (so it also fixes an already-stale agent whose repo is already current), then
+ * agent-level recompiles. Content- and conversation-preserving.
+ */
+async function maybeReprojectSkills(
+  agentId: string,
+  agentName: string,
+  memoryMode: string | undefined,
+  memfsReconciler: MemfsReconciler,
+  client: LettaClientWrapper,
+  options: any,
+): Promise<void> {
+  if (!options.reprojectSkills || options.dryRun) return;
+  if (memoryMode !== 'memfs') return;
+  const prefix = `  [memfs:${agentName}]`;
+  if (options.waitForIdle !== false) {
+    await waitForAgentIdle(client, agentId, { ...defaultWaitLogger(() => agentName) });
+  }
+  try {
+    const skills = await memfsReconciler.reprojectSkills(agentId);
+    if (skills.length === 0) {
+      log(`${prefix} reproject: no skills found`);
+      return;
+    }
+    await client.recompileAgent(agentId);
+    log(`${prefix} ✓ reprojected ${skills.length} skill(s): ${skills.join(', ')}`);
+  } catch (e: any) {
+    warn(`${prefix} reproject FAILED: ${e?.message ?? e}`);
+  }
 }
 
 async function ensureDeclaredConversationsForAgent(

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ program
   .option('--promote', 'promote canary config to production (use with --canary)')
   .option('--cleanup', 'remove canary agents (use with --canary)')
   .option('--skip-recompile', 'skip automatic conversation recompilation after block changes')
+  .option('--reproject-skills', 'force re-render of skill blocks on running git-memory agents (detach + re-add current skill content, then agent-level recompile). Fixes Letta Cloud not re-projecting skills/*/SKILL.md updates without recreation. Content- and conversation-preserving.')
   .option('--fresh-context', 'reset message buffer for agents that had changes (agent reads blocks fresh)')
   .option('--fresh-context-tags <tags>', 'filter context reset to agents matching tags (comma-separated, AND logic)')
   .option('--fresh-context-match <pattern>', 'filter context reset to agents matching glob pattern')

--- a/src/lib/client/letta-client.ts
+++ b/src/lib/client/letta-client.ts
@@ -898,4 +898,25 @@ export class LettaClientWrapper {
     }
     return await response.json();
   }
+
+  /**
+   * Agent-level system-prompt recompile. Unlike the conversation recompile
+   * (which dry-run-no-ops for real conversation ids), this rewrites the agent's
+   * persisted system message from the current memory cache. `update_timestamp`
+   * forces the rebuild past the substring diff-gate so a genuine change persists.
+   * Reuses the existing system-message id, so conversation history is preserved.
+   */
+  async recompileAgent(agentId: string) {
+    const baseUrl = process.env.LETTA_BASE_URL;
+    const response = await fetch(`${baseUrl}/v1/agents/${agentId}/recompile?update_timestamp=true`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+    });
+    if (!response.ok) {
+      const err: any = new Error(`Failed to recompile agent: ${response.status} ${response.statusText}`);
+      err.status = response.status;
+      throw err;
+    }
+    return await response.json();
+  }
 }

--- a/src/lib/memfs-reconciler/executor.ts
+++ b/src/lib/memfs-reconciler/executor.ts
@@ -39,6 +39,10 @@ export interface MemfsExecutionResult {
   error?: string;
 }
 
+/** Seconds to let Letta's async post-push block sync settle between the detach
+ *  and re-attach pushes during a skill reprojection. */
+const REPROJECT_SYNC_DELAY_MS = 4000;
+
 export class MemfsReconciler {
   constructor(
     private readonly letta: LettaClientWrapper,
@@ -260,6 +264,56 @@ export class MemfsReconciler {
       filesChanged,
       filesDeleted,
     };
+  }
+
+  /**
+   * Force Letta to re-project skill blocks onto a RUNNING agent, no recreation.
+   *
+   * Letta Cloud (git-memory) re-renders `system/*` on an agent recompile, but a
+   * plain `skills/*​/SKILL.md` content update never re-projects on a running
+   * agent — only agent creation, or detaching + re-attaching the block, does
+   * (see the upstream bug). This reprojects the CURRENT bare-repo skill content:
+   * delete every SKILL.md (push → post-push sync DETACHES the blocks), then
+   * re-add identical content (push → sync CREATES fresh blocks). Follow with
+   * `client.recompileAgent()` to render them. Content-preserving (re-adds what's
+   * already in the repo, so agent-authored skills are untouched) and
+   * conversation-preserving. Returns the skill names reprojected.
+   */
+  async reprojectSkills(agentId: string): Promise<string[]> {
+    const tempDir = await this.git.cloneToTemp(agentId);
+    try {
+      const skillFiles = new Map<string, string>();
+      const names = await fs.readdir(path.join(tempDir, 'skills')).catch(() => [] as string[]);
+      for (const name of names) {
+        const rel = `skills/${name}/SKILL.md`;
+        const content = await fs.readFile(path.join(tempDir, rel), 'utf8').catch(() => null);
+        if (content !== null) skillFiles.set(rel, content);
+      }
+      if (skillFiles.size === 0) return [];
+      const skillNames = [...skillFiles.keys()].map((p) => p.split('/')[1]);
+      const v = this.opts.lettactlVersion;
+      // Push 1 — detach: delete every SKILL.md so the post-push sync drops the blocks.
+      await this.git.writeCommitPush(
+        tempDir,
+        new Map(),
+        `reproject: detach ${skillNames.length} skills (lettactl ${v})`,
+        [...skillFiles.keys()],
+      );
+      await sleep(REPROJECT_SYNC_DELAY_MS);
+      // Push 2 — attach: re-add identical content so the sync creates fresh blocks.
+      await this.git.writeCommitPush(
+        tempDir,
+        skillFiles,
+        `reproject: re-attach ${skillNames.length} skills (lettactl ${v})`,
+      );
+      await sleep(REPROJECT_SYNC_DELAY_MS);
+      return skillNames;
+    } finally {
+      await this.git.cleanup(tempDir).catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error('[MemfsReconciler.reprojectSkills] cleanup errored:', e);
+      });
+    }
   }
 
   private async writeBlockSnapshot(agentId: string, blocks: import('./plan').BlockSnapshot[]): Promise<string> {


### PR DESCRIPTION
Closes #408

Adds `--reproject-skills` to `apply`. Detaches + re-adds each `skills/<name>/SKILL.md` (two pushes) then agent-recompiles, so skill content changes render on running memfs agents without recreation. Conversation-preserving; runs even on a no-op memfs diff (refreshes already-stale agents). Skip for `system/*`-only changes.

Workaround for an upstream Letta Cloud limitation (recompile refreshes `system/*` but not the skill projection layer).