### PR TITLE
fix: v1.0.16 fail-loud memfs + scope letta CLI probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -945,10 +945,12 @@ async function reconcileSecretsForAgent(
 
 /**
  * Run the memFS reconciler for a single agent. Pulls server state, computes
- * the diff, executes (or dry-runs). Returns the result so apply can log it.
+ * the diff, executes (or dry-runs). Returns the result (for logging) on success.
  *
- * Errors here are caught and returned as failed results — they don't abort
- * the whole apply (kubectl-style: per-agent failures continue).
+ * THROWS on any materialization failure (thrown error OR in-band status:'failed')
+ * so the per-agent catch in the apply loop records it in failed[] and the apply
+ * fails — never a silent shell agent. Still kubectl-style: other agents continue,
+ * the summary throws at the end.
  */
 async function reconcileMemfsForAgent(
   agent: any,
@@ -958,18 +960,24 @@ async function reconcileMemfsForAgent(
   memfsReconciler: MemfsReconciler,
   rootPath: string,
 ): Promise<MemfsExecutionResult> {
+  let result: MemfsExecutionResult;
   try {
     const serverState = await buildServerAgentState(client, gitClient, agentId);
     const action = computeMemfsAction(agent.name, agent, serverState, rootPath);
-    return await memfsReconciler.execute(action);
+    result = await memfsReconciler.execute(action);
   } catch (err) {
-    return {
-      kind: 'no-op',
-      agentId,
-      status: 'failed',
-      error: `memFS reconcile failed: ${(err as Error).message}`,
-    };
+    // Fail loud: a thrown reconcile error must abort THIS agent's apply so the
+    // per-agent catch records it in failed[] — never silently return a failed
+    // result that the caller treats as a successful (shell) deploy.
+    throw new Error(`memFS reconcile failed for ${agent.name}: ${(err as Error).message}`);
   }
+  // In-band failures (executor remote-verify / post-flip verify) return a
+  // status:'failed' result rather than throwing — surface those the same way.
+  // (status:'applied' with an error stays a soft warning — do not throw on it.)
+  if (result.status === 'failed') {
+    throw new Error(`memFS materialization failed for ${agent.name}: ${result.error ?? '(no detail)'}`);
+  }
+  return result;
 }
 
 function logSecretResult(result: SecretApplyResult, agentName: string): void {

--- a/src/commands/apply/types.ts
+++ b/src/commands/apply/types.ts
@@ -33,6 +33,10 @@ export interface ApplyOptions {
   recalibrateMatch?: string;
   wait?: boolean;  // Commander maps --no-wait to wait=false
   waitForIdle?: boolean;  // Commander maps --no-wait-for-idle to waitForIdle=false
+  /** Force skill blocks to re-render on running git-memory agents (detach +
+   *  re-add each SKILL.md, then agent-recompile). Content- and conversation-
+   *  preserving. See --reproject-skills. */
+  reprojectSkills?: boolean;
 }
 
 export interface DeployResult {

--- a/src/lib/memfs-reconciler/letta-cli.ts
+++ b/src/lib/memfs-reconciler/letta-cli.ts
@@ -14,6 +14,16 @@ export function fleetUsesMemfs(config: FleetConfig): boolean {
 export async function assertLettaCliAvailableForMemfs(config: FleetConfig): Promise<void> {
   if (!fleetUsesMemfs(config)) return;
 
+  // lettactl materializes memfs skills by pushing to the runtime's git endpoint
+  // (/v1/git) — it never runs `letta` itself. The `letta` CLI is a RUNTIME need
+  // (the server that renders skills). On Letta Cloud that runtime is managed and
+  // always has it, so there is nothing to verify client-side — skip entirely.
+  if (isLettaCloud()) return;
+
+  // Self-hosted / local runtime: we still don't run `letta` here, but the
+  // runtime image must include it to render skills. We can only probe the client
+  // env — a weak proxy — so WARN, never block. The git push (the actual work) is
+  // unaffected; a missing runtime `letta` surfaces at skill-render time.
   const command = resolveLettaCodeCli();
   try {
     await execFileAsync(command, ['skills', '--help'], {
@@ -21,21 +31,25 @@ export async function assertLettaCliAvailableForMemfs(config: FleetConfig): Prom
       maxBuffer: 1024 * 1024,
     });
   } catch (err: any) {
-    const detail = [
-      err?.code ? `code=${err.code}` : '',
-      err?.stdout ? `stdout=${String(err.stdout).trim()}` : '',
-      err?.stderr ? `stderr=${String(err.stderr).trim()}` : '',
-      err?.message ? `message=${err.message}` : '',
-    ].filter(Boolean).join('\n  ');
-
-    throw new Error(
-      `MemFS agents require a working Letta Code CLI so runtime skills can be materialized.\n` +
-      `Could not run: ${command} skills --help\n\n` +
-      `Install or update the "letta" CLI in the same environment running lettactl, ` +
-      `or set LETTA_CODE_CLI=/absolute/path/to/letta.\n` +
-      `If you are deploying self-managed runtimes, the runtime image must also include "letta".` +
-      (detail ? `\n\nDetails:\n  ${detail}` : ''),
+    console.warn(
+      `[lettactl] Could not run "${command} skills --help" in this environment. ` +
+      `lettactl does not need it (memfs is materialized over git), but a SELF-HOSTED ` +
+      `runtime image must include "letta" to render skills (set LETTA_CODE_CLI to override the path). ` +
+      `This does NOT block the deploy.` +
+      (err?.message ? `\n  ${err.message}` : ''),
     );
+  }
+}
+
+/** True when deploying against Letta Cloud (letta.com / *.letta.com). */
+function isLettaCloud(): boolean {
+  const url = process.env.LETTA_BASE_URL;
+  if (!url) return false;
+  try {
+    const host = new URL(url).hostname;
+    return host === 'letta.com' || host.endsWith('.letta.com');
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
Closes #410. Fail-loud on memfs materialization failure (no more silent shell agents) + scope the letta-CLI probe to self-hosted runtimes (Cloud never needed it). Builds clean.