### PR TITLE
feat: v1.0.17 prune_paths — explicit removal of renamed/removed memfs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,9 @@ MemFS skills and secrets:
   memory.template_dir             Copy a full MemFS template directory
   memory.preserve_existing_paths  Seed listed paths, then preserve remote edits
   memory.prune_missing_skills     Delete managed skills/<name> files missing from memory.skills
+  memory.prune_paths              Explicit bare-repo paths to delete on apply — for a renamed/removed
+                                  non-skill file (system/, reference/, state/). Skipped if the path is
+                                  also a target file. Safe: only these named paths are ever removed.
   memory.files[]                  Write explicit inline/from_file content to a MemFS path
   memory.skills[].from_dir        Copy a skill directory containing SKILL.md into skills/<name>
   global-secrets                  Sync secret values to every agent

--- a/src/lib/memfs-reconciler/plan.ts
+++ b/src/lib/memfs-reconciler/plan.ts
@@ -131,7 +131,10 @@ export function computeMemfsAction(
       changedFiles.set(filePath, content);
     }
   }
-  const deletedFiles = computeManagedSkillDeletions(memory, targetFiles, server.bareRepoFiles);
+  const deletedFiles = Array.from(new Set([
+    ...computeManagedSkillDeletions(memory, targetFiles, server.bareRepoFiles),
+    ...computeExplicitPruneDeletions(memory, targetFiles, server.bareRepoFiles),
+  ])).sort();
 
   if (changedFiles.size === 0 && deletedFiles.length === 0) {
     return {
@@ -170,6 +173,27 @@ function computeManagedSkillDeletions(
   }
 
   return Array.from(deleted).sort();
+}
+
+/**
+ * Explicit removals: paths the config names in `prune_paths` (a renamed or
+ * removed system/reference/state file). Non-skill files can't be auto-pruned —
+ * agents author their own memory files under system/, so a blanket "delete
+ * anything not in target" would erase agent memory. Explicit naming is safe and
+ * works on the first apply. A path is only deleted if it exists in the bare repo
+ * and is NOT also a target file (never delete a file we intend to keep).
+ */
+function computeExplicitPruneDeletions(
+  memory: AgentMemoryConfig,
+  targetFiles: Map<string, string>,
+  bareRepoFiles: Map<string, string>,
+): string[] {
+  if (!memory.prune_paths || memory.prune_paths.length === 0) return [];
+  const deleted: string[] = [];
+  for (const p of memory.prune_paths) {
+    if (bareRepoFiles.has(p) && !targetFiles.has(p)) deleted.push(p);
+  }
+  return deleted;
 }
 
 /**

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -86,6 +86,10 @@ export interface AgentMemoryConfig {
   template_dir?: string;                     // dir of skeleton .md files; relative to root_path
   preserve_existing_paths?: string[];        // memfs paths to seed but not overwrite once present
   prune_missing_skills?: boolean;            // when true, delete remote skills/<name> dirs absent from memory.skills
+  prune_paths?: string[];                    // explicit bare-repo paths to DELETE on apply (e.g. a renamed/removed
+                                             // system/ or reference/ file). Safe + explicit — unlike skills, non-skill
+                                             // files can't be auto-pruned (agents author memory files under system/),
+                                             // so removals are named here. Ignored if the path is also a target file.
   files?: Array<{
     to: string;                              // memfs target path
     value?: string;                          // inline content


### PR DESCRIPTION
Adds `memory.prune_paths` for explicit deletion of renamed/removed non-skill memfs files on apply (system/reference/state). Safe: only named paths, only if present in the bare repo AND not a target file. Already published as 1.0.17; this brings main in sync. Closes #413.