### PR TITLE
fix: v1.0.18 send enable_thinking as string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/lib/messaging/message-sender.ts
+++ b/src/lib/messaging/message-sender.ts
@@ -36,7 +36,9 @@ export async function sendMessageToAgent(
     };
 
     if (options.maxSteps) params.max_steps = options.maxSteps;
-    if (options.enableThinking) params.enable_thinking = options.enableThinking;
+    // The Letta API types enable_thinking as a STRING (a boolean here 422s:
+    // "Input should be a valid string"). Send the string form.
+    if (options.enableThinking) params.enable_thinking = String(options.enableThinking);
 
     let response;
 


### PR DESCRIPTION
The --enable-thinking flag sent a JS boolean, but the Letta API types enable_thinking as a string and 422s a boolean ('Input should be a valid string'). Send the string form. Single fix point in lib/messaging/message-sender.ts (all send paths funnel through it).