### PR TITLE
feat: v1.0.20 provenance-based memfs removal (closes #416)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -1014,23 +1014,29 @@ function logMemfsResult(result: MemfsExecutionResult, agentName: string): void {
       break;
     case 'dry-run':
       if (result.kind === 'migrate-forward') {
-        log(`${prefix} DRY-RUN migrate-forward: ${result.filesChanged?.length ?? 0} files → bare repo, then add git-memory-enabled tag (backup: ${result.backupPath})`);
+        const del = result.filesDeleted?.length ? `, ${result.filesDeleted.length} deleted` : '';
+        log(`${prefix} DRY-RUN migrate-forward: ${result.filesChanged?.length ?? 0} files${del} → bare repo, then add git-memory-enabled tag (backup: ${result.backupPath})`);
+        for (const p of result.filesDeleted ?? []) log(`${prefix}   delete: ${p}`);
       } else if (result.kind === 'rollback') {
         log(`${prefix} DRY-RUN rollback: remove git-memory-enabled tag`);
       } else if (result.kind === 'sync-files-only') {
-        const count = (result.filesChanged?.length ?? 0) + (result.filesDeleted?.length ?? 0);
-        log(`${prefix} DRY-RUN sync-files-only: ${count} files`);
+        const del = result.filesDeleted?.length ? `, ${result.filesDeleted.length} deleted` : '';
+        log(`${prefix} DRY-RUN sync-files-only: ${result.filesChanged?.length ?? 0} changed${del}`);
+        for (const p of result.filesDeleted ?? []) log(`${prefix}   delete: ${p}`);
       }
       break;
     case 'applied':
       if (result.kind === 'migrate-forward') {
-        log(`${prefix} ✓ migrated to memfs (${result.filesChanged?.length} files, commit ${result.commitSha?.slice(0, 7)}, backup ${result.backupPath})`);
+        const del = result.filesDeleted?.length ? `, ${result.filesDeleted.length} deleted` : '';
+        log(`${prefix} ✓ migrated to memfs (${result.filesChanged?.length} files${del}, commit ${result.commitSha?.slice(0, 7)}, backup ${result.backupPath})`);
+        for (const p of result.filesDeleted ?? []) log(`${prefix}   deleted: ${p}`);
         if (result.error) warn(`${prefix} ${result.error}`);
       } else if (result.kind === 'rollback') {
         log(`${prefix} ✓ rolled back to block-mode (tag removed)`);
       } else if (result.kind === 'sync-files-only') {
-        const count = (result.filesChanged?.length ?? 0) + (result.filesDeleted?.length ?? 0);
-        log(`${prefix} ✓ synced ${count} files (commit ${result.commitSha?.slice(0, 7)})`);
+        const del = result.filesDeleted?.length ? `, ${result.filesDeleted.length} deleted` : '';
+        log(`${prefix} ✓ synced ${result.filesChanged?.length ?? 0} changed${del} (commit ${result.commitSha?.slice(0, 7)})`);
+        for (const p of result.filesDeleted ?? []) log(`${prefix}   deleted: ${p}`);
       }
       break;
     case 'failed':

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -470,15 +470,17 @@ function formatMemfsDetails(result: DryRunResult, fancy: boolean): void {
       const fileCount = action.targetFiles.size;
       const detail = `migrate-forward (${formatMemfsFileList(fileCount, Array.from(action.targetFiles.keys()))} → bare repo, add tag git-memory-enabled)`;
       output(`${indent}${colorPurple('Memfs [~]:')} ${detail}`);
+      for (const p of action.deletedFiles) output(`${indent}  ${red('delete:')} ${p}`);
       if (result.memfsResult?.backupPath) {
         output(`${indent}  ${dim('backup snapshot:')} ${result.memfsResult.backupPath}`);
       }
       break;
     }
     case 'sync-files-only': {
-      const paths = [...Array.from(action.changedFiles.keys()), ...action.deletedFiles];
-      const detail = `sync-files-only (${formatMemfsFileList(paths.length, paths)})`;
-      output(`${indent}${colorPurple('Memfs [~]:')} ${detail}`);
+      const parts = [`~${action.changedFiles.size} changed`];
+      if (action.deletedFiles.length) parts.push(`-${action.deletedFiles.length} deleted`);
+      output(`${indent}${colorPurple('Memfs [~]:')} sync-files-only (${parts.join(', ')})`);
+      for (const p of action.deletedFiles) output(`${indent}  ${red('delete:')} ${p}`);
       break;
     }
     case 'rollback':

--- a/src/lib/memfs-reconciler/executor.ts
+++ b/src/lib/memfs-reconciler/executor.ts
@@ -18,6 +18,7 @@ import {
   type MemfsAction,
   GIT_MEMORY_ENABLED_TAG,
   GIT_MEMORY_ENABLED_METADATA_KEY,
+  MEMFS_PROJECTED_METADATA_KEY,
   gitBlobSha,
 } from './plan';
 
@@ -54,6 +55,9 @@ export class MemfsReconciler {
     try {
       switch (action.kind) {
         case 'no-op':
+          if (action.newProvenance && !this.opts.dryRun) {
+            await this.writeProvenance(action.agentId, action.newProvenance);
+          }
           return { kind: 'no-op', agentId: action.agentId, status: 'noop' };
 
         case 'rollback':
@@ -108,6 +112,7 @@ export class MemfsReconciler {
     // ready-made restore source if anything goes wrong post-flip.
     const backupPath = await this.writeBlockSnapshot(action.agentId, action.sourceBlocks);
     const filesChanged = Array.from(action.targetFiles.keys());
+    const filesDeleted = action.deletedFiles;
 
     if (this.opts.dryRun) {
       return {
@@ -117,6 +122,7 @@ export class MemfsReconciler {
         backupPath,
         newTags: [...action.currentTags, GIT_MEMORY_ENABLED_TAG],
         filesChanged,
+        filesDeleted,
       };
     }
 
@@ -133,7 +139,7 @@ export class MemfsReconciler {
     try {
       try {
         tempDir = await this.git.cloneToTemp(action.agentId);
-        commitSha = await this.git.writeCommitPush(tempDir, action.targetFiles, commitMessage);
+        commitSha = await this.git.writeCommitPush(tempDir, action.targetFiles, commitMessage, action.deletedFiles);
       } finally {
         if (tempDir) {
           await this.git.cleanup(tempDir).catch((e) => {
@@ -143,7 +149,7 @@ export class MemfsReconciler {
         }
       }
 
-      const remoteVerify = await this.verifyRemoteFiles(action.agentId, action.targetFiles);
+      const remoteVerify = await this.verifyRemoteFiles(action.agentId, action.targetFiles, action.deletedFiles);
       if (!remoteVerify.ok) {
         await this.rollbackMemfsMarker(action.agentId, action.currentTags, 'verify-failure');
         return {
@@ -153,6 +159,7 @@ export class MemfsReconciler {
           backupPath,
           commitSha,
           filesChanged,
+          filesDeleted,
           error:
             `Remote MemFS verification failed after push: ${remoteVerify.error}. ` +
             `MemFS marker was rolled back; retry apply after the remote git repo is healthy.`,
@@ -165,6 +172,8 @@ export class MemfsReconciler {
       });
       throw err;
     }
+
+    await this.writeProvenance(action.agentId, action.newProvenance);
 
     // Phase 3: verify — /context should now show core_memory: 0 tokens
     try {
@@ -179,6 +188,7 @@ export class MemfsReconciler {
           commitSha,
           newTags,
           filesChanged,
+          filesDeleted,
           error:
             `Post-flip verify failed: expected num_tokens_core_memory=0 ` +
             `but got ${ctx?.num_tokens_core_memory ?? '<missing>'}. ` +
@@ -196,6 +206,7 @@ export class MemfsReconciler {
         commitSha,
         newTags,
         filesChanged,
+        filesDeleted,
         error: `Migration applied but verify failed: ${(verifyErr as Error).message}`,
       };
     }
@@ -208,6 +219,7 @@ export class MemfsReconciler {
       commitSha,
       newTags,
       filesChanged,
+      filesDeleted,
     };
   }
 
@@ -255,6 +267,8 @@ export class MemfsReconciler {
         error: `Remote MemFS verification failed after push: ${remoteVerify.error}.`,
       };
     }
+
+    await this.writeProvenance(action.agentId, action.newProvenance);
 
     return {
       kind: 'sync-files-only',
@@ -352,6 +366,13 @@ export class MemfsReconciler {
     // Tags remain for self-hosted/legacy servers. Cloud currently accepts the
     // field but does not persist it, so metadata is the durable marker.
     await this.letta.updateAgent(agentId, { tags, metadata });
+  }
+
+  private async writeProvenance(agentId: string, projected: Map<string, string>): Promise<void> {
+    const agent = await this.letta.getAgent(agentId);
+    const metadata = { ...((agent as any).metadata ?? {}) };
+    metadata[MEMFS_PROJECTED_METADATA_KEY] = Object.fromEntries(projected);
+    await this.letta.updateAgent(agentId, { metadata });
   }
 
   private async rollbackMemfsMarker(agentId: string, currentTags: string[], reason: string): Promise<void> {

--- a/src/lib/memfs-reconciler/plan.ts
+++ b/src/lib/memfs-reconciler/plan.ts
@@ -31,24 +31,30 @@ export interface ServerAgentState {
   blocks: BlockSnapshot[];
   // path -> blob SHA at HEAD of the bare repo. Empty if no commits yet.
   bareRepoFiles: Map<string, string>;
+  // path -> sha lettactl recorded projecting last apply. Empty pre-provenance.
+  projectedFiles: Map<string, string>;
 }
 
 export const GIT_MEMORY_ENABLED_TAG = 'git-memory-enabled';
 export const GIT_MEMORY_ENABLED_METADATA_KEY = 'lettactl.memfs.enabled';
+export const MEMFS_PROJECTED_METADATA_KEY = 'lettactl.memfs.projected';
 
 export type MemfsAction =
   | {
       kind: 'no-op';
       agentId: string;
       reason: string;
+      // Set when files match but provenance needs seeding (metadata-only write).
+      newProvenance?: Map<string, string>;
     }
   | {
       kind: 'migrate-forward';
       agentId: string;
       currentTags: string[];
       sourceBlocks: BlockSnapshot[];
-      // Full target file set to push (path -> content).
       targetFiles: Map<string, string>;
+      deletedFiles: string[];
+      newProvenance: Map<string, string>;
     }
   | {
       kind: 'rollback';
@@ -58,10 +64,9 @@ export type MemfsAction =
   | {
       kind: 'sync-files-only';
       agentId: string;
-      // Only files whose content differs from the bare repo (or are new).
       changedFiles: Map<string, string>;
-      // Managed remote files that should be removed.
       deletedFiles: string[];
+      newProvenance: Map<string, string>;
     };
 
 /**
@@ -105,42 +110,49 @@ export function computeMemfsAction(
 
   // mode === 'memfs' from here
   const targetFiles = buildTargetFiles(agentName, memory, server, rootPath);
+  const preserveExistingPaths = new Set(memory.preserve_existing_paths ?? []);
 
   if (!hasTag) {
+    const { deletedFiles, newProvenance } = computeProvenancePlan(
+      memory, targetFiles, server.bareRepoFiles, server.projectedFiles, preserveExistingPaths,
+    );
     return {
       kind: 'migrate-forward',
       agentId: server.agentId,
       currentTags: server.tags,
       sourceBlocks: server.blocks,
       targetFiles,
+      deletedFiles,
+      newProvenance,
     };
   }
 
-  // Tag already set — diff targetFiles vs bareRepoFiles. Paths listed in
-  // preserve_existing_paths are seed-only after their first remote write:
-  // if the file exists in the bare repo, do not overwrite agent-owned edits.
+  // Tag set. Paths in preserve_existing_paths are seed-only: once present in the
+  // bare repo we never overwrite the agent's edits.
   const changedFiles = new Map<string, string>();
-  const preserveExistingPaths = new Set(memory.preserve_existing_paths ?? []);
   for (const [filePath, content] of targetFiles) {
     const currentSha = server.bareRepoFiles.get(filePath);
-    if (preserveExistingPaths.has(filePath) && currentSha) {
-      continue;
-    }
-    const desiredSha = gitBlobSha(content);
-    if (desiredSha !== currentSha) {
-      changedFiles.set(filePath, content);
-    }
+    if (preserveExistingPaths.has(filePath) && currentSha) continue;
+    if (gitBlobSha(content) !== currentSha) changedFiles.set(filePath, content);
   }
-  const deletedFiles = Array.from(new Set([
-    ...computeManagedSkillDeletions(memory, targetFiles, server.bareRepoFiles),
-    ...computeExplicitPruneDeletions(memory, targetFiles, server.bareRepoFiles),
-  ])).sort();
+
+  const { deletedFiles, newProvenance } = computeProvenancePlan(
+    memory, targetFiles, server.bareRepoFiles, server.projectedFiles, preserveExistingPaths,
+  );
 
   if (changedFiles.size === 0 && deletedFiles.length === 0) {
+    if (mapsEqual(newProvenance, server.projectedFiles)) {
+      return {
+        kind: 'no-op',
+        agentId: server.agentId,
+        reason: `memfs in sync: ${targetFiles.size} files match bare repo HEAD`,
+      };
+    }
     return {
       kind: 'no-op',
       agentId: server.agentId,
-      reason: `memfs in sync: ${targetFiles.size} files match bare repo HEAD`,
+      reason: `memfs in sync; recording provenance (${newProvenance.size} paths)`,
+      newProvenance,
     };
   }
 
@@ -149,51 +161,53 @@ export function computeMemfsAction(
     agentId: server.agentId,
     changedFiles,
     deletedFiles,
+    newProvenance,
   };
 }
 
-function computeManagedSkillDeletions(
+/**
+ * Provenance-based removal. lettactl only ever deletes files IT recorded
+ * projecting on a prior apply (server.projectedFiles) that the config no longer
+ * ships — never files the agent or another operator authored. prune_paths is a
+ * legacy escape hatch for agents that predate provenance tracking.
+ * Returns the delete set plus the path->sha map to record after the push.
+ */
+export function computeProvenancePlan(
   memory: AgentMemoryConfig,
   targetFiles: Map<string, string>,
   bareRepoFiles: Map<string, string>,
-): string[] {
-  if (!memory.prune_missing_skills || !memory.skills) return [];
-
-  const desiredSkills = new Set(
-    memory.skills.map((skill) => skill.name || path.basename(skill.from_dir)),
-  );
-  const deleted = new Set<string>();
-
-  for (const filePath of bareRepoFiles.keys()) {
-    const match = filePath.match(/^skills\/([^/]+)\//);
-    if (!match) continue;
-    if (!desiredSkills.has(match[1]) || !targetFiles.has(filePath)) {
-      deleted.add(filePath);
-    }
+  priorProjected: Map<string, string>,
+  preserveSet: Set<string>,
+): { deletedFiles: string[]; newProvenance: Map<string, string> } {
+  const newProvenance = new Map<string, string>();
+  for (const [p, content] of targetFiles) {
+    // Preserved files we skip writing keep the sha that's actually in the repo.
+    newProvenance.set(
+      p,
+      preserveSet.has(p) && bareRepoFiles.has(p) ? bareRepoFiles.get(p)! : gitBlobSha(content),
+    );
   }
 
-  return Array.from(deleted).sort();
+  const deleted = new Set<string>();
+  for (const [p, recordedSha] of priorProjected) {
+    if (targetFiles.has(p)) continue;      // still shipped
+    if (!bareRepoFiles.has(p)) continue;   // already gone
+    // Agent edited a seeded file we no longer ship — hand it off, stop tracking.
+    if (preserveSet.has(p) && bareRepoFiles.get(p) !== recordedSha) continue;
+    deleted.add(p);
+  }
+
+  for (const p of memory.prune_paths ?? []) {
+    if (bareRepoFiles.has(p) && !targetFiles.has(p)) deleted.add(p);
+  }
+
+  return { deletedFiles: Array.from(deleted).sort(), newProvenance };
 }
 
-/**
- * Explicit removals: paths the config names in `prune_paths` (a renamed or
- * removed system/reference/state file). Non-skill files can't be auto-pruned —
- * agents author their own memory files under system/, so a blanket "delete
- * anything not in target" would erase agent memory. Explicit naming is safe and
- * works on the first apply. A path is only deleted if it exists in the bare repo
- * and is NOT also a target file (never delete a file we intend to keep).
- */
-function computeExplicitPruneDeletions(
-  memory: AgentMemoryConfig,
-  targetFiles: Map<string, string>,
-  bareRepoFiles: Map<string, string>,
-): string[] {
-  if (!memory.prune_paths || memory.prune_paths.length === 0) return [];
-  const deleted: string[] = [];
-  for (const p of memory.prune_paths) {
-    if (bareRepoFiles.has(p) && !targetFiles.has(p)) deleted.push(p);
-  }
-  return deleted;
+function mapsEqual(a: Map<string, string>, b: Map<string, string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) if (b.get(k) !== v) return false;
+  return true;
 }
 
 /**

--- a/src/lib/memfs-reconciler/server-state.ts
+++ b/src/lib/memfs-reconciler/server-state.ts
@@ -6,6 +6,7 @@
 import type { LettaClientWrapper } from '../client/letta-client';
 import type { GitClient } from './git-client';
 import type { ServerAgentState, BlockSnapshot } from './plan';
+import { MEMFS_PROJECTED_METADATA_KEY } from './plan';
 
 export async function buildServerAgentState(
   letta: LettaClientWrapper,
@@ -34,6 +35,14 @@ export async function buildServerAgentState(
   const tags = ((agent as any).tags ?? []) as string[];
   const metadata = ((agent as any).metadata ?? {}) as Record<string, any>;
 
+  const projectedFiles = new Map<string, string>();
+  const rawProjected = metadata[MEMFS_PROJECTED_METADATA_KEY];
+  if (rawProjected && typeof rawProjected === 'object') {
+    for (const [p, sha] of Object.entries(rawProjected)) {
+      if (typeof sha === 'string') projectedFiles.set(p, sha);
+    }
+  }
+
   // Pull the bare repo file SHAs. If the bare repo doesn't exist yet (first
   // migration), the sidecar auto-creates it on clone and we get an empty map.
   let bareRepoFiles = new Map<string, string>();
@@ -53,5 +62,6 @@ export async function buildServerAgentState(
     metadata,
     blocks,
     bareRepoFiles,
+    projectedFiles,
   };
 }

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -85,11 +85,10 @@ export interface AgentMemoryConfig {
   bare_repo?: 'auto';                        // 'auto' = resolve via Letta /v1/git/<id>/state.git
   template_dir?: string;                     // dir of skeleton .md files; relative to root_path
   preserve_existing_paths?: string[];        // memfs paths to seed but not overwrite once present
-  prune_missing_skills?: boolean;            // when true, delete remote skills/<name> dirs absent from memory.skills
-  prune_paths?: string[];                    // explicit bare-repo paths to DELETE on apply (e.g. a renamed/removed
-                                             // system/ or reference/ file). Safe + explicit — unlike skills, non-skill
-                                             // files can't be auto-pruned (agents author memory files under system/),
-                                             // so removals are named here. Ignored if the path is also a target file.
+  prune_missing_skills?: boolean;            // deprecated no-op — provenance now removes any file lettactl stops shipping
+  prune_paths?: string[];                    // legacy escape hatch: force-delete bare-repo paths on apply. Provenance
+                                             // handles removals automatically for agents projected by a recent lettactl;
+                                             // only needed to clean up files projected before provenance tracking existed.
   files?: Array<{
     to: string;                              // memfs target path
     value?: string;                          // inline content


### PR DESCRIPTION
Provenance-based memfs removal. lettactl records the projected path→sha set in agent metadata (`lettactl.memfs.projected`) and deletes only files it previously projected that a config stopped shipping — never agent/operator-authored files, never by owning a folder namespace.

Replaces the `prune_missing_skills` skill-mirror (now a deprecated no-op) and removes the need to hardcode removed files into `prune_paths` (kept as a legacy escape hatch). No extension policing — non-`.md` files in skills pass through.

Verified end-to-end on a live Draper agent: content sync, single-file removal, whole-skill removal, agent-authored-file survival, first-apply seeding, and a SHA-level reconciliation of recorded provenance against remote git blobs (0 mismatches).

closes #416