### PR TITLE
fix: v1.0.21 memfs test fixtures for provenance fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -480,6 +480,9 @@ function formatMemfsDetails(result: DryRunResult, fancy: boolean): void {
       const parts = [`~${action.changedFiles.size} changed`];
       if (action.deletedFiles.length) parts.push(`-${action.deletedFiles.length} deleted`);
       output(`${indent}${colorPurple('Memfs [~]:')} sync-files-only (${parts.join(', ')})`);
+      if (action.changedFiles.size) {
+        output(`${indent}  ${dim('changed:')} ${formatMemfsFileList(action.changedFiles.size, Array.from(action.changedFiles.keys()))}`);
+      }
       for (const p of action.deletedFiles) output(`${indent}  ${red('delete:')} ${p}`);
       break;
     }

--- a/tests/unit/lib/apply/dry-run.test.ts
+++ b/tests/unit/lib/apply/dry-run.test.ts
@@ -51,13 +51,15 @@ describe('displayDryRunResults memfs rendering', () => {
       currentTags: ['tenant:foo'],
       sourceBlocks: [],
       targetFiles,
+      deletedFiles: [],
+      newProvenance: new Map(),
     };
   }
 
   function makeSyncOnly(paths: string[], deletedFiles: string[] = []): MemfsAction {
     const changedFiles = new Map<string, string>();
     for (const p of paths) changedFiles.set(p, 'x');
-    return { kind: 'sync-files-only', agentId: 'agent-1', changedFiles, deletedFiles };
+    return { kind: 'sync-files-only', agentId: 'agent-1', changedFiles, deletedFiles, newProvenance: new Map() };
   }
 
   it('renders migrate-forward with file list and backup path', () => {
@@ -93,8 +95,8 @@ describe('displayDryRunResults memfs rendering', () => {
     displayDryRunResults([result], false);
     const memfsLines = lines.filter((l) => l.includes('Memfs'));
     expect(memfsLines.some((l) => l.includes('sync-files-only'))).toBe(true);
-    expect(memfsLines.some((l) => l.includes('prompting.md'))).toBe(true);
-    expect(memfsLines.some((l) => l.includes('identity.md'))).toBe(true);
+    expect(lines.some((l) => l.includes('prompting.md'))).toBe(true);
+    expect(lines.some((l) => l.includes('identity.md'))).toBe(true);
   });
 
   it('renders sync-files-only deleted files', () => {
@@ -107,7 +109,7 @@ describe('displayDryRunResults memfs rendering', () => {
     displayDryRunResults([result], false);
     const memfsLines = lines.filter((l) => l.includes('Memfs'));
     expect(memfsLines.some((l) => l.includes('sync-files-only'))).toBe(true);
-    expect(memfsLines.some((l) => l.includes('SKILL.md'))).toBe(true);
+    expect(lines.some((l) => l.includes('SKILL.md'))).toBe(true);
   });
 
   it('renders rollback', () => {

--- a/tests/unit/lib/memfs-reconciler/plan.test.ts
+++ b/tests/unit/lib/memfs-reconciler/plan.test.ts
@@ -23,6 +23,7 @@ function mkServer(opts: {
   metadata?: Record<string, any>;
   blocks?: BlockSnapshot[];
   files?: Record<string, string>;
+  projected?: Record<string, string>;
 } = {}): ServerAgentState {
   return {
     agentId: 'agent-test',
@@ -30,6 +31,7 @@ function mkServer(opts: {
     metadata: opts.metadata ?? {},
     blocks: opts.blocks ?? [],
     bareRepoFiles: new Map(Object.entries(opts.files ?? {})),
+    projectedFiles: new Map(Object.entries(opts.projected ?? {})),
   };
 }
 
@@ -614,7 +616,7 @@ describe('template_dir scan', () => {
     }
   });
 
-  it('prunes remote skill files missing from memory.skills when enabled', () => {
+  it('deletes files it previously projected that config no longer ships (provenance)', () => {
     const skillDir = path.join(tmpDir, 'skills-src', 'saved-memory');
     fs.mkdirSync(skillDir, { recursive: true });
     fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'saved');
@@ -624,7 +626,6 @@ describe('template_dir scan', () => {
       'test-agent',
       mkAgent({
         mode: 'memfs',
-        prune_missing_skills: true,
         skills: [{ name: 'saved-memory', from_dir: 'skills-src/saved-memory' }],
       }),
       mkServer({
@@ -635,7 +636,16 @@ describe('template_dir scan', () => {
           'skills/saved-memory/old-reference.md': gitBlobSha('old-reference'),
           'skills/old-memory/SKILL.md': gitBlobSha('old'),
           'skills/old-memory/scripts/call.sh': gitBlobSha('old-script'),
-          'system/persona.md': gitBlobSha('persona'),
+          'system/agent-note.md': gitBlobSha('agent wrote this'),
+        },
+        // What lettactl recorded projecting last apply. system/agent-note.md is
+        // absent — the agent authored it — so it must never be deleted.
+        projected: {
+          'skills/saved-memory/SKILL.md': gitBlobSha('saved'),
+          'skills/saved-memory/current.md': gitBlobSha('current'),
+          'skills/saved-memory/old-reference.md': gitBlobSha('old-reference'),
+          'skills/old-memory/SKILL.md': gitBlobSha('old'),
+          'skills/old-memory/scripts/call.sh': gitBlobSha('old-script'),
         },
       }),
       tmpDir,
@@ -649,6 +659,36 @@ describe('template_dir scan', () => {
         'skills/old-memory/scripts/call.sh',
         'skills/saved-memory/old-reference.md',
       ]);
+      expect(action.deletedFiles).not.toContain('system/agent-note.md');
+    }
+  });
+
+  it('deletes nothing on first apply (empty provenance) even with stale bare-repo files', () => {
+    const skillDir = path.join(tmpDir, 'skills-src', 'saved-memory');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'saved');
+
+    const action = computeMemfsAction(
+      'test-agent',
+      mkAgent({
+        mode: 'memfs',
+        skills: [{ name: 'saved-memory', from_dir: 'skills-src/saved-memory' }],
+      }),
+      mkServer({
+        tags: [GIT_MEMORY_ENABLED_TAG],
+        files: {
+          'skills/saved-memory/SKILL.md': gitBlobSha('saved'),
+          'skills/old-memory/SKILL.md': gitBlobSha('old'),
+        },
+        // No provenance recorded yet — nothing is deletable; seed instead.
+      }),
+      tmpDir,
+    );
+
+    expect(action.kind).toBe('no-op');
+    if (action.kind === 'no-op') {
+      expect(action.newProvenance?.has('skills/saved-memory/SKILL.md')).toBe(true);
+      expect(action.newProvenance?.has('skills/old-memory/SKILL.md')).toBe(false);
     }
   });
 


### PR DESCRIPTION
Follow-up to #417 — v1.0.20 CI failed because test fixtures constructed `ServerAgentState`/`MemfsAction` literals without the new required fields (`projectedFiles`, `deletedFiles`, `newProvenance`). `tsc` (build config) excludes `tests/`, so the local build passed while jest's type-check did not.

Changes:
- Add the new fields to test fixtures (`plan.test.ts`, `dry-run.test.ts`).
- Replace the old `prune_missing_skills` mirror test with a provenance-deletion test (also asserts an agent-authored file is never deleted).
- Add a first-apply-seeds-no-deletion test.
- Dry-run sync-files-only now lists changed files (concise) alongside deletions.

All 340 tests pass locally.