### PR TITLE
feat: v1.1.0 --prune <targets> with secrets support

### DIFF
--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 description: Thorough code review covering architecture, code quality, and performance. Use when asked to "review this plan", "review code", "audit architecture", "check code quality", or "review for performance". Walks through issues interactively with tradeoff analysis and opinionated recommendations.
 metadata:
-  author: adspectre
+  author: lettactl
   version: "1.0.0"
   argument-hint: <file-or-pattern>
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -32,7 +32,8 @@ import { buildAgentManifest, getDefaultManifestPath, writeAgentManifest } from '
 import { ApplyOptions, DeployResult } from './types';
 import { batchProcess } from '../../lib/shared/batch';
 import { DEFAULT_CANARY_PREFIX, rewriteAgentNamesForCanary, rewriteFolderNamesForCanary, cleanupCanaryAgents, buildCanaryMetadata } from '../../lib/apply/canary';
-import { bulkSendMessage } from '../../lib/messaging/bulk-messenger';
+import { bulkSendMessage, promptConfirmation } from '../../lib/messaging/bulk-messenger';
+import { parsePruneTargets, isPruning, selectedPruneTargets } from '../../lib/prune-targets';
 import { waitForAgentIdle, defaultWaitLogger, RequiresApprovalError } from '../../lib/messaging/wait-for-idle';
 import { retryOn409 } from '../../lib/shared/retry';
 import { minimatch } from 'minimatch';
@@ -43,7 +44,19 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
   const verbose = isQuietMode() ? false : (command.parent?.opts().verbose || false);
   const spinnerEnabled = getSpinnerEnabled(command);
 
+  const pruneTargets = parsePruneTargets(options.prune);
+
   try {
+    // Gate before any network call — confirming after resources are already
+    // touched would be theatre. Dry-run never deletes, so it never prompts.
+    if (isPruning(pruneTargets) && !options.confirm && !options.dryRun) {
+      output('');
+      output(`--prune will DELETE ${selectedPruneTargets(pruneTargets).join(', ')} not present in ${options.file}.`);
+      if (!(await promptConfirmation('Proceed? (y/N) '))) {
+        throw new Error('Aborted at prune confirmation');
+      }
+    }
+
     const parseSpinner = createSpinner(`Parsing ${options.file}...`, spinnerEnabled).start();
 
     if (options.dryRun) {
@@ -241,7 +254,8 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
         fileTracker,
         parser,
         agentFilter: options.agent,
-        verbose
+        verbose,
+        pruneSecrets: pruneTargets.secrets
       });
       displayDryRunResults(results, verbose, options.skipFirstMessage);
       return { agents: {}, created: [], updated: [], unchanged: [] };
@@ -435,7 +449,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
               logMemfsResult(result, agent.name);
               sidecarChanged = sidecarChanged || result.status === 'applied';
             }
-            const secretResult = await reconcileSecretsForAgent(config, agent, existingAgent.id, client, false);
+            const secretResult = await reconcileSecretsForAgent(config, agent, existingAgent.id, client, false, pruneTargets.secrets);
             if (secretResult) {
               secretResults.push(secretResult);
               logSecretResult(secretResult, agent.name);
@@ -475,7 +489,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
             spinnerEnabled,
             verbose,
             force: options.force || false,
-            prune: options.prune || false,
+            prune: pruneTargets.blocks || pruneTargets.tools,
             previousFolderFileHashes
           });
 
@@ -530,7 +544,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
             }
             await maybeReprojectSkills(existingAgent.id, existingAgent.name, agent.memory?.mode, memfsReconciler, client, options);
           }
-          const secretResult = await reconcileSecretsForAgent(config, agent, existingAgent.id, client, false);
+          const secretResult = await reconcileSecretsForAgent(config, agent, existingAgent.id, client, false, pruneTargets.secrets);
           if (secretResult) {
             secretResults.push(secretResult);
             logSecretResult(secretResult, agent.name);
@@ -582,7 +596,7 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
               await recompileConversationsForAgent(createdAgent.id, createdAgent.name, client, options.waitForIdle !== false);
             }
           }
-          const secretResult = await reconcileSecretsForAgent(config, agent, createdAgent.id, client, false);
+          const secretResult = await reconcileSecretsForAgent(config, agent, createdAgent.id, client, false, pruneTargets.secrets);
           if (secretResult) {
             secretResults.push(secretResult);
             logSecretResult(secretResult, agent.name);
@@ -927,9 +941,10 @@ async function reconcileSecretsForAgent(
   agentId: string,
   client: LettaClientWrapper,
   dryRun: boolean,
+  prune: boolean = false,
 ): Promise<SecretApplyResult | null> {
   try {
-    const plan = await planAgentSecrets(client, config, agent, agentId);
+    const plan = await planAgentSecrets(client, config, agent, agentId, prune);
     if (!plan) return null;
     return await applySecretPlan(client, plan, dryRun);
   } catch (err) {

--- a/src/commands/apply/types.ts
+++ b/src/commands/apply/types.ts
@@ -9,10 +9,13 @@ export interface ApplyOptions {
   scope?: string;
   dryRun?: boolean;
   force?: boolean;
-  /** Detach blocks/tools not in config (safe reconciliation). Unlike --force it
-   *  never touches folders/archives, so it can't lose archival data (#257).
-   *  Gives a safe path to reconcile the common case. See nouamanecodes/lettactl#384. */
-  prune?: boolean;
+  /** Comma-separated targets to delete when absent from config: blocks, tools,
+   *  secrets, agents, all. Unlike --force it never touches folders/archives, so it
+   *  can't lose archival data (#257). See nouamanecodes/lettactl#384.
+   *  BREAKING (v1.1.0): was a boolean meaning blocks+tools; now requires a target. */
+  prune?: string;
+  /** Skip the --prune confirmation prompt (for CI / non-interactive runs). */
+  confirm?: boolean;
   root?: string;
   manifest?: string;
   skipFirstMessage?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,8 @@ program
   .option('--scope <tags>', 'deploy only agents whose tags include ALL listed tags (comma-separated). Example: --scope tenant:acme,role:draper')
   .option('--dry-run', 'show what would be created without making changes')
   .option('--force', 'remove ALL resources not in config incl. folders/archives (can lose data, see #257)')
-  .option('--prune', 'detach blocks/tools not in config (safe, leaves folders/archives untouched)')
+  .option('--prune <targets>', 'delete resources not in config. Comma-separated: blocks, tools, secrets, agents, all. Prompts unless --confirm')
+  .option('--confirm', 'skip the --prune confirmation prompt')
   .option('--root <path>', 'root directory for resolving file paths')
   .option('--manifest [path]', 'write agent manifest (default: <config>.manifest.json)')
   .option('--skip-first-message', 'skip sending first_message on agent creation')
@@ -158,11 +159,15 @@ MemFS skills and secrets:
   global-secrets                  Sync secret values to every agent
   agents[].secrets                Sync per-agent secrets; overrides globals
   preserve_existing: true         Reuse the current remote value when from_env is unset
+  preserve_secrets                Secret names --prune secrets must never delete
 
 Example:
   global-secrets:
-    ADSPECTRE_API_BASE:
-      value: https://app.adspectre.ai
+    API_BASE_URL:
+      value: https://api.example.com
+
+  preserve_secrets:
+    - RUNTIME_AGENT_TOKEN          # injected by the runtime, not declared here
 
   agents:
     - name: agent-migrate
@@ -183,8 +188,8 @@ Example:
           - name: media-generation
             from_dir: migration-artifacts/agent-migrate/memfs/skills/media-generation
       secrets:
-        ADSPECTRE_AGENT_TOKEN:
-          from_env: ADSPECTRE_AGENT_MIGRATE_TOKEN
+        RUNTIME_AGENT_TOKEN:
+          from_env: AGENT_MIGRATE_TOKEN
           preserve_existing: true
 
 Notes:

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -52,6 +52,8 @@ interface DryRunContext {
   parser: FleetParser;
   agentFilter?: string;
   verbose: boolean;
+  /** Mirrors --prune secrets so the preview lists removals it would make. */
+  pruneSecrets?: boolean;
 }
 
 /**
@@ -149,7 +151,7 @@ export async function computeDryRunDiffs(
       continue;
     }
     try {
-      const plan = await planAgentSecrets(client, config, agent, result.existingAgentId);
+      const plan = await planAgentSecrets(client, config, agent, result.existingAgentId, ctx.pruneSecrets || false);
       if (!plan) continue;
       result.secretPlan = plan;
       result.secretResult = await applySecretPlan(client, plan, true);

--- a/src/lib/memfs-reconciler/git-client.ts
+++ b/src/lib/memfs-reconciler/git-client.ts
@@ -39,7 +39,7 @@ export class GitClient {
     this.baseUrl = opts.baseUrl.replace(/\/$/, '');
     this.authToken = opts.authToken;
     this.authorName = opts.commitAuthor?.name ?? 'lettactl';
-    this.authorEmail = opts.commitAuthor?.email ?? 'lettactl@adspectre.ai';
+    this.authorEmail = opts.commitAuthor?.email ?? 'lettactl@localhost';
   }
 
   /**

--- a/src/lib/prune-targets.ts
+++ b/src/lib/prune-targets.ts
@@ -1,0 +1,49 @@
+// --prune <targets> selects WHAT apply is allowed to delete. Every target is
+// destructive, so apply gates on a confirmation prompt (or --confirm) before acting.
+
+export const PRUNE_TARGETS = ['blocks', 'tools', 'secrets', 'agents', 'all'] as const;
+export type PruneTarget = (typeof PRUNE_TARGETS)[number];
+
+export interface PruneSelection {
+  blocks: boolean;
+  tools: boolean;
+  secrets: boolean;
+  agents: boolean;
+}
+
+export const NO_PRUNE: PruneSelection = { blocks: false, tools: false, secrets: false, agents: false };
+
+/**
+ * Parse the comma-separated --prune value. Throws on an empty or unknown target
+ * rather than silently pruning nothing — a typo here deletes the wrong things.
+ */
+export function parsePruneTargets(raw: string | undefined): PruneSelection {
+  if (raw === undefined) return { ...NO_PRUNE };
+
+  const parts = raw.split(',').map((p) => p.trim().toLowerCase()).filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error(`--prune requires at least one target: ${PRUNE_TARGETS.join(', ')}`);
+  }
+
+  const unknown = parts.filter((p) => !(PRUNE_TARGETS as readonly string[]).includes(p));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown --prune target(s): ${unknown.join(', ')}. Valid: ${PRUNE_TARGETS.join(', ')}`);
+  }
+
+  if (parts.includes('all')) return { blocks: true, tools: true, secrets: true, agents: true };
+
+  return {
+    blocks: parts.includes('blocks'),
+    tools: parts.includes('tools'),
+    secrets: parts.includes('secrets'),
+    agents: parts.includes('agents'),
+  };
+}
+
+export function selectedPruneTargets(selection: PruneSelection): string[] {
+  return (Object.keys(selection) as Array<keyof PruneSelection>).filter((k) => selection[k]);
+}
+
+export function isPruning(selection: PruneSelection): boolean {
+  return selectedPruneTargets(selection).length > 0;
+}

--- a/src/lib/secrets-reconciler.ts
+++ b/src/lib/secrets-reconciler.ts
@@ -26,7 +26,6 @@ export interface SecretApplyResult {
 }
 
 const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
-const KNOWN_AGENT_SCOPED_SECRETS = new Set(['ADSPECTRE_AGENT_TOKEN']);
 
 export function normalizeSecretName(raw: string): string {
   const name = raw.toUpperCase();
@@ -64,10 +63,7 @@ export function validateSecretConfigMap(
     throw new Error(`${label} must be an object mapping SECRET_NAME to { from_env } or { value }.`);
   }
   for (const [rawName, config] of Object.entries(secrets)) {
-    const name = normalizeSecretName(rawName);
-    if (opts.global && KNOWN_AGENT_SCOPED_SECRETS.has(name)) {
-      throw new Error(`${name} must be configured per-agent, not in global-secrets.`);
-    }
+    normalizeSecretName(rawName);
     if (!config || typeof config !== 'object' || Array.isArray(config)) {
       throw new Error(`${label}.${rawName} must be an object.`);
     }
@@ -95,7 +91,10 @@ export function computeSecretPlan(
   agentId: string,
   desired: Record<string, string>,
   current: Record<string, string>,
+  prune: boolean = false,
+  preserve: string[] = [],
 ): SecretPlan {
+  const preserved = new Set(preserve.map((n) => n.toUpperCase()));
   const toAdd: string[] = [];
   const toUpdate: string[] = [];
   const toRemove: string[] = [];
@@ -105,7 +104,15 @@ export function computeSecretPlan(
     else if (current[name] !== value) toUpdate.push(name);
   }
 
-  // lettactl only manages declared secrets. Existing undeclared secrets are preserved.
+  // Without --prune, lettactl only manages declared secrets and preserves undeclared ones.
+  // With it, undeclared secrets are removed — except those listed in preserve_secrets,
+  // which a runtime injects rather than config declaring, so pruning would wipe them.
+  if (prune) {
+    for (const name of Object.keys(current)) {
+      if (!(name in desired) && !preserved.has(name)) toRemove.push(name);
+    }
+  }
+
   const diff = {
     toAdd: toAdd.sort(),
     toUpdate: toUpdate.sort(),
@@ -126,11 +133,12 @@ export async function planAgentSecrets(
   config: FleetConfig,
   agent: AgentConfig,
   agentId: string,
+  prune: boolean = false,
 ): Promise<SecretPlan | null> {
   if (!config['global-secrets'] && !agent.secrets) return null;
   const current = await client.getAgentSecrets(agentId);
   const desired = resolveAgentSecrets(config, agent, current);
-  return computeSecretPlan(agentId, desired, current);
+  return computeSecretPlan(agentId, desired, current, prune, config.preserve_secrets || []);
 }
 
 export async function applySecretPlan(
@@ -145,7 +153,11 @@ export async function applySecretPlan(
     return { kind: 'sync', agentId: plan.agentId, status: 'dry-run', diff: plan.diff };
   }
   try {
-    await client.updateAgentSecrets(plan.agentId, { ...plan.current, ...plan.desired });
+    // The API replaces the whole secret set, so the merge is what preserves undeclared
+    // secrets. Dropping the toRemove keys from it is what makes --prune delete them.
+    const next = { ...plan.current, ...plan.desired };
+    for (const name of plan.diff.toRemove) delete next[name];
+    await client.updateAgentSecrets(plan.agentId, next);
     return { kind: 'sync', agentId: plan.agentId, status: 'applied', diff: plan.diff };
   } catch (err) {
     return {

--- a/src/types/fleet-config.ts
+++ b/src/types/fleet-config.ts
@@ -1,6 +1,9 @@
 export interface FleetConfig {
   root_path?: string;
   'global-secrets'?: Record<string, SecretConfig>;
+  /** Secret names `--prune secrets` must never delete. For values injected by a
+   *  runtime rather than declared here, which would otherwise be wiped every apply. */
+  preserve_secrets?: string[];
   providers?: ProviderConfig[];
   prune_missing_providers?: boolean;
   shared_blocks?: SharedBlock[];
@@ -78,8 +81,7 @@ export interface AgentConfig {
 // repo, and flip the `git-memory-enabled` tag on the agent. When `mode:
 // blocks` (or section omitted), the agent operates in classic block-mode.
 // Round-trip is supported: flipping mode back to blocks removes the tag and
-// blocks come back online. See:
-//   adspectre_dashboard/docs/research/1531-migration-tooling.md
+// blocks come back online.
 export interface AgentMemoryConfig {
   mode: 'blocks' | 'memfs';
   bare_repo?: 'auto';                        // 'auto' = resolve via Letta /v1/git/<id>/state.git

--- a/tests/unit/lib/config-validators.test.ts
+++ b/tests/unit/lib/config-validators.test.ts
@@ -89,12 +89,12 @@ describe('FleetConfigValidator - secrets', () => {
   it('accepts global-secrets and per-agent secrets', () => {
     expect(() => FleetConfigValidator.validate({
       'global-secrets': {
-        ADSPECTRE_API_BASE: { value: 'https://app.adspectre.ai' },
+        API_BASE_URL: { value: 'https://api.example.com' },
       },
       agents: [
         baseAgent({
           secrets: {
-            ADSPECTRE_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
+            RUNTIME_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
           },
         }),
       ],
@@ -113,14 +113,6 @@ describe('FleetConfigValidator - secrets', () => {
     })).toThrow('Invalid secret name');
   });
 
-  it('rejects agent-scoped token in global-secrets', () => {
-    expect(() => FleetConfigValidator.validate({
-      'global-secrets': {
-        ADSPECTRE_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
-      },
-      agents: [baseAgent()],
-    })).toThrow('ADSPECTRE_AGENT_TOKEN must be configured per-agent');
-  });
 });
 
 describe('AgentValidator - tags', () => {

--- a/tests/unit/lib/secrets-reconciler.test.ts
+++ b/tests/unit/lib/secrets-reconciler.test.ts
@@ -1,9 +1,11 @@
 import {
+  applySecretPlan,
   computeSecretPlan,
   normalizeSecretName,
   resolveAgentSecrets,
   validateSecretConfigMap,
 } from '../../../src/lib/secrets-reconciler';
+import { NO_PRUNE, parsePruneTargets } from '../../../src/lib/prune-targets';
 
 describe('secrets-reconciler', () => {
   const originalEnv = process.env;
@@ -21,22 +23,12 @@ describe('secrets-reconciler', () => {
     expect(() => normalizeSecretName('bad-name')).toThrow('Invalid secret name');
   });
 
-  it('rejects globally scoped agent identity secrets', () => {
-    expect(() =>
-      validateSecretConfigMap(
-        'global-secrets',
-        { ADSPECTRE_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' } },
-        { global: true },
-      ),
-    ).toThrow('ADSPECTRE_AGENT_TOKEN must be configured per-agent');
-  });
-
   it('resolves global and agent secrets with agent overrides', () => {
     const resolved = resolveAgentSecrets(
       {
         agents: [],
         'global-secrets': {
-          ADSPECTRE_API_BASE: { value: 'https://app.adspectre.ai' },
+          API_BASE_URL: { value: 'https://api.example.com' },
           SHARED_VALUE: { value: 'global' },
         },
       },
@@ -46,15 +38,15 @@ describe('secrets-reconciler', () => {
         system_prompt: { value: 'p' },
         llm_config: { model: 'm', context_window: 1000 },
         secrets: {
-          ADSPECTRE_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
+          RUNTIME_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
           SHARED_VALUE: { value: 'agent' },
         },
       },
     );
 
     expect(resolved).toEqual({
-      ADSPECTRE_API_BASE: 'https://app.adspectre.ai',
-      ADSPECTRE_AGENT_TOKEN: 'agent-token',
+      API_BASE_URL: 'https://api.example.com',
+      RUNTIME_AGENT_TOKEN: 'agent-token',
       SHARED_VALUE: 'agent',
     });
   });
@@ -72,14 +64,14 @@ describe('secrets-reconciler', () => {
         system_prompt: { value: 'p' },
         llm_config: { model: 'm', context_window: 1000 },
         secrets: {
-          ADSPECTRE_AGENT_TOKEN: { from_env: 'AGENT_TOKEN', preserve_existing: true },
+          RUNTIME_AGENT_TOKEN: { from_env: 'AGENT_TOKEN', preserve_existing: true },
         },
       },
-      { ADSPECTRE_AGENT_TOKEN: 'existing-token' },
+      { RUNTIME_AGENT_TOKEN: 'existing-token' },
     );
 
     expect(resolved).toEqual({
-      ADSPECTRE_AGENT_TOKEN: 'existing-token',
+      RUNTIME_AGENT_TOKEN: 'existing-token',
     });
   });
 
@@ -95,10 +87,10 @@ describe('secrets-reconciler', () => {
           system_prompt: { value: 'p' },
           llm_config: { model: 'm', context_window: 1000 },
           secrets: {
-            ADSPECTRE_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
+            RUNTIME_AGENT_TOKEN: { from_env: 'AGENT_TOKEN' },
           },
         },
-        { ADSPECTRE_AGENT_TOKEN: 'existing-token' },
+        { RUNTIME_AGENT_TOKEN: 'existing-token' },
       ),
     ).toThrow('missing or empty environment variable');
   });
@@ -121,5 +113,67 @@ describe('secrets-reconciler', () => {
   it('returns no-op when managed secrets match', () => {
     const plan = computeSecretPlan('agent-1', { A: 'same' }, { A: 'same', OTHER: 'keep' });
     expect(plan.kind).toBe('no-op');
+  });
+
+  it('removes undeclared secrets when pruning', () => {
+    const plan = computeSecretPlan('agent-1', { A: 'same' }, { A: 'same', ORPHAN: 'stale' }, true);
+
+    expect(plan.kind).toBe('sync');
+    expect(plan.diff.toRemove).toEqual(['ORPHAN']);
+  });
+
+  it('never prunes secrets listed in preserve_secrets', () => {
+    const plan = computeSecretPlan(
+      'agent-1',
+      { A: 'same' },
+      { A: 'same', RUNTIME_AGENT_TOKEN: 'runtime-injected', ORPHAN: 'stale' },
+      true,
+      ['RUNTIME_AGENT_TOKEN'],
+    );
+
+    expect(plan.diff.toRemove).toEqual(['ORPHAN']);
+  });
+
+  it('applies the merged set minus pruned keys', async () => {
+    const updateAgentSecrets = jest.fn().mockResolvedValue(undefined);
+    const plan = computeSecretPlan('agent-1', { A: 'new' }, { A: 'old', ORPHAN: 'stale' }, true);
+
+    const result = await applySecretPlan({ updateAgentSecrets } as any, plan, false);
+
+    expect(result.status).toBe('applied');
+    // The API replaces the whole set, so the payload IS the post-prune state.
+    expect(updateAgentSecrets).toHaveBeenCalledWith('agent-1', { A: 'new' });
+  });
+
+  it('preserves undeclared secrets when not pruning', async () => {
+    const updateAgentSecrets = jest.fn().mockResolvedValue(undefined);
+    const plan = computeSecretPlan('agent-1', { A: 'new' }, { A: 'old', UNMANAGED: 'keep' });
+
+    await applySecretPlan({ updateAgentSecrets } as any, plan, false);
+
+    expect(updateAgentSecrets).toHaveBeenCalledWith('agent-1', { A: 'new', UNMANAGED: 'keep' });
+  });
+});
+
+describe('parsePruneTargets', () => {
+  it('defaults to pruning nothing', () => {
+    expect(parsePruneTargets(undefined)).toEqual(NO_PRUNE);
+  });
+
+  it('parses a comma-separated list', () => {
+    expect(parsePruneTargets('secrets,tools')).toEqual({
+      blocks: false, tools: true, secrets: true, agents: false,
+    });
+  });
+
+  it('expands all', () => {
+    expect(parsePruneTargets('all')).toEqual({
+      blocks: true, tools: true, secrets: true, agents: true,
+    });
+  });
+
+  it('rejects unknown and empty targets rather than silently pruning nothing', () => {
+    expect(() => parsePruneTargets('sekrets')).toThrow('Unknown --prune target');
+    expect(() => parsePruneTargets('')).toThrow('requires at least one target');
   });
 });


### PR DESCRIPTION
Closes #419. Follow-up: #420.

BREAKING: `--prune` now requires a target (`blocks, tools, secrets, agents, all`). Bare `--prune` errors.

**Why the merge existed:** `PATCH /v1/agents/{id}` with `secrets` replaces the whole set — verified by sending one key and watching the other four vanish. Merging client-side is what protected hand-added secrets, and is also why a secret lettactl stopped declaring could never be removed. Pruning drops `toRemove` from the payload; the replace is the delete.

Non-prune behavior is byte-identical (`toRemove` stays empty), which the 340 pre-existing tests passing unchanged demonstrates.

Also de-vendors Adspectre from the codebase — two of those were behavioral, not cosmetic: a hardcoded company secret name that this PR would have promoted into a data-protection rule, and a company domain as the default memfs commit author on every install.

346 tests passing.