### PR TITLE
feat: v1.1.1 default web_search + fetch_webpage, cloud-aware EXA, missing-tool warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/commands/apply/apply.ts
+++ b/src/commands/apply/apply.ts
@@ -25,7 +25,7 @@ import * as nodePath from 'path';
 import { formatLettaError } from '../../lib/shared/error-handler';
 import { computeDryRunDiffs, displayDryRunResults } from '../../lib/apply/dry-run';
 import { log, warn, output, isQuietMode } from '../../lib/shared/logger';
-import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules } from '../../lib/tools/builtin-tools';
+import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules, missingWebTools } from '../../lib/tools/builtin-tools';
 import { displayApplySummary } from '../../lib/ux/display';
 import { buildMcpServerRegistry, expandMcpToolsForAgents } from '../../lib/tools/mcp-tools';
 import { buildAgentManifest, getDefaultManifestPath, writeAgentManifest } from '../../lib/apply/agent-manifest';
@@ -365,6 +365,11 @@ export async function applyCommand(options: ApplyOptions, command: any): Promise
 
         // Build agent config - resolve base tools and file search tools by mode.
         const tools = resolveAgentToolNames(agent);
+
+        const missingWeb = missingWebTools(tools);
+        if (missingWeb.length) {
+          warn(`  ${agent.name}: web-research tools not attached (${missingWeb.join(', ')}). An explicit tools list omits them — confirm that's intended.`);
+        }
 
         const agentConfig = {
           systemPrompt: agent.system_prompt.value || '',

--- a/src/lib/apply/dry-run.ts
+++ b/src/lib/apply/dry-run.ts
@@ -8,7 +8,7 @@ import { AgentManager } from '../managers/agent-manager';
 import { DiffEngine, AgentUpdateOperations } from './diff-engine';
 import { FileContentTracker } from './file-content-tracker';
 import { FleetParser } from './fleet-parser';
-import { output } from '../shared/logger';
+import { output, warn } from '../shared/logger';
 import { displayDryRunHeader, displayDryRunSummary, displayDryRunAction } from '../ux/display';
 import { shouldUseFancyUx, truncate } from '../ux/box';
 import { purple } from '../ux/constants';
@@ -23,7 +23,7 @@ import {
   type SecretApplyResult,
   type SecretPlan,
 } from '../secrets-reconciler';
-import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules } from '../tools/builtin-tools';
+import { resolveAgentToolNames, shouldIncludeBaseTools, shouldIncludeBaseToolRules, missingWebTools } from '../tools/builtin-tools';
 
 export interface DryRunResult {
   name: string;
@@ -254,6 +254,11 @@ async function computeAgentDiff(
     firstMessage: agent.first_message || null,
     conversations: agent.conversations || null
   };
+
+  const missingWeb = missingWebTools(agentConfig.tools);
+  if (missingWeb.length) {
+    warn(`  ${agent.name}: web-research tools not attached (${missingWeb.join(', ')}). An explicit tools list omits them — confirm that's intended.`);
+  }
 
   // Check if agent exists
   const { shouldCreate, existingAgent } = await agentManager.getOrCreateAgentName(

--- a/src/lib/tools/builtin-tools.ts
+++ b/src/lib/tools/builtin-tools.ts
@@ -75,6 +75,13 @@ export const PROTECTED_MEMORY_TOOLS = new Set([
 export const DEFAULT_AGENT_TOOLS = ['conversation_search'];
 
 /**
+ * Web-research tools attached by default when an agent does NOT specify `tools`.
+ * An explicit `tools` list (even `[]`) opts out. On Letta Cloud these work out of
+ * the box (Letta provides Exa); self-hosted servers need EXA_API_KEY.
+ */
+export const DEFAULT_WEB_TOOLS = ['web_search', 'fetch_webpage'];
+
+/**
  * File search tools auto-added when folders are attached
  * Note: open_files excluded - it loads files into context which bloats the window
  */
@@ -106,7 +113,8 @@ export function resolveAgentToolNames(agent: {
   include_base_tools?: boolean;
   memory?: { mode?: string };
 }): string[] {
-  let tools = agent.tools ? [...agent.tools] : [];
+  // `tools` unspecified → seed the web-research defaults; an explicit list (even []) opts out.
+  let tools = agent.tools === undefined ? [...DEFAULT_WEB_TOOLS] : [...agent.tools];
 
   if (shouldIncludeBaseTools(agent)) {
     const toolSet = new Set(tools);
@@ -186,9 +194,34 @@ export function getRequiredEnvVar(toolName: string): string | undefined {
 }
 
 /**
- * Format a helpful message when a built-in tool is not available on the server
+ * Which of the web-research defaults are absent from a resolved tool list — for a
+ * "not attached, check if intended" nudge in dry-run / apply.
  */
-export function formatBuiltinToolWarning(toolName: string): string {
+export function missingWebTools(resolvedTools: string[]): string[] {
+  const set = new Set(resolvedTools);
+  return DEFAULT_WEB_TOOLS.filter((t) => !set.has(t));
+}
+
+/**
+ * True when LETTA_BASE_URL points at a self-hosted server (not letta.com). Letta
+ * Cloud bundles Exa, so web_search/fetch_webpage need no key there; self-host does.
+ */
+export function isSelfHostedLetta(baseUrl = process.env.LETTA_BASE_URL): boolean {
+  if (!baseUrl) return true;
+  try {
+    const host = new URL(baseUrl).hostname;
+    return host !== 'letta.com' && !host.endsWith('.letta.com');
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Format a helpful message when a built-in tool is not available on the server.
+ * The EXA_API_KEY guidance applies only to self-hosted servers — on Letta Cloud
+ * these tools are provided automatically, so we don't send cloud users chasing a key.
+ */
+export function formatBuiltinToolWarning(toolName: string, selfHosted = isSelfHostedLetta()): string {
   const info = BUILTIN_TOOLS[toolName];
   if (!info) return `Tool '${toolName}' not found on server.`;
 
@@ -196,9 +229,11 @@ export function formatBuiltinToolWarning(toolName: string): string {
     `Built-in tool '${toolName}' not found on server.`
   ];
 
-  if (info.requiredEnvVar) {
+  if (info.requiredEnvVar && selfHosted) {
     lines.push(`This tool requires ${info.requiredEnvVar} to be set on your Letta server.`);
     lines.push(`Restart your Letta server with: -e ${info.requiredEnvVar}=your_key`);
+  } else if (info.requiredEnvVar) {
+    lines.push(`On Letta Cloud this is provided automatically — no ${info.requiredEnvVar} needed.`);
   }
 
   lines.push(`See: ${info.docsUrl}`);

--- a/tests/unit/lib/builtin-tools.test.ts
+++ b/tests/unit/lib/builtin-tools.test.ts
@@ -1,0 +1,41 @@
+import {
+  resolveAgentToolNames,
+  missingWebTools,
+  isSelfHostedLetta,
+  DEFAULT_WEB_TOOLS,
+} from '../../../src/lib/tools/builtin-tools';
+
+// memfs agents get no base tools, so the only additions are the web-research defaults.
+const memfs = { memory: { mode: 'memfs' }, include_base_tools: false };
+
+describe('resolveAgentToolNames web-research defaults', () => {
+  it('injects web_search + fetch_webpage when tools is unspecified', () => {
+    expect(resolveAgentToolNames({ ...memfs }).sort()).toEqual([...DEFAULT_WEB_TOOLS].sort());
+  });
+
+  it('honors an explicit tools list (opts out of the un-listed default)', () => {
+    expect(resolveAgentToolNames({ ...memfs, tools: ['web_search'] })).toEqual(['web_search']);
+  });
+
+  it('honors an explicit empty list as a full opt-out', () => {
+    expect(resolveAgentToolNames({ ...memfs, tools: [] })).toEqual([]);
+  });
+});
+
+describe('missingWebTools', () => {
+  it('reports the absent web-research tools', () => {
+    expect(missingWebTools(['web_search'])).toEqual(['fetch_webpage']);
+    expect(missingWebTools(['web_search', 'fetch_webpage'])).toEqual([]);
+    expect(missingWebTools([]).sort()).toEqual([...DEFAULT_WEB_TOOLS].sort());
+  });
+});
+
+describe('isSelfHostedLetta', () => {
+  it('treats letta.com and subdomains as cloud, everything else as self-hosted', () => {
+    expect(isSelfHostedLetta('https://api.letta.com')).toBe(false);
+    expect(isSelfHostedLetta('https://letta.com')).toBe(false);
+    expect(isSelfHostedLetta('http://localhost:8283')).toBe(true);
+    expect(isSelfHostedLetta('https://letta.example.com')).toBe(true);
+    expect(isSelfHostedLetta(undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Agents with no explicit `tools` now default to `['web_search', 'fetch_webpage']` (matches letta-code's own default). An explicit `tools` list — even `[]` — opts out.
- Dry-run AND apply warn when an agent's resolved tools omit the web-research defaults, so an explicit opt-out is a conscious choice.
- `formatBuiltinToolWarning` is cloud-aware: EXA_API_KEY guidance only on self-hosted; Letta Cloud provides Exa automatically.

## Changes
- `builtin-tools.ts`: `DEFAULT_WEB_TOOLS`, default-when-unspecified in `resolveAgentToolNames`, `missingWebTools`, `isSelfHostedLetta`, cloud-aware warning
- `apply.ts` + `dry-run.ts`: missing-tool warning in both paths
- New unit test `builtin-tools.test.ts` (5 cases)

All 346 existing tests pass + 5 new.