### PR TITLE
fix: v1.1.2 inject default web tools at parse time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettactl",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "kubectl-style CLI for managing Letta AI agent fleets",
   "main": "dist/sdk.js",
   "exports": {

--- a/src/lib/apply/fleet-parser.ts
+++ b/src/lib/apply/fleet-parser.ts
@@ -5,7 +5,7 @@ import * as crypto from 'crypto';
 import { FleetConfig, FolderConfig, FolderFileConfig, SharedFolderConfig } from '../../types/fleet-config';
 import { StorageBackendManager, SupabaseStorageBackend, BucketConfig } from '../storage/storage-backend';
 import { FleetConfigValidator } from '../validation/config-validators';
-import { isBuiltinTool, formatBuiltinToolWarning, CORE_MEMORY_TOOLS } from '../tools/builtin-tools';
+import { isBuiltinTool, formatBuiltinToolWarning, CORE_MEMORY_TOOLS, DEFAULT_WEB_TOOLS } from '../tools/builtin-tools';
 import { log, warn } from '../shared/logger';
 
 export interface FleetParserOptions {
@@ -66,6 +66,12 @@ export class FleetParser {
     }
 
     for (const agent of config.agents) {
+      // Unspecified tools → default to the web-research tools so every downstream consumer
+      // (registration, diff, attach) sees them. An explicit list (even []) opts out.
+      if ((agent as any).tools === undefined) {
+        (agent as any).tools = [...DEFAULT_WEB_TOOLS];
+      }
+
       // Resolve system prompt
       await this.resolvePromptContent(agent.system_prompt);
 

--- a/tests/unit/lib/fleet-parser.test.ts
+++ b/tests/unit/lib/fleet-parser.test.ts
@@ -42,6 +42,27 @@ agents:
       expect(config.agents[0].system_prompt.value).toContain('You are a test agent');
     });
 
+    it('defaults tools to web_search + fetch_webpage when unspecified, honors an explicit list', async () => {
+      const base = `
+agents:
+  - name: a
+    description: "d"
+    llm_config:
+      model: "m"
+      context_window: 32000
+    system_prompt:
+      value: "s"`;
+      mockedFs.existsSync.mockReturnValue(true);
+
+      mockedFs.readFileSync.mockReturnValue(base);
+      let config = await parser.parseFleetConfig('/test/path/fleet.yaml');
+      expect(((config.agents[0] as any).tools as string[]).sort()).toEqual(['fetch_webpage', 'web_search']);
+
+      mockedFs.readFileSync.mockReturnValue(base + `\n    tools: []`);
+      config = await parser.parseFleetConfig('/test/path/fleet.yaml');
+      expect((config.agents[0] as any).tools).toEqual([]);
+    });
+
     it('should handle shared blocks', async () => {
       const yamlContent = `
 shared_blocks:


### PR DESCRIPTION
## Bug
v1.1.1 defaulted `tools` inside `resolveAgentToolNames`, but `registerRequiredTools` reads raw `agent.tools` (`if (agent.tools)` skips `undefined`). So agents with no `tools` field never had web_search/fetch_webpage registered or attached — the dry-run showed `[+]` but apply reported "Tools: unchanged".

## Fix
Inject `DEFAULT_WEB_TOOLS` at parse time in `resolveConfig`, so registration, diff, and attach all see them. Explicit `tools` (even `[]`) still opts out.

Verified live: apply now reports "Added tool: web_search/fetch_webpage [builtin]" and `/v1/agents/<id>/tools` returns both. New parser test + all 352 pass.